### PR TITLE
chunk: http-retry (#5)

### DIFF
--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -8,12 +8,23 @@ import requests
 import json
 from typing import Optional, Dict, Any, Union, List
 import time
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from almaapitk.alma_logging import get_logger
 
 
 # Default per-request timeout (seconds) for Alma API calls. Mirrors the
 # previous per-verb literal so behavior is unchanged after consolidation.
 DEFAULT_REQUEST_TIMEOUT = 300
+
+# Default retry configuration for the urllib3-backed HTTPAdapter mounted
+# on the persistent session (issue #5). The status forcelist covers Alma's
+# rate-limit response (429) and the transient-server-error band (5xx) that
+# is safe to retry idempotently.
+DEFAULT_RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+DEFAULT_RETRY_TOTAL = 3
+DEFAULT_RETRY_BACKOFF_FACTOR = 1.0
+DEFAULT_RETRY_ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "DELETE"})
 
 
 def _safe_response_body(response):
@@ -93,21 +104,112 @@ class AlmaAPIClient:
     (BiblioGraphicRecords, Users, Admin, etc.)
     """
     
-    def __init__(self, environment: str = 'SANDBOX'):
-        """
-        Initialize the API client.
+    def __init__(
+        self,
+        environment: str = 'SANDBOX',
+        *,
+        max_retries: int = DEFAULT_RETRY_TOTAL,
+        backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
+        retry: Optional[Retry] = None,
+    ):
+        """Initialize the API client.
 
         Args:
-            environment: 'SANDBOX' or 'PRODUCTION'
+            environment: 'SANDBOX' or 'PRODUCTION'.
+            max_retries: Total number of retries the mounted HTTPAdapter
+                should attempt on retryable responses (429 and 5xx).
+                Must be an ``int >= 0``. Ignored when ``retry`` is given.
+            backoff_factor: Exponential backoff multiplier passed to
+                ``urllib3.util.Retry``. With ``backoff_factor=1`` the wait
+                schedule between attempts is roughly 1s, 2s, 4s, ...
+                Must be a non-negative number. Ignored when ``retry`` is
+                given.
+            retry: Optional fully-built ``urllib3.util.Retry`` instance.
+                When supplied, it is used verbatim and ``max_retries`` /
+                ``backoff_factor`` are ignored — this is the escape hatch
+                for advanced callers who need to tune fields not exposed
+                by the simple kwargs (allowed_methods, raise_on_status,
+                etc.).
+
+        Raises:
+            AlmaValidationError: If ``max_retries`` is negative or not an
+                int, or if ``backoff_factor`` is negative or not numeric.
+
+        Pattern source: GitHub issue #5 (HTTP: retry with exponential
+        backoff for 429/5xx).
         """
         self.environment = environment.upper()
         # Default per-request timeout. Per-call ``timeout=`` kwargs in
         # ``_request`` override this on a request-by-request basis.
         self.timeout = DEFAULT_REQUEST_TIMEOUT
+        # Validate retry knobs early so misconfiguration surfaces at
+        # construction time rather than on the first network failure.
+        if retry is None:
+            self._validate_retry_kwargs(max_retries, backoff_factor)
+        self._max_retries = max_retries
+        self._backoff_factor = backoff_factor
+        self._retry_override = retry
         self._load_configuration()
         self._setup_headers()
         self._setup_logger()
         self._setup_session()
