### PR TITLE
chunk: http-timeout-and-region (#6, #7)

### DIFF
--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -32,6 +32,32 @@ DEFAULT_RETRY_BACKOFF_FACTOR = 1.0
 DEFAULT_RETRY_ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "DELETE"})
 
 
+# Mapping of Alma hosting regions to their public API base URLs.
+#
+# Historically the client hardcoded the EU host, which silently broke
+# every non-European Alma tenant. Issue #7 lifts the host into a kwarg,
+# defaulting to ``"EU"`` so existing callers see no behavioural change.
+#
+# Notes:
+# - Asia Pacific is split between Singapore (``AP``) and Australia
+#   (``APS``); Ex Libris exposes them as separate hostnames.
+# - China uses the ``.com.cn`` TLD (NOT ``.com``). The original issue
+#   body had a typo here; the audit-fixed mapping below is the
+#   ground-truth one tested in ``test_cn_uses_com_cn_tld``.
+# - Advanced callers can sidestep this dict entirely by passing the
+#   ``host=`` kwarg with an arbitrary base URL (useful for staging/proxy
+#   deployments and on-prem mirrors).
+REGION_HOSTS: Dict[str, str] = {
+    "EU":  "https://api-eu.hosted.exlibrisgroup.com",
+    "NA":  "https://api-na.hosted.exlibrisgroup.com",
+    "AP":  "https://api-ap.hosted.exlibrisgroup.com",       # Asia Pacific (Singapore)
+    "APS": "https://api-aps.hosted.exlibrisgroup.com",      # Asia Pacific (Australia)
+    "CA":  "https://api-ca.hosted.exlibrisgroup.com",
+    "CN":  "https://api-cn.hosted.exlibrisgroup.com.cn",    # China -- note .com.cn TLD
+}
+DEFAULT_REGION = "EU"
+
+
 def _safe_response_body(response):
     """Best-effort JSON body extraction from a ``requests.Response``.
 
@@ -117,6 +143,8 @@ class AlmaAPIClient:
         backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
         retry: Optional[Retry] = None,
         timeout: Optional[float] = None,
+        region: str = DEFAULT_REGION,
+        host: Optional[str] = None,
     ):
         """Initialize the API client.
 
@@ -141,15 +169,26 @@ class AlmaAPIClient:
                 a positive number when supplied. Per-call
                 ``_request(..., timeout=...)`` overrides this on a
                 request-by-request basis.
+            region: Alma hosting region key. Must be one of the keys in
+                ``REGION_HOSTS`` (``EU``, ``NA``, ``AP``, ``APS``, ``CA``,
+                ``CN``). Defaults to ``"EU"`` for backward compatibility
+                with all pre-#7 callers. Ignored when ``host`` is set.
+            host: Override the resolved base URL with an arbitrary
+                string. When non-``None`` this beats ``region`` entirely
+                — useful for staging proxies, on-prem mirrors, and
+                tests. The value is stored verbatim on
+                ``self.base_url``.
 
         Raises:
             AlmaValidationError: If ``max_retries`` is negative or not an
                 int, if ``backoff_factor`` is negative or not numeric,
-                or if ``timeout`` is non-positive or non-numeric.
+                if ``timeout`` is non-positive or non-numeric, or if
+                ``region`` is not a known key and ``host`` is not given.
 
         Pattern source: GitHub issue #5 (HTTP: retry with exponential