+
+    @staticmethod
+    def _validate_retry_kwargs(max_retries: Any, backoff_factor: Any) -> None:
+        """Validate the simple retry kwargs accepted by ``__init__``.
+
+        Args:
+            max_retries: Candidate value for the ``max_retries`` kwarg.
+            backoff_factor: Candidate value for the ``backoff_factor``
+                kwarg.
+
+        Raises:
+            AlmaValidationError: If either value falls outside its
+                allowed domain.
+        """
+        # ``bool`` is a subclass of ``int`` in Python -- callers passing
+        # ``True``/``False`` almost certainly mean to enable/disable the
+        # feature, not to set a numeric retry count. Reject explicitly.
+        if isinstance(max_retries, bool) or not isinstance(max_retries, int):
+            raise AlmaValidationError(
+                f"max_retries must be an int >= 0, got {type(max_retries).__name__}"
+            )
+        if max_retries < 0:
+            raise AlmaValidationError(
+                f"max_retries must be >= 0, got {max_retries}"
+            )
+        if isinstance(backoff_factor, bool) or not isinstance(
+            backoff_factor, (int, float)
+        ):
+            raise AlmaValidationError(
+                "backoff_factor must be a non-negative number, "
+                f"got {type(backoff_factor).__name__}"
+            )
+        if backoff_factor < 0:
+            raise AlmaValidationError(
+                f"backoff_factor must be >= 0, got {backoff_factor}"
+            )
+
+    @staticmethod
+    def _build_retry(max_retries: int, backoff_factor: float) -> Retry:
+        """Construct the default ``urllib3.util.Retry`` policy.
+
+        Args:
+            max_retries: Total number of retry attempts.
+            backoff_factor: Exponential backoff multiplier.
+
+        Returns:
+            A configured ``Retry`` instance with the project defaults
+            applied (status forcelist, allowed methods, Retry-After
+            header respected).
+        """
+        return Retry(
+            total=max_retries,
+            status_forcelist=list(DEFAULT_RETRY_STATUS_FORCELIST),
+            backoff_factor=backoff_factor,
+            allowed_methods=DEFAULT_RETRY_ALLOWED_METHODS,
+            respect_retry_after_header=True,
+        )
 
     def _setup_logger(self) -> None:
         """Setup comprehensive logger for API client."""
@@ -122,13 +224,34 @@ class AlmaAPIClient:
         also gives downstream improvements (retry adapters, rate limiting,
         context-manager support) a single mount point.
 
-        Pattern source: GitHub issue #3 (HTTP: persistent requests.Session).
+        Mounts an ``HTTPAdapter`` with a ``urllib3.util.Retry`` policy so
+        transient 429/5xx responses from Alma are retried with
+        exponential backoff and ``Retry-After`` header awareness — long
+        paged jobs no longer have to be re-run from scratch when a single
+        intermediate response trips the rate limiter (issue #5).
+
+        Pattern source: GitHub issue #3 (HTTP: persistent requests.Session)
+        and issue #5 (HTTP: add retry with exponential backoff for
+        429/5xx).
         """
         self._session = requests.Session()
         # Default headers live on the session; per-call ``custom_headers``
         # still wins via the per-call ``headers=`` kwarg passed to
         # ``self._session.request(...)``.
         self._session.headers.update(self.default_headers)
+
+        # Mount the retry-aware HTTPAdapter on both schemes. ``http://``
+        # is included for completeness even though Alma's public API is
+        # HTTPS-only -- a misconfigured base URL or a future on-prem
+        # variant should still benefit from the same retry policy.
+        retry_policy = (
+            self._retry_override
+            if self._retry_override is not None
+            else self._build_retry(self._max_retries, self._backoff_factor)
+        )
+        adapter = HTTPAdapter(max_retries=retry_policy)
+        self._session.mount("https://", adapter)
+        self._session.mount("http://", adapter)
 
 
     def _load_configuration(self) -> None:

--- a/tests/unit/client/test_alma_api_client.py
+++ b/tests/unit/client/test_alma_api_client.py
@@ -22,9 +22,14 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from almaapitk import AlmaAPIClient
-from almaapitk.client.AlmaAPIClient import _safe_response_body
+from almaapitk.client.AlmaAPIClient import (
+    AlmaValidationError,
+    _safe_response_body,
+)
 
 
 def _make_mock_response(
@@ -318,6 +323,111 @@ class TestRequestChokepoint(_AlmaAPIClientTestBase):
             "should not be called for non-JSON content"
         )
         self.assertIsNone(_safe_response_body(text_response))
+
+
+class TestRetryAdapterMounted(_AlmaAPIClientTestBase):
+    """Tests for issue #5: HTTPAdapter with Retry policy mounted on session.
+
+    These tests inspect the *configuration* of the mounted adapter
+    rather than driving the retry loop end-to-end. The earlier code
+    review of #5 noted that the existing test suite patches
+    ``client._session.request`` — patching at that level bypasses
+    urllib3's adapter logic, so retry behavior cannot be verified by
+    patching at that level. Inspecting the adapter's ``max_retries``
+    attribute (which is the ``Retry`` instance after ``HTTPAdapter``
+    init) is the recommended alternative.
+
+    Pattern source: GitHub issue #5 acceptance criteria.
+    """
+
+    def _get_mounted_retry(
+        self, client: AlmaAPIClient, scheme: str
+    ) -> Retry:
+        """Pull the ``Retry`` instance off the adapter mounted for ``scheme``."""
+        adapter = client._session.adapters[scheme]
+        self.assertIsInstance(adapter, HTTPAdapter)
+        retry = adapter.max_retries
+        self.assertIsInstance(retry, Retry)
+        return retry
+
+    def test_init_mounts_retry_adapter_https(self):
+        """AC-1 + AC-2: default Retry policy is mounted for ``https://``."""
+        client = AlmaAPIClient('SANDBOX')
+        retry = self._get_mounted_retry(client, 'https://')
+        self.assertEqual(retry.total, 3)
+        self.assertEqual(
+            set(retry.status_forcelist), {429, 500, 502, 503, 504}
+        )
+        self.assertEqual(retry.backoff_factor, 1)
+        # ``allowed_methods`` is normalized by urllib3 -- compare as a set.
+        self.assertEqual(
+            set(retry.allowed_methods), {"GET", "POST", "PUT", "DELETE"}
+        )
+        self.assertTrue(retry.respect_retry_after_header)
+
+    def test_init_mounts_retry_adapter_http(self):
+        """AC-1 + AC-2: default Retry policy is mounted for ``http://`` too."""
+        client = AlmaAPIClient('SANDBOX')
+        retry = self._get_mounted_retry(client, 'http://')
+        self.assertEqual(retry.total, 3)
+        self.assertEqual(
+            set(retry.status_forcelist), {429, 500, 502, 503, 504}
+        )
+        self.assertEqual(retry.backoff_factor, 1)
+        self.assertEqual(
+            set(retry.allowed_methods), {"GET", "POST", "PUT", "DELETE"}
+        )
+        self.assertTrue(retry.respect_retry_after_header)
+
+    def test_max_retries_kwarg_overrides_default(self):
+        """AC-3: ``max_retries`` kwarg overrides the ``total`` default."""
+        client = AlmaAPIClient('SANDBOX', max_retries=5)
+        retry = self._get_mounted_retry(client, 'https://')
+        self.assertEqual(retry.total, 5)
+        # Other defaults should be unaffected by the override.
+        self.assertEqual(retry.backoff_factor, 1)
+        self.assertEqual(
+            set(retry.status_forcelist), {429, 500, 502, 503, 504}
+        )
+
+    def test_backoff_factor_kwarg_overrides_default(self):
+        """AC-3: ``backoff_factor`` kwarg overrides the multiplier."""
+        client = AlmaAPIClient('SANDBOX', backoff_factor=0.5)
+        retry = self._get_mounted_retry(client, 'https://')
+        self.assertEqual(retry.backoff_factor, 0.5)
+        # Defaults preserved for the other knobs.
+        self.assertEqual(retry.total, 3)
+
+    def test_retry_kwarg_wins_over_other_kwargs(self):
+        """AC-4: a hand-built ``Retry`` instance overrides simple kwargs."""
+        custom_retry = Retry(
+            total=10,
+            status_forcelist=[418],
+            backoff_factor=0.25,
+            allowed_methods=frozenset({"GET"}),
+        )
+        # Pass conflicting simple kwargs to prove ``retry`` wins.
+        client = AlmaAPIClient(
+            'SANDBOX',
+            max_retries=99,
+            backoff_factor=2.0,
+            retry=custom_retry,
+        )
+        retry = self._get_mounted_retry(client, 'https://')
+        self.assertEqual(retry.total, 10)
+        self.assertEqual(list(retry.status_forcelist), [418])
+        self.assertEqual(retry.backoff_factor, 0.25)
+        self.assertEqual(set(retry.allowed_methods), {"GET"})
+
+    def test_invalid_max_retries_raises(self):
+        """Negative ``max_retries`` should be rejected at construction time."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', max_retries=-1)
+
+    def test_invalid_backoff_factor_raises(self):
+        """Negative ``backoff_factor`` should be rejected at construction time."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', backoff_factor=-0.1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Chunk: `http-retry`

Closes #5

## Implementation summary

HTTPAdapter with urllib3 Retry mounted on session for https/http (total=3, backoff=1, status_forcelist={429,500,502,503,504}, allowed_methods={GET,POST,PUT,DELETE}, respect_retry_after). 22 unit + 25 contract tests green.

## SANDBOX test summary

1 SANDBOX smoke test passed against user <user_primary_id>. Adapter mounted with Retry instance verified live; happy-path GET still works. 4 of 5 ACs in unmappable[] (private internals); not auto-close eligible per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/http-retry/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)