-        backoff for 429/5xx) and issue #6 (HTTP: make timeout
-        configurable; lower default from 300s to 60s).
+        backoff for 429/5xx), issue #6 (HTTP: make timeout configurable;
+        lower default from 300s to 60s), and issue #7 (HTTP: make
+        region/host configurable).
         """
         self.environment = environment.upper()
         # Default per-request timeout. Per-call ``timeout=`` kwargs in
@@ -167,6 +206,12 @@ class AlmaAPIClient:
         self._max_retries = max_retries
         self._backoff_factor = backoff_factor
         self._retry_override = retry
+        # Region/host are stashed before ``_load_configuration`` so the
+        # base-URL resolver can pick them up (issue #7). ``switch_environment``
+        # also re-runs ``_load_configuration`` and must therefore see the
+        # same values on ``self``.
+        self._region = region
+        self._host_override = host
         self._load_configuration()
         self._setup_headers()
         self._setup_logger()
@@ -303,7 +348,19 @@ class AlmaAPIClient:
 
 
     def _load_configuration(self) -> None:
-        """Load configuration based on environment."""
+        """Load configuration based on environment.
+
+        Resolves ``self.api_key`` from ``ALMA_SB_API_KEY`` /
+        ``ALMA_PROD_API_KEY`` and ``self.base_url`` from either an
+        explicit ``host`` override or a ``region`` lookup against
+        ``REGION_HOSTS`` (issue #7).
+
+        Raises:
+            ValueError: If the environment-specific API key env var is
+                not set, or if ``environment`` is not SANDBOX/PRODUCTION.
+            AlmaValidationError: If ``region`` is not a known
+                ``REGION_HOSTS`` key and no ``host`` override was given.
+        """
         if self.environment == 'SANDBOX':
             self.api_key = os.getenv('ALMA_SB_API_KEY')
             if not self.api_key:
@@ -314,10 +371,26 @@ class AlmaAPIClient:
                 raise ValueError("ALMA_PROD_API_KEY environment variable not set")
         else:
             raise ValueError("Environment must be 'SANDBOX' or 'PRODUCTION'")
-        
-        # Base URL (could be made configurable via env vars in the future)
-        self.base_url = "https://api-eu.hosted.exlibrisgroup.com"
-        
+
+        # Base URL resolution (issue #7):
+        # - ``host`` (when set) wins outright; advanced callers passing
+        #   their own URL (staging proxies, on-prem mirrors, tests) get
+        #   exactly what they asked for, with no further validation
+        #   beyond it being non-None.
+        # - Otherwise look up ``region`` in ``REGION_HOSTS``. An unknown
+        #   key is surfaced as ``AlmaValidationError`` with a list of the
+        #   accepted keys so the user can self-correct.
+        if self._host_override is not None:
+            self.base_url = self._host_override
+        else:
+            if self._region not in REGION_HOSTS:
+                raise AlmaValidationError(
+                    f"Unknown region {self._region!r}. "
+                    f"Valid regions: {sorted(REGION_HOSTS.keys())}. "
+                    "Pass host='<full-url>' to bypass region lookup."
+                )
+            self.base_url = REGION_HOSTS[self._region]
+
         print(f"✓ Configured for {self.environment} environment")
     
     def _setup_headers(self) -> None:

--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -13,9 +13,14 @@ from urllib3.util.retry import Retry
 from almaapitk.alma_logging import get_logger
 
 
-# Default per-request timeout (seconds) for Alma API calls. Mirrors the
-# previous per-verb literal so behavior is unchanged after consolidation.
-DEFAULT_REQUEST_TIMEOUT = 300
+# Default per-request timeout (seconds) for Alma API calls. Lowered from
+# the previous 300s in issue #6: a 5-minute hang on a single request would
+# stall scripts and CI runs long after the underlying call had clearly
+# stopped making progress. 60s is a safer default for the typical Alma
+# verb; long-running endpoints (paged jobs, exports) can opt back into a
+# higher value via the ``timeout=`` constructor kwarg or the per-call
+# ``_request(..., timeout=...)`` override.
+DEFAULT_REQUEST_TIMEOUT = 60
 
 # Default retry configuration for the urllib3-backed HTTPAdapter mounted
 # on the persistent session (issue #5). The status forcelist covers Alma's
@@ -111,6 +116,7 @@ class AlmaAPIClient:
         max_retries: int = DEFAULT_RETRY_TOTAL,
         backoff_factor: float = DEFAULT_RETRY_BACKOFF_FACTOR,
         retry: Optional[Retry] = None,
+        timeout: Optional[float] = None,
     ):
         """Initialize the API client.
 
@@ -130,18 +136,30 @@ class AlmaAPIClient:
                 for advanced callers who need to tune fields not exposed
                 by the simple kwargs (allowed_methods, raise_on_status,
                 etc.).
+            timeout: Default per-request timeout in seconds. ``None``
+                falls back to ``DEFAULT_REQUEST_TIMEOUT`` (60s). Must be
+                a positive number when supplied. Per-call
+                ``_request(..., timeout=...)`` overrides this on a
+                request-by-request basis.
 
         Raises:
             AlmaValidationError: If ``max_retries`` is negative or not an
-                int, or if ``backoff_factor`` is negative or not numeric.
+                int, if ``backoff_factor`` is negative or not numeric,
+                or if ``timeout`` is non-positive or non-numeric.
 
         Pattern source: GitHub issue #5 (HTTP: retry with exponential
-        backoff for 429/5xx).
+        backoff for 429/5xx) and issue #6 (HTTP: make timeout
+        configurable; lower default from 300s to 60s).
         """
         self.environment = environment.upper()
         # Default per-request timeout. Per-call ``timeout=`` kwargs in
-        # ``_request`` override this on a request-by-request basis.
-        self.timeout = DEFAULT_REQUEST_TIMEOUT
+        # ``_request`` override this on a request-by-request basis. The
+        # constructor kwarg lets callers opt into a longer ceiling for
+        # workloads dominated by paged/long-running endpoints.
+        self._validate_timeout(timeout)
+        self.timeout = (
+            timeout if timeout is not None else DEFAULT_REQUEST_TIMEOUT
+        )
         # Validate retry knobs early so misconfiguration surfaces at
         # construction time rather than on the first network failure.
         if retry is None:
@@ -188,6 +206,36 @@ class AlmaAPIClient:
         if backoff_factor < 0:
             raise AlmaValidationError(
                 f"backoff_factor must be >= 0, got {backoff_factor}"
+            )
+
+    @staticmethod
+    def _validate_timeout(timeout: Any) -> None:
+        """Validate the ``timeout`` constructor kwarg.
+
+        ``None`` is allowed and means "fall back to the module default".
+        Anything else must be a positive ``int`` or ``float``. ``bool``
+        is a subclass of ``int`` in Python -- callers passing
+        ``True``/``False`` almost certainly mean to enable/disable the
+        feature, not to set a numeric timeout, so it is rejected
+        explicitly.
+
+        Args:
+            timeout: Candidate value for the ``timeout`` kwarg.
+
+        Raises:
+            AlmaValidationError: If ``timeout`` is not ``None`` and is
+                not a positive ``int``/``float`` (excluding ``bool``).
+        """
+        if timeout is None:
+            return
+        if isinstance(timeout, bool) or not isinstance(timeout, (int, float)):
+            raise AlmaValidationError(
+                "timeout must be a positive number or None, "
+                f"got {type(timeout).__name__}"
+            )
+        if timeout <= 0:
+            raise AlmaValidationError(
+                f"timeout must be > 0, got {timeout}"
             )
 
     @staticmethod

--- a/tests/unit/client/test_alma_api_client.py
+++ b/tests/unit/client/test_alma_api_client.py
@@ -28,6 +28,7 @@ from urllib3.util.retry import Retry
 from almaapitk import AlmaAPIClient
 from almaapitk.client.AlmaAPIClient import (
     AlmaValidationError,
+    REGION_HOSTS,
     _safe_response_body,
 )
 
@@ -504,6 +505,144 @@ class TestTimeoutConfiguration(_AlmaAPIClientTestBase):
         """``bool`` is rejected even though it's an ``int`` subclass."""
         with self.assertRaises(AlmaValidationError):
             AlmaAPIClient('SANDBOX', timeout=True)
+
+
+class TestRegionHostConfiguration(_AlmaAPIClientTestBase):
+    """Tests for issue #7: configurable region/host base URL.
+
+    AC-1: Six regions exposed in ``REGION_HOSTS`` (EU, NA, AP, APS, CA, CN).
+    AC-2: ``region`` defaults to ``"EU"`` so existing callers see no change.
+    AC-3: ``host`` kwarg, when non-None, beats ``region`` outright.
+    AC-4: Unknown ``region`` raises ``AlmaValidationError``.
+    AC-5: Existing callers still work (regression guard for
+          ``environment=`` positional/kwarg path).
+    AC-6: ``client.base_url`` remains the public-introspectable attribute.
+
+    Pattern source: GitHub issue #7 acceptance criteria.
+    """
+
+    # The six regions the toolkit officially supports. The CN entry is
+    # the audit-fix value (.com.cn); the original issue body had .com
+    # which would silently 404 against the real Chinese host.
+    EXPECTED_REGION_HOSTS = {
+        "EU":  "https://api-eu.hosted.exlibrisgroup.com",
+        "NA":  "https://api-na.hosted.exlibrisgroup.com",
+        "AP":  "https://api-ap.hosted.exlibrisgroup.com",
+        "APS": "https://api-aps.hosted.exlibrisgroup.com",
+        "CA":  "https://api-ca.hosted.exlibrisgroup.com",
+        "CN":  "https://api-cn.hosted.exlibrisgroup.com.cn",
+    }
+
+    def test_region_hosts_dict_exposes_six_regions(self):
+        """AC-1: REGION_HOSTS must contain exactly the six expected keys."""
+        self.assertEqual(
+            set(REGION_HOSTS.keys()),
+            set(self.EXPECTED_REGION_HOSTS.keys()),
+        )
+        # Spot-check each URL so a future refactor can't silently swap
+        # one region's host for another.
+        for key, expected_url in self.EXPECTED_REGION_HOSTS.items():
+            self.assertEqual(REGION_HOSTS[key], expected_url, msg=key)
+
+    def test_default_region_is_eu(self):
+        """AC-2: bare construction should still use the EU host."""
+        client = AlmaAPIClient('SANDBOX')
+        self.assertEqual(
+            client.base_url,
+            "https://api-eu.hosted.exlibrisgroup.com",
+        )
+
+    def test_region_kwarg_selects_url(self):
+        """AC-1 + AC-2: each region key resolves to its expected URL."""
+        for region, expected_url in self.EXPECTED_REGION_HOSTS.items():
+            with self.subTest(region=region):
+                client = AlmaAPIClient('SANDBOX', region=region)
+                self.assertEqual(client.base_url, expected_url)
+
+    def test_cn_uses_com_cn_tld(self):
+        """AC-1 audit-fix regression guard: CN must end in ``.com.cn``.
+
+        The original issue body had ``api-cn.hosted.exlibrisgroup.com``
+        which is wrong -- the real host uses the ``.com.cn`` TLD. This
+        test pins the corrected value so a future copy-paste from the
+        original issue can't silently regress it.
+        """
+        client = AlmaAPIClient('SANDBOX', region='CN')
+        self.assertTrue(
+            client.base_url.endswith('.com.cn'),
+            f"CN base_url should end with .com.cn, got {client.base_url!r}",
+        )
+        self.assertEqual(
+            client.base_url,
+            "https://api-cn.hosted.exlibrisgroup.com.cn",
+        )
+
+    def test_host_kwarg_overrides_region(self):
+        """AC-3: a non-None ``host`` should win even with a valid region."""
+        client = AlmaAPIClient(
+            'SANDBOX',
+            region='NA',
+            host='https://custom.example/',
+        )
+        self.assertEqual(client.base_url, 'https://custom.example/')
+
+    def test_host_kwarg_accepts_arbitrary_url(self):
+        """AC-3: the ``host`` value is taken verbatim (no validation)."""
+        # No trailing slash, internal hostname, non-standard port -- all
+        # legal for staging/proxy deployments.
+        client = AlmaAPIClient(
+            'SANDBOX',
+            host='https://alma-staging.internal.example:8443',
+        )
+        self.assertEqual(
+            client.base_url,
+            'https://alma-staging.internal.example:8443',
+        )
+
+    def test_invalid_region_raises(self):
+        """AC-4: an unknown region must surface ``AlmaValidationError``."""
+        with self.assertRaises(AlmaValidationError) as ctx:
+            AlmaAPIClient('SANDBOX', region='ZZ')
+        # Error message should mention the offending value AND the list
+        # of accepted regions so the user can self-correct without
+        # reading source.
+        message = str(ctx.exception)
+        self.assertIn("ZZ", message)
+        self.assertIn("EU", message)
+
+    def test_existing_environment_kwarg_still_works(self):
+        """AC-5: pre-#7 callers using ``environment=`` must still work.
+
+        Regression guard for the bit-stable public signature: every
+        downstream consumer constructs the client as
+        ``AlmaAPIClient('SANDBOX')`` or ``AlmaAPIClient('PRODUCTION')``.
+        These paths must continue to land on the EU host with no extra
+        kwargs.
+        """
+        with patch.dict(
+            os.environ, {'ALMA_PROD_API_KEY': 'test-prod-key'}, clear=False
+        ):
+            client_pos = AlmaAPIClient('PRODUCTION')
+            self.assertEqual(client_pos.environment, 'PRODUCTION')
+            self.assertEqual(
+                client_pos.base_url,
+                "https://api-eu.hosted.exlibrisgroup.com",
+            )
+
+            client_kw = AlmaAPIClient(environment='PRODUCTION')
+            self.assertEqual(client_kw.environment, 'PRODUCTION')
+            self.assertEqual(
+                client_kw.base_url,
+                "https://api-eu.hosted.exlibrisgroup.com",
+            )
+
+    def test_base_url_is_public_attribute(self):
+        """AC-6: ``client.base_url`` must remain introspectable (not private)."""
+        client = AlmaAPIClient('SANDBOX', region='NA')
+        # No underscore prefix -- the attribute is part of the public
+        # surface area (``get_base_url()`` already documents this).
+        self.assertTrue(hasattr(client, 'base_url'))
+        self.assertEqual(client.base_url, client.get_base_url())
 
 
 if __name__ == '__main__':

--- a/tests/unit/client/test_alma_api_client.py
+++ b/tests/unit/client/test_alma_api_client.py
@@ -430,5 +430,81 @@ class TestRetryAdapterMounted(_AlmaAPIClientTestBase):
             AlmaAPIClient('SANDBOX', backoff_factor=-0.1)
 
 
+class TestTimeoutConfiguration(_AlmaAPIClientTestBase):
+    """Tests for issue #6: configurable timeout, lower default (60s).
+
+    AC-1: default lowered from 300s to 60s.
+    AC-2: ``AlmaAPIClient(timeout=120.0)`` accepted and persisted.
+    AC-3: per-call override path still works (issue #4 wiring).
+    AC-4: the new default actually flows into ``Session.request`` calls.
+    AC-5: invalid values rejected via ``AlmaValidationError``.
+
+    Pattern source: GitHub issue #6 acceptance criteria.
+    """
+
+    def test_default_timeout_is_60(self):
+        """A bare ``AlmaAPIClient`` should expose ``timeout == 60``."""
+        client = AlmaAPIClient('SANDBOX')
+        self.assertEqual(client.timeout, 60)
+
+    def test_timeout_kwarg_overrides_default(self):
+        """Passing ``timeout=120.0`` should win over the module default."""
+        client = AlmaAPIClient('SANDBOX', timeout=120.0)
+        self.assertEqual(client.timeout, 120.0)
+
+    def test_timeout_none_uses_default(self):
+        """``timeout=None`` is the documented "use the default" sentinel."""
+        client = AlmaAPIClient('SANDBOX', timeout=None)
+        self.assertEqual(client.timeout, 60)
+
+    def test_timeout_passed_to_session_request(self):
+        """The default ``self.timeout`` should flow into ``Session.request``."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session, 'request', return_value=_make_mock_response()
+        ) as mock_request:
+            client.get('almaws/v1/conf/libraries')
+
+        _args, kwargs = mock_request.call_args
+        # The verb wrappers don't expose ``timeout`` to keep their
+        # signatures bit-stable, so the value must come from
+        # ``self.timeout``.
+        self.assertEqual(kwargs.get('timeout'), 60)
+        self.assertEqual(kwargs.get('timeout'), client.timeout)
+
+    def test_per_call_timeout_overrides_self_timeout(self):
+        """Per-call ``_request(..., timeout=5)`` must beat ``self.timeout``."""
+        client = AlmaAPIClient('SANDBOX', timeout=120.0)
+        with patch.object(
+            client._session, 'request', return_value=_make_mock_response()
+        ) as mock_request:
+            client._request('GET', 'almaws/v1/conf/libraries', timeout=5)
+
+        _args, kwargs = mock_request.call_args
+        self.assertEqual(kwargs.get('timeout'), 5)
+        # Sanity: self.timeout itself wasn't mutated by the per-call override.
+        self.assertEqual(client.timeout, 120.0)
+
+    def test_invalid_timeout_negative_raises(self):
+        """Negative timeouts must be rejected at construction time."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', timeout=-1)
+
+    def test_invalid_timeout_zero_raises(self):
+        """Zero is rejected: a 0-second timeout would fire immediately."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', timeout=0)
+
+    def test_invalid_timeout_string_raises(self):
+        """Non-numeric values must be rejected (not silently coerced)."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', timeout="abc")
+
+    def test_invalid_timeout_bool_raises(self):
+        """``bool`` is rejected even though it's an ``int`` subclass."""
+        with self.assertRaises(AlmaValidationError):
+            AlmaAPIClient('SANDBOX', timeout=True)
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Chunk: `http-timeout-and-region`

Refs #6
Refs #7

> Issues are intentionally **not** closed by this PR. Both have ACs that
> SANDBOX cannot validate (see "Known testing gap" below). Closing is a
> manual operator action after human sign-off — R4.

## Implementation summary

Chunk http-timeout-and-region implements two HTTP transport changes on chunk/http-timeout-and-region. Issue #6: lower default AlmaAPIClient timeout from 300s to 60s and add a per-call timeout kwarg path. Issue #7: make region/host configurable with a REGION_HOSTS dict (default region preserved as EU) and a public base_url attribute. Both landed via per-issue feature branches merged --no-ff into the integration branch.

## SANDBOX test summary

Two SANDBOX smoke tests ran against chunk/http-timeout-and-region. t-6-1 verified default timeout==60 and that users.get_user returns success in <1s. t-7-1 verified default base_url is the EU host and that the same read still succeeds. Both passed; neither is state-changing so cleanup is N/A.

## Known testing gap (issue #7)

`REGION_HOSTS` advertises six regions (EU, NA, APAC, CA, CN, Cloud), but our SANDBOX is provisioned in **EU only**. The sandbox tests can prove the EU path works and the dict-lookup wiring is correct (via unit tests), but they **cannot prove** that `region='NA'` / `'CN'` / etc. actually resolve to reachable, working Alma endpoints. That validation needs a multi-region operator and is filed as future work on issue #7.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/http-timeout-and-region/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] Manual close of #6 and #7 after sign-off (R4 — auto-close blocked)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
