### PR TITLE
refactor(logging): route library output through logger; remove safe_request (closes #14)

### DIFF
--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -6,7 +6,7 @@ This is designed to be 'pluggable' - other classes will use this as their founda
 import os
 import requests
 import json
-from typing import Optional, Dict, Any, Union, List
+from typing import Optional, Dict, Any
 import time
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -212,9 +212,12 @@ class AlmaAPIClient:
         # same values on ``self``.
         self._region = region
         self._host_override = host
+        # Logger is set up first so ``_load_configuration`` can use
+        # ``self.logger`` instead of ``print()``. Only ``self.environment``
+        # (set above) is required for logger setup.
+        self._setup_logger()
         self._load_configuration()
         self._setup_headers()
-        self._setup_logger()
         self._setup_session()
 
     @staticmethod
@@ -391,7 +394,7 @@ class AlmaAPIClient:
                 )
             self.base_url = REGION_HOSTS[self._region]
 
-        print(f"✓ Configured for {self.environment} environment")
+        self.logger.info(f"Configured for {self.environment} environment")
     
     def _setup_headers(self) -> None:
         """Setup default headers for API requests."""
@@ -634,12 +637,14 @@ class AlmaAPIClient:
             response = self.get('almaws/v1/conf/libraries')
             success = response.status_code == 200
             if success:
-                print(f"✓ Successfully connected to Alma API ({self.environment})")
+                self.logger.info(f"Successfully connected to Alma API ({self.environment})")
             else:
-                print(f"✗ Connection failed: {response.status_code} - {response.text}")
+                self.logger.error(
+                    f"Connection failed: {response.status_code} - {response.text}"
+                )
             return success
         except Exception as e:
-            print(f"✗ Connection error: {e}")
+            self.logger.exception(f"Connection error: {e}")
             return False
     
     def switch_environment(self, new_environment: str) -> None:
@@ -659,7 +664,7 @@ class AlmaAPIClient:
             # forward (issue #3).
             if hasattr(self, '_session') and self._session is not None:
                 self._session.headers.update(self.default_headers)
-            print(f"✓ Switched from {old_env} to {self.environment}")
+            self.logger.info(f"Switched from {old_env} to {self.environment}")
         except Exception as e:
             # Revert to old environment if switch fails
             self.environment = old_env
@@ -677,50 +682,6 @@ class AlmaAPIClient:
         """Get base URL."""
         return self.base_url
     
-    # Utility methods that domain classes can use
-    
-    def safe_request(self, method: str, endpoint: str, **kwargs) -> Union[Dict, str, None]:
-        """
-        Make a request and handle common errors gracefully.
-        
-        Args:
-            method: HTTP method ('GET', 'POST', 'PUT', 'DELETE')
-            endpoint: API endpoint
-            **kwargs: Additional arguments for the request
-            
-        Returns:
-            Parsed response data or None if error
-        """
-        try:
-            method = method.upper()
-            if method == 'GET':
-                response = self.get(endpoint, **kwargs)
-            elif method == 'POST':
-                response = self.post(endpoint, **kwargs)
-            elif method == 'PUT':
-                response = self.put(endpoint, **kwargs)
-            elif method == 'DELETE':
-                response = self.delete(endpoint, **kwargs)
-            else:
-                raise ValueError(f"Unsupported method: {method}")
-            
-            response.raise_for_status()
-            
-            # Try to return JSON, fall back to text
-            try:
-                return response.json()
-            except:
-                return response.text
-                
-        except requests.exceptions.RequestException as e:
-            print(f"Request error: {e}")
-            return None
-        except Exception as e:
-            print(f"Unexpected error: {e}")
-            return None
-
-
-
 
 
 
@@ -732,6 +693,15 @@ if __name__ == "__main__":
     Example usage of the AlmaAPIClient.
     This shows how the class works as a foundation.
     """
+    # Mirror INFO+ logger output to stderr so CLI users see the same
+    # progress/error messages that the alma_logging file handlers
+    # capture. Library code itself emits no raw stdout (issue #14).
+    import logging as _logging
+    _stderr_handler = _logging.StreamHandler(sys.stderr)
+    _stderr_handler.setFormatter(_logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _logging.getLogger("almapi").addHandler(_stderr_handler)
+    _logging.getLogger("almapi").setLevel(_logging.INFO)
+
     try:
         # Initialize client
         client = AlmaAPIClient('PRODUCTION')  # or 'SANDBOX'

--- a/src/almaapitk/domains/acquisition.py
+++ b/src/almaapitk/domains/acquisition.py
@@ -378,12 +378,12 @@ class Acquisitions:
             )
 
             # Create invoice via low-level method
-            print(f"Creating invoice {invoice_number} for vendor {vendor_code}: {total_amount} {currency}")
+            self.logger.info(f"Creating invoice {invoice_number} for vendor {vendor_code}: {total_amount} {currency}")
             created_invoice = self.create_invoice(invoice_data)
 
             invoice_id = created_invoice.get('id')
             if invoice_id:
-                print(f"✓ Invoice created successfully: {invoice_id}")
+                self.logger.info(f"✓ Invoice created successfully: {invoice_id}")
                 self.logger.info(
                     f"Invoice created successfully: {invoice_id}",
                     invoice_id=invoice_id,
@@ -392,7 +392,7 @@ class Acquisitions:
                     total_amount=total_amount
                 )
             else:
-                print(f"⚠️ Invoice created but no ID returned")
+                self.logger.warning(f"⚠️ Invoice created but no ID returned")
                 self.logger.warning(
                     "Invoice created but no ID in response",
                     invoice_number=invoice_number
@@ -509,7 +509,7 @@ class Acquisitions:
         try:
             # If fund_code not provided, try to get from POL
             if not fund_code:
-                print(f"No fund code provided - attempting to extract from POL {pol_id}")
+                self.logger.info(f"No fund code provided - attempting to extract from POL {pol_id}")
                 self.logger.debug(
                     f"Extracting fund code from POL: {pol_id}",
                     pol_id=pol_id
@@ -517,7 +517,7 @@ class Acquisitions:
                 fund_code = self.get_fund_from_pol(pol_id)
 
                 if fund_code:
-                    print(f"✓ Found fund code in POL: {fund_code}")
+                    self.logger.info(f"✓ Found fund code in POL: {fund_code}")
                     self.logger.info(
                         f"Fund code extracted from POL: {fund_code}",
                         pol_id=pol_id,
@@ -552,10 +552,10 @@ class Acquisitions:
             )
 
             # Create invoice line via low-level method
-            print(f"Creating invoice line for POL {pol_id}: {quantity} x {amount} {currency} (Fund: {fund_code})")
+            self.logger.info(f"Creating invoice line for POL {pol_id}: {quantity} x {amount} {currency} (Fund: {fund_code})")
             created_line = self.create_invoice_line(invoice_id, line_data)
 
-            print(f"✓ Invoice line created successfully")
+            self.logger.info(f"✓ Invoice line created successfully")
             self.logger.info(
                 f"Invoice line created successfully",
                 invoice_id=invoice_id,
@@ -765,9 +765,9 @@ class Acquisitions:
 
         try:
             # Step 1: Calculate total amount from lines
-            print("=" * 70)
-            print("STEP 1: Calculate total amount from lines")
-            print("-" * 70)
+            self.logger.info("=" * 70)
+            self.logger.info("STEP 1: Calculate total amount from lines")
+            self.logger.info("-" * 70)
 
             self.logger.info(
                 "Workflow Step 1: Calculating total amount",
@@ -778,8 +778,8 @@ class Acquisitions:
             total_amount = sum(line['amount'] for line in lines)
             result['total_amount'] = total_amount
 
-            print(f"Lines: {len(lines)}")
-            print(f"Total amount: {total_amount} {currency}")
+            self.logger.info(f"Lines: {len(lines)}")
+            self.logger.info(f"Total amount: {total_amount} {currency}")
 
             self.logger.info(
                 "Total amount calculated",
@@ -790,9 +790,9 @@ class Acquisitions:
             )
 
             # Step 2: Create invoice
-            print("\n" + "=" * 70)
-            print("STEP 2: Create invoice")
-            print("-" * 70)
+            self.logger.info("\n" + "=" * 70)
+            self.logger.info("STEP 2: Create invoice")
+            self.logger.info("-" * 70)
 
             self.logger.info(
                 "Workflow Step 2: Creating invoice",
@@ -819,7 +819,7 @@ class Acquisitions:
                 raise AlmaAPIError("Invoice created but no ID returned")
 
             result['invoice_id'] = invoice_id
-            print(f"✓ Invoice created: {invoice_id}")
+            self.logger.info(f"✓ Invoice created: {invoice_id}")
 
             self.logger.info(
                 "Invoice created in workflow",
@@ -828,9 +828,9 @@ class Acquisitions:
             )
 
             # Step 3: Add all lines
-            print("\n" + "=" * 70)
-            print(f"STEP 3: Add {len(lines)} invoice line(s)")
-            print("-" * 70)
+            self.logger.info("\n" + "=" * 70)
+            self.logger.info(f"STEP 3: Add {len(lines)} invoice line(s)")
+            self.logger.info("-" * 70)
 
             self.logger.info(
                 f"Workflow Step 3: Adding {len(lines)} invoice lines",
@@ -842,7 +842,7 @@ class Acquisitions:
 
             # Optional: Check for duplicate invoicing
             if check_duplicates:
-                print("\n⚠️  Duplicate check enabled - validating POLs...")
+                self.logger.info("\n⚠️  Duplicate check enabled - validating POLs...")
                 duplicates_found = []
                 for line in lines:
                     pol_id = line['pol_id']
@@ -854,16 +854,16 @@ class Acquisitions:
                                 'existing_invoices': check['invoices']
                             })
                     except Exception as e:
-                        print(f"  ⚠️  Could not check {pol_id}: {e}")
+                        self.logger.exception(f"  ⚠️  Could not check {pol_id}: {e}")
 
                 if duplicates_found:
                     error_msg = f"Duplicate invoicing detected for {len(duplicates_found)} POL(s)"
-                    print(f"\n✗ {error_msg}:")
+                    self.logger.error(f"\n✗ {error_msg}:")
                     for dup in duplicates_found:
-                        print(f"  - {dup['pol_id']}: already has {len(dup['existing_invoices'])} invoice(s)")
+                        self.logger.debug(f"  - {dup['pol_id']}: already has {len(dup['existing_invoices'])} invoice(s)")
                     raise ValueError(error_msg)
                 else:
-                    print("  ✓ No duplicates found - safe to proceed")
+                    self.logger.debug("  ✓ No duplicates found - safe to proceed")
 
             for idx, line in enumerate(lines, 1):
                 try:
@@ -876,7 +876,7 @@ class Acquisitions:
                     line_kwargs = {k: v for k, v in line.items()
                                    if k not in ['pol_id', 'amount', 'quantity', 'fund_code']}
 
-                    print(f"\nLine {idx}/{len(lines)}: POL {pol_id}, Amount: {amount}")
+                    self.logger.info(f"\nLine {idx}/{len(lines)}: POL {pol_id}, Amount: {amount}")
 
                     created_line = self.create_invoice_line_simple(
                         invoice_id=invoice_id,
@@ -895,7 +895,7 @@ class Acquisitions:
                 except Exception as e:
                     error_msg = f"Line {idx} (POL {pol_id}): {str(e)}"
                     result['errors'].append(error_msg)
-                    print(f"✗ {error_msg}")
+                    self.logger.exception(f"✗ {error_msg}")
                     # Continue with remaining lines
 
             # Check if all lines succeeded
@@ -910,7 +910,7 @@ class Acquisitions:
 
             if len(result['line_ids']) < len(lines):
                 failed_count = len(lines) - len(result['line_ids'])
-                print(f"\n⚠️ Warning: {failed_count} line(s) failed")
+                self.logger.error(f"\n⚠️ Warning: {failed_count} line(s) failed")
                 self.logger.warning(
                     f"{failed_count} invoice lines failed",
                     invoice_id=invoice_id,
@@ -920,7 +920,7 @@ class Acquisitions:
                     total=len(lines)
                 )
             else:
-                print(f"\n✓ All {len(lines)} line(s) created successfully")
+                self.logger.info(f"\n✓ All {len(lines)} line(s) created successfully")
                 self.logger.info(
                     "All invoice lines created successfully",
                     invoice_id=invoice_id,
@@ -930,9 +930,9 @@ class Acquisitions:
 
             # Step 4: Process invoice (if requested)
             if auto_process:
-                print("\n" + "=" * 70)
-                print("STEP 4: Process (approve) invoice")
-                print("-" * 70)
+                self.logger.info("\n" + "=" * 70)
+                self.logger.info("STEP 4: Process (approve) invoice")
+                self.logger.info("-" * 70)
 
                 self.logger.info(
                     "Workflow Step 4: Processing invoice",
@@ -944,7 +944,7 @@ class Acquisitions:
                     processed_invoice = self.approve_invoice(invoice_id)
                     result['processed'] = True
                     result['status'] = processed_invoice.get('invoice_status', {}).get('value')
-                    print(f"✓ Invoice processed")
+                    self.logger.info(f"✓ Invoice processed")
 
                     self.logger.info(
                         "Invoice processed successfully",
@@ -956,7 +956,7 @@ class Acquisitions:
                 except Exception as e:
                     error_msg = f"Failed to process invoice: {str(e)}"
                     result['errors'].append(error_msg)
-                    print(f"✗ {error_msg}")
+                    self.logger.exception(f"✗ {error_msg}")
                     self.logger.error(
                         "Failed to process invoice",
                         invoice_id=invoice_id,
@@ -969,7 +969,7 @@ class Acquisitions:
                 if not auto_process or not result['processed']:
                     error_msg = "Cannot pay invoice: must be processed first"
                     result['errors'].append(error_msg)
-                    print(f"\n✗ {error_msg}")
+                    self.logger.error(f"\n✗ {error_msg}")
                     self.logger.warning(
                         "Cannot pay invoice: not processed",
                         invoice_id=invoice_id,
@@ -978,9 +978,9 @@ class Acquisitions:
                         processed=result['processed']
                     )
                 else:
-                    print("\n" + "=" * 70)
-                    print("STEP 5: Mark invoice as paid")
-                    print("-" * 70)
+                    self.logger.info("\n" + "=" * 70)
+                    self.logger.info("STEP 5: Mark invoice as paid")
+                    self.logger.info("-" * 70)
 
                     self.logger.info(
                         "Workflow Step 5: Marking invoice as paid",
@@ -992,7 +992,7 @@ class Acquisitions:
                         paid_invoice = self.mark_invoice_paid(invoice_id)
                         result['paid'] = True
                         result['status'] = paid_invoice.get('invoice_status', {}).get('value')
-                        print(f"✓ Invoice marked as paid")
+                        self.logger.info(f"✓ Invoice marked as paid")
 
                         self.logger.info(
                             "Invoice marked as paid successfully",
@@ -1004,7 +1004,7 @@ class Acquisitions:
                     except Exception as e:
                         error_msg = f"Failed to mark invoice as paid: {str(e)}"
                         result['errors'].append(error_msg)
-                        print(f"✗ {error_msg}")
+                        self.logger.exception(f"✗ {error_msg}")
                         self.logger.error(
                             "Failed to mark invoice as paid",
                             invoice_id=invoice_id,
@@ -1013,21 +1013,21 @@ class Acquisitions:
                         )
 
             # Final summary
-            print("\n" + "=" * 70)
-            print("WORKFLOW SUMMARY")
-            print("=" * 70)
-            print(f"Invoice ID: {result['invoice_id']}")
-            print(f"Invoice Number: {result['invoice_number']}")
-            print(f"Total Amount: {result['total_amount']} {currency}")
-            print(f"Lines Created: {len(result['line_ids'])}/{len(lines)}")
-            print(f"Processed: {'Yes' if result['processed'] else 'No'}")
-            print(f"Paid: {'Yes' if result['paid'] else 'No'}")
-            print(f"Status: {result['status'] or 'Unknown'}")
+            self.logger.info("\n" + "=" * 70)
+            self.logger.info("WORKFLOW SUMMARY")
+            self.logger.info("=" * 70)
+            self.logger.info(f"Invoice ID: {result['invoice_id']}")
+            self.logger.info(f"Invoice Number: {result['invoice_number']}")
+            self.logger.info(f"Total Amount: {result['total_amount']} {currency}")
+            self.logger.info(f"Lines Created: {len(result['line_ids'])}/{len(lines)}")
+            self.logger.info(f"Processed: {'Yes' if result['processed'] else 'No'}")
+            self.logger.info(f"Paid: {'Yes' if result['paid'] else 'No'}")
+            self.logger.info(f"Status: {result['status'] or 'Unknown'}")
 
             if result['errors']:
-                print(f"\nErrors encountered: {len(result['errors'])}")
+                self.logger.error(f"\nErrors encountered: {len(result['errors'])}")
                 for error in result['errors']:
-                    print(f"  - {error}")
+                    self.logger.error(f"  - {error}")
                 self.logger.warning(
                     f"Workflow completed with {len(result['errors'])} errors",
                     invoice_id=result['invoice_id'],
@@ -1036,7 +1036,7 @@ class Acquisitions:
                     errors=result['errors']
                 )
             else:
-                print("\n✓ Workflow completed successfully with no errors")
+                self.logger.info("\n✓ Workflow completed successfully with no errors")
                 self.logger.info(
                     "Workflow completed successfully",
                     invoice_id=result['invoice_id'],
@@ -1095,7 +1095,7 @@ class Acquisitions:
         if not invoice_id:
             raise ValueError("Invoice ID is required")
         
-        print(f"Retrieving invoice: {invoice_id} from {self.environment}")
+        self.logger.info(f"Retrieving invoice: {invoice_id} from {self.environment}")
         
         params = {"view": view} if view != "full" else None
         
@@ -1110,11 +1110,11 @@ class Acquisitions:
             # Parse JSON response
             invoice_data = response.json()
             
-            print(f"✓ Successfully retrieved invoice {invoice_id}")
+            self.logger.info(f"✓ Successfully retrieved invoice {invoice_id}")
             return invoice_data
             
         except Exception as e:
-            print(f"✗ Failed to retrieve invoice {invoice_id}: {str(e)}")
+            self.logger.exception(f"✗ Failed to retrieve invoice {invoice_id}: {str(e)}")
             raise
     
     def process_invoice_service(self, invoice_id: str, operation: str) -> Dict[str, Any]:
@@ -1145,9 +1145,9 @@ class Acquisitions:
         # Validate operation
         valid_operations = ['paid', 'process_invoice', 'mark_in_erp', 'rejected']
         if operation not in valid_operations:
-            print(f"⚠️  Warning: '{operation}' is not in known operations: {valid_operations}")
+            self.logger.warning(f"⚠️  Warning: '{operation}' is not in known operations: {valid_operations}")
         
-        print(f"Processing invoice service: {invoice_id}, operation: {operation}")
+        self.logger.debug(f"Processing invoice service: {invoice_id}, operation: {operation}")
         
         try:
             endpoint = f"almaws/v1/acq/invoices/{invoice_id}"
@@ -1165,11 +1165,11 @@ class Acquisitions:
             # Parse JSON response
             result_data = response.json()
             
-            print(f"✓ Successfully processed invoice service {operation} for invoice {invoice_id}")
+            self.logger.info(f"✓ Successfully processed invoice service {operation} for invoice {invoice_id}")
             return result_data
             
         except Exception as e:
-            print(f"✗ Failed to process invoice service {operation} for invoice {invoice_id}: {str(e)}")
+            self.logger.exception(f"✗ Failed to process invoice service {operation} for invoice {invoice_id}: {str(e)}")
             raise
     
     def check_invoice_payment_status(self, invoice_id: str) -> Dict[str, Any]:
@@ -1294,10 +1294,10 @@ class Acquisitions:
                 raise AlmaAPIError(error_msg)
 
             # Log that payment protection check passed
-            print(f"✓ Payment protection check passed for invoice {invoice_id}")
-            print(f"  Current state: {check['invoice_status']} / {check['approval_status']} / {check['payment_status']}")
+            self.logger.info(f"✓ Payment protection check passed for invoice {invoice_id}")
+            self.logger.debug(f"  Current state: {check['invoice_status']} / {check['approval_status']} / {check['payment_status']}")
         else:
-            print(f"⚠️ WARNING: Bypassing payment protection for invoice {invoice_id}")
+            self.logger.warning(f"⚠️ WARNING: Bypassing payment protection for invoice {invoice_id}")
 
         return self.process_invoice_service(invoice_id, "paid")
     
@@ -1384,11 +1384,11 @@ class Acquisitions:
                 "payment_status": payment_status_value
             }
             
-            print(f"✓ Generated summary for invoice {invoice_id}")
+            self.logger.info(f"✓ Generated summary for invoice {invoice_id}")
             return summary
             
         except Exception as e:
-            print(f"✗ Failed to generate summary for invoice {invoice_id}: {str(e)}")
+            self.logger.exception(f"✗ Failed to generate summary for invoice {invoice_id}: {str(e)}")
             raise
     
     def list_invoices(self, limit: int = 10, offset: int = 0, 
@@ -1406,7 +1406,7 @@ class Acquisitions:
         Returns:
             Dict containing the list of invoices
         """
-        print(f"Listing invoices (limit: {limit}, offset: {offset})")
+        self.logger.info(f"Listing invoices (limit: {limit}, offset: {offset})")
         
         params = {
             "limit": str(limit),
@@ -1435,11 +1435,11 @@ class Acquisitions:
             invoices_data = response.json()
             
             total_count = invoices_data.get('total_record_count', 0)
-            print(f"✓ Successfully retrieved {total_count} invoices")
+            self.logger.info(f"✓ Successfully retrieved {total_count} invoices")
             return invoices_data
             
         except Exception as e:
-            print(f"✗ Failed to list invoices: {str(e)}")
+            self.logger.exception(f"✗ Failed to list invoices: {str(e)}")
             raise
     
     def search_invoices(self, query: str, limit: int = 10, offset: int = 0) -> Dict[str, Any]:
@@ -1457,7 +1457,7 @@ class Acquisitions:
         if not query:
             raise ValueError("Search query is required")
         
-        print(f"Searching invoices with query: {query}")
+        self.logger.info(f"Searching invoices with query: {query}")
         
         params = {
             "q": query,
@@ -1477,11 +1477,11 @@ class Acquisitions:
             search_results = response.json()
             
             total_count = search_results.get('total_record_count', 0)
-            print(f"✓ Search found {total_count} invoices matching query")
+            self.logger.info(f"✓ Search found {total_count} invoices matching query")
             return search_results
             
         except Exception as e:
-            print(f"✗ Invoice search failed: {str(e)}")
+            self.logger.exception(f"✗ Invoice search failed: {str(e)}")
             raise
     
     def get_invoice_lines(self, invoice_id: str, limit: int = 100, offset: int = 0) -> List[Dict[str, Any]]:
@@ -1499,7 +1499,7 @@ class Acquisitions:
         if not invoice_id:
             raise ValueError("Invoice ID is required")
 
-        print(f"Retrieving lines for invoice: {invoice_id}")
+        self.logger.info(f"Retrieving lines for invoice: {invoice_id}")
 
         try:
             # Use dedicated lines endpoint
@@ -1524,11 +1524,11 @@ class Acquisitions:
                 invoice_lines = [invoice_lines]
 
             total_count = lines_data.get('total_record_count', len(invoice_lines))
-            print(f"✓ Retrieved {len(invoice_lines)} line(s) for invoice {invoice_id} (total: {total_count})")
+            self.logger.info(f"✓ Retrieved {len(invoice_lines)} line(s) for invoice {invoice_id} (total: {total_count})")
             return invoice_lines
 
         except Exception as e:
-            print(f"✗ Failed to get invoice lines for {invoice_id}: {str(e)}")
+            self.logger.exception(f"✗ Failed to get invoice lines for {invoice_id}: {str(e)}")
             raise
 
     def get_pol(self, pol_id: str) -> Dict[str, Any]:
@@ -1583,51 +1583,51 @@ class Acquisitions:
         items = []
 
         # DEBUG: Check if location field exists
-        print(f"[DEBUG] Checking for 'location' field in POL data...")
+        self.logger.info(f"[DEBUG] Checking for 'location' field in POL data...")
         if 'location' not in pol_data:
-            print(f"[DEBUG] ✗ No 'location' field found in POL data")
-            print(f"[DEBUG] Available top-level fields: {list(pol_data.keys())}")
+            self.logger.info(f"[DEBUG] ✗ No 'location' field found in POL data")
+            self.logger.info(f"[DEBUG] Available top-level fields: {list(pol_data.keys())}")
             return items
 
-        print(f"[DEBUG] ✓ 'location' field found")
+        self.logger.info(f"[DEBUG] ✓ 'location' field found")
 
         # Navigate to location list
         locations = pol_data.get('location', [])
-        print(f"[DEBUG] Location type: {type(locations)}")
+        self.logger.info(f"[DEBUG] Location type: {type(locations)}")
 
         # Ensure locations is a list
         if isinstance(locations, dict):
-            print(f"[DEBUG] Location is a dict, converting to list")
+            self.logger.info(f"[DEBUG] Location is a dict, converting to list")
             locations = [locations]
 
-        print(f"[DEBUG] Number of locations: {len(locations)}")
+        self.logger.info(f"[DEBUG] Number of locations: {len(locations)}")
 
         # Extract items from each location's copy list
         for loc_idx, location in enumerate(locations):
-            print(f"[DEBUG] Processing location {loc_idx + 1}/{len(locations)}")
-            print(f"[DEBUG] Location keys: {list(location.keys())}")
+            self.logger.debug(f"[DEBUG] Processing location {loc_idx + 1}/{len(locations)}")
+            self.logger.info(f"[DEBUG] Location keys: {list(location.keys())}")
 
             if 'copy' not in location:
-                print(f"[DEBUG] ✗ No 'copy' field in location {loc_idx + 1}")
+                self.logger.info(f"[DEBUG] ✗ No 'copy' field in location {loc_idx + 1}")
                 continue
 
             copies = location.get('copy', [])
-            print(f"[DEBUG] Copy type: {type(copies)}")
+            self.logger.info(f"[DEBUG] Copy type: {type(copies)}")
 
             # Ensure copies is a list
             if isinstance(copies, dict):
-                print(f"[DEBUG] Copy is a dict, converting to list")
+                self.logger.info(f"[DEBUG] Copy is a dict, converting to list")
                 copies = [copies]
 
-            print(f"[DEBUG] Number of copies in location {loc_idx + 1}: {len(copies)}")
+            self.logger.info(f"[DEBUG] Number of copies in location {loc_idx + 1}: {len(copies)}")
 
             # Each copy is an item
             for copy_idx, copy in enumerate(copies):
-                print(f"[DEBUG] Copy {copy_idx + 1} keys: {list(copy.keys())[:10]}")  # First 10 keys
+                self.logger.info(f"[DEBUG] Copy {copy_idx + 1} keys: {list(copy.keys())[:10]}")  # First 10 keys
                 items.append(copy)
 
-        print(f"[DEBUG] Total items extracted: {len(items)}")
-        print(f"✓ Extracted {len(items)} item(s) from POL data")
+        self.logger.info(f"[DEBUG] Total items extracted: {len(items)}")
+        self.logger.info(f"✓ Extracted {len(items)} item(s) from POL data")
         return items
 
     def get_pol_items(self, pol_id: str) -> List[Dict[str, Any]]:
@@ -1653,7 +1653,7 @@ class Acquisitions:
         if not pol_id:
             raise ValueError("POL ID is required")
 
-        print(f"Retrieving items for POL: {pol_id}")
+        self.logger.info(f"Retrieving items for POL: {pol_id}")
 
         endpoint = f"almaws/v1/acq/po-lines/{pol_id}/items"
         response = self.client.get(endpoint)
@@ -1666,10 +1666,10 @@ class Acquisitions:
                 items = items_data['item']
                 if isinstance(items, dict):
                     items = [items]
-                print(f"✓ Retrieved {len(items)} item(s) for POL {pol_id}")
+                self.logger.info(f"✓ Retrieved {len(items)} item(s) for POL {pol_id}")
                 return items
             else:
-                print(f"✓ No items found for POL {pol_id}")
+                self.logger.info(f"✓ No items found for POL {pol_id}")
                 return []
         else:
             raise AlmaAPIError(f"Failed to get items for POL {pol_id}")
@@ -1710,7 +1710,7 @@ class Acquisitions:
         if not item_id:
             raise ValueError("Item ID is required")
 
-        print(f"Receiving item {item_id} for POL {pol_id}")
+        self.logger.info(f"Receiving item {item_id} for POL {pol_id}")
 
         # Build query parameters
         params = {"op": "receive"}
@@ -1736,7 +1736,7 @@ class Acquisitions:
             )
 
             if response.success:
-                print(f"✓ Successfully received item {item_id} for POL {pol_id}")
+                self.logger.info(f"✓ Successfully received item {item_id} for POL {pol_id}")
                 # API returns XML for this endpoint, try JSON first, fall back to XML parsing
                 try:
                     return response.json()
@@ -1761,7 +1761,7 @@ class Acquisitions:
         except AlmaAPIError:
             raise
         except Exception as e:
-            print(f"✗ Failed to receive item {item_id} for POL {pol_id}: {str(e)}")
+            self.logger.exception(f"✗ Failed to receive item {item_id} for POL {pol_id}: {str(e)}")
             raise
 
     def receive_and_keep_in_department(self,
@@ -1824,12 +1824,12 @@ class Acquisitions:
                 "POL ID, item ID, MMS ID, holding ID, library, and department are required"
             )
 
-        print(f"\n=== Receiving item and keeping in department ===")
-        print(f"POL: {pol_id}, Item: {item_id}")
-        print(f"Department: {department} at library {library}")
+        self.logger.info(f"\n=== Receiving item and keeping in department ===")
+        self.logger.info(f"POL: {pol_id}, Item: {item_id}")
+        self.logger.info(f"Department: {department} at library {library}")
 
         # Step 1: Receive the item
-        print(f"\nStep 1: Receiving item {item_id}...")
+        self.logger.info(f"\nStep 1: Receiving item {item_id}...")
         receive_result = self.receive_item(
             pol_id=pol_id,
             item_id=item_id,
@@ -1839,7 +1839,7 @@ class Acquisitions:
         )
 
         # Step 2: Scan in the item to keep it in department
-        print(f"\nStep 2: Scanning item into department to prevent Transit...")
+        self.logger.info(f"\nStep 2: Scanning item into department to prevent Transit...")
         bibs = BibliographicRecords(self.client)
 
         scan_result = bibs.scan_in_item(
@@ -1854,8 +1854,8 @@ class Acquisitions:
         )
 
         if scan_result.success:
-            print(f"✓ Successfully received and kept item in department {department}")
-            print(f"  Work order: {work_order_type} - Status: {work_order_status}")
+            self.logger.info(f"✓ Successfully received and kept item in department {department}")
+            self.logger.debug(f"  Work order: {work_order_type} - Status: {work_order_status}")
             return scan_result.json()
         else:
             raise AlmaAPIError(
@@ -1972,14 +1972,14 @@ class Acquisitions:
             vendor_code = pol_data.get('vendor', {}).get('value')
 
             if vendor_code:
-                print(f"✓ Found vendor in POL {pol_id}: {vendor_code}")
+                self.logger.info(f"✓ Found vendor in POL {pol_id}: {vendor_code}")
             else:
-                print(f"⚠️ No vendor found in POL {pol_id}")
+                self.logger.warning(f"⚠️ No vendor found in POL {pol_id}")
 
             return vendor_code
 
         except AlmaAPIError as e:
-            print(f"✗ Failed to get vendor from POL {pol_id}: {e}")
+            self.logger.exception(f"✗ Failed to get vendor from POL {pol_id}: {e}")
             raise
 
     def get_fund_from_pol(self, pol_id: str) -> Optional[str]:
@@ -2041,16 +2041,16 @@ class Acquisitions:
                 fund_code = first_fund.get('fund_code', {}).get('value')
 
                 if fund_code:
-                    print(f"✓ Found fund in POL {pol_id}: {fund_code}")
+                    self.logger.info(f"✓ Found fund in POL {pol_id}: {fund_code}")
                     if len(fund_distribution) > 1:
-                        print(f"  Note: POL has {len(fund_distribution)} funds, using first (primary) fund")
+                        self.logger.debug(f"  Note: POL has {len(fund_distribution)} funds, using first (primary) fund")
                     return fund_code
 
-            print(f"⚠️ No fund distribution found in POL {pol_id}")
+            self.logger.warning(f"⚠️ No fund distribution found in POL {pol_id}")
             return None
 
         except AlmaAPIError as e:
-            print(f"✗ Failed to get fund from POL {pol_id}: {e}")
+            self.logger.exception(f"✗ Failed to get fund from POL {pol_id}: {e}")
             raise
 
     def get_price_from_pol(self, pol_id: str) -> Optional[float]:
@@ -2110,17 +2110,17 @@ class Acquisitions:
             if price is not None:
                 price_float = float(price)
                 currency = pol_data.get('price', {}).get('currency', {}).get('value', 'N/A')
-                print(f"✓ Found price in POL {pol_id}: {price_float} {currency}")
+                self.logger.info(f"✓ Found price in POL {pol_id}: {price_float} {currency}")
                 return price_float
 
-            print(f"⚠️ No price found in POL {pol_id}")
+            self.logger.warning(f"⚠️ No price found in POL {pol_id}")
             return None
 
         except (ValueError, TypeError) as e:
-            print(f"⚠️ Could not parse price from POL {pol_id}: {e}")
+            self.logger.exception(f"⚠️ Could not parse price from POL {pol_id}: {e}")
             return None
         except AlmaAPIError as e:
-            print(f"✗ Failed to get price from POL {pol_id}: {e}")
+            self.logger.exception(f"✗ Failed to get price from POL {pol_id}: {e}")
             raise
 
     def check_pol_invoiced(self, pol_id: str) -> Dict[str, Any]:
@@ -2180,7 +2180,7 @@ class Acquisitions:
                 'invoices': []
             }
 
-            print(f"Checking if POL {pol_id} is already invoiced...")
+            self.logger.info(f"Checking if POL {pol_id} is already invoiced...")
 
             # Direct POL search - Alma API supports searching by pol_number
             # Query format: pol_number~{pol_id}
@@ -2202,7 +2202,7 @@ class Acquisitions:
                     invoices = data.get('invoice', [])
 
                     if invoices:
-                        print(f"  Found {len(invoices)} invoice(s) containing POL {pol_id}")
+                        self.logger.debug(f"  Found {len(invoices)} invoice(s) containing POL {pol_id}")
 
                         # Get detailed line information for each invoice
                         for invoice in invoices:
@@ -2247,26 +2247,26 @@ class Acquisitions:
                                         'amount': amount_display,
                                         'line_status': line.get('status', {}).get('value', 'N/A')
                                     })
-                                    print(f"  ⚠️  Found: Invoice {invoice_number} (status: {invoice_status}, payment: {payment_status}) has line for {pol_id}: {amount_display}")
+                                    self.logger.debug(f"  ⚠️  Found: Invoice {invoice_number} (status: {invoice_status}, payment: {payment_status}) has line for {pol_id}: {amount_display}")
 
                     if not result['is_invoiced']:
-                        print(f"  ✓ POL {pol_id} is not yet invoiced")
+                        self.logger.debug(f"  ✓ POL {pol_id} is not yet invoiced")
                     else:
-                        print(f"  ⚠️  POL {pol_id} has {result['invoice_count']} existing invoice line(s)")
+                        self.logger.debug(f"  ⚠️  POL {pol_id} has {result['invoice_count']} existing invoice line(s)")
 
                 else:
-                    print(f"  ⚠️ Could not search invoices: {response.status_code}")
+                    self.logger.debug(f"  ⚠️ Could not search invoices: {response.status_code}")
                     result['search_error'] = f"API returned status {response.status_code}"
 
             except Exception as e:
-                print(f"  ⚠️ Could not complete invoice search: {e}")
+                self.logger.exception(f"  ⚠️ Could not complete invoice search: {e}")
                 # Return inconclusive result
                 result['search_error'] = str(e)
 
             return result
 
         except AlmaAPIError as e:
-            print(f"✗ Failed to check if POL {pol_id} is invoiced: {e}")
+            self.logger.exception(f"✗ Failed to check if POL {pol_id} is invoiced: {e}")
             raise
 
     # =========================================================================
@@ -2290,14 +2290,14 @@ class Acquisitions:
             success = response.status_code == 200
             
             if success:
-                print(f"✓ Acquisitions API connection successful ({self.environment})")
+                self.logger.info(f"✓ Acquisitions API connection successful ({self.environment})")
             else:
-                print(f"✗ Acquisitions API connection failed: {response.status_code}")
+                self.logger.error(f"✗ Acquisitions API connection failed: {response.status_code}")
             
             return success
             
         except Exception as e:
-            print(f"✗ Acquisitions API connection error: {e}")
+            self.logger.exception(f"✗ Acquisitions API connection error: {e}")
             return False
 
 
@@ -2306,6 +2306,16 @@ if __name__ == "__main__":
     """
     Example usage of the Acquisitions domain with AlmaAPIClient.
     """
+    # Mirror INFO+ logger output to stderr so CLI users see the
+    # progress messages that the alma_logging file handlers also
+    # capture. Library code itself emits no raw stdout (issue #14).
+    import logging as _logging
+    import sys as _sys
+    _stderr_handler = _logging.StreamHandler(_sys.stderr)
+    _stderr_handler.setFormatter(_logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _logging.getLogger("almapi").addHandler(_stderr_handler)
+    _logging.getLogger("almapi").setLevel(_logging.INFO)
+
     try:
         # Initialize the base client
         client = AlmaAPIClient('SANDBOX')  # or 'PRODUCTION'

--- a/src/almaapitk/utils/tsv_generator.py
+++ b/src/almaapitk/utils/tsv_generator.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from typing import Dict, List, Any, Optional
 from pathlib import Path
 
+from almaapitk.alma_logging import get_logger
 from almaapitk.client.AlmaAPIClient import AlmaAPIClient
 from almaapitk.domains.admin import Admin
 
@@ -31,6 +32,9 @@ class TSVGenerator:
             config_path: Path to JSON configuration file
         """
         self.config_path = config_path
+        # Logger goes up first so ``_load_config`` can use ``self.logger``
+        # instead of ``print()`` (issue #14).
+        self.logger = get_logger("tsv_generator")
         self.config = self._load_config()
         self.alma_client = None
         self.admin_client = None
@@ -62,14 +66,14 @@ class TSVGenerator:
                 if not os.path.exists(tsv_path):
                     raise ValueError(f"Direct TSV file not found: {tsv_path}")
                 
-                print(f"✓ Using direct TSV input: {tsv_path}")
+                self.logger.info(f"✓ Using direct TSV input: {tsv_path}")
             else:
 
 
 
                 if 'alma_set_id' not in input_config:
                     raise ValueError("Missing 'alma_set_id' in input configuration")
-                print(f"✓ Using Alma set ID: {input_config['alma_set_id']}")
+                self.logger.info(f"✓ Using Alma set ID: {input_config['alma_set_id']}")
                 
             if 'environment' not in input_config:
                 raise ValueError("Missing 'environment' in input configuration")
@@ -78,7 +82,7 @@ class TSVGenerator:
             if not config['columns'] or not isinstance(config['columns'], list):
                 raise ValueError("'columns' must be a non-empty list")
             
-            print(f"✓ Configuration loaded successfully from {self.config_path}")
+            self.logger.info(f"✓ Configuration loaded successfully from {self.config_path}")
             return config
             
         except FileNotFoundError:
@@ -90,7 +94,7 @@ class TSVGenerator:
         """Initialize Alma API clients."""
         environment = environment_override or self.config['input']['environment']
         
-        print(f"Initializing Alma API client for {environment} environment...")
+        self.logger.info(f"Initializing Alma API client for {environment} environment...")
         
         try:
             self.alma_client = AlmaAPIClient(environment)
@@ -103,7 +107,7 @@ class TSVGenerator:
             if not self.admin_client.test_connection():
                 raise RuntimeError("Failed to connect to Alma Admin API")
             
-            print(f"✓ Alma API clients initialized successfully")
+            self.logger.info(f"✓ Alma API clients initialized successfully")
             
         except Exception as e:
             raise RuntimeError(f"Failed to initialize Alma clients: {e}")
@@ -112,11 +116,11 @@ class TSVGenerator:
         """Get MMS IDs from the configured Alma set."""
         set_id = set_id_override or self.config['input']['alma_set_id']
         
-        print(f"Retrieving MMS IDs from Alma set: {set_id}")
+        self.logger.info(f"Retrieving MMS IDs from Alma set: {set_id}")
         
         try:
             mms_ids = self.admin_client.get_set_members(set_id)
-            print(f"✓ Retrieved {len(mms_ids)} MMS IDs from set {set_id}")
+            self.logger.info(f"✓ Retrieved {len(mms_ids)} MMS IDs from set {set_id}")
             return mms_ids
             
         except Exception as e:
@@ -156,7 +160,7 @@ class TSVGenerator:
         output_path = Path(output_dir).resolve()
         output_path.mkdir(parents=True, exist_ok=True)
         
-        print(f"✓ Output directory ready: {output_path}")
+        self.logger.info(f"✓ Output directory ready: {output_path}")
         return str(output_path)
     
     def _generate_filename(self, set_id: str) -> str:
@@ -184,8 +188,8 @@ class TSVGenerator:
         
         include_headers = self.config['output_settings'].get('include_headers', False)
         
-        print(f"Writing TSV file: {full_path}")
-        print(f"Processing {len(mms_ids)} records...")
+        self.logger.info(f"Writing TSV file: {full_path}")
+        self.logger.debug(f"Processing {len(mms_ids)} records...")
         
         try:
             with open(full_path, 'w', newline='', encoding='utf-8') as tsvfile:
@@ -195,7 +199,7 @@ class TSVGenerator:
                 if include_headers:
                     headers = [col.get('name', f'Column_{i}') for i, col in enumerate(self.config['columns'])]
                     writer.writerow(headers)
-                    print(f"  ✓ Headers written: {headers}")
+                    self.logger.debug(f"  ✓ Headers written: {headers}")
                 
                 # Write data rows
                 for i, mms_id in enumerate(mms_ids, 1):
@@ -204,11 +208,11 @@ class TSVGenerator:
                     
                     # Progress indicator for large sets
                     if i % 100 == 0:
-                        print(f"  Processed {i}/{len(mms_ids)} records...")
+                        self.logger.debug(f"  Processed {i}/{len(mms_ids)} records...")
                 
-            print(f"✓ TSV file created successfully: {full_path}")
-            print(f"  Total records: {len(mms_ids)}")
-            print(f"  Columns: {len(self.config['columns'])}")
+            self.logger.info(f"✓ TSV file created successfully: {full_path}")
+            self.logger.debug(f"  Total records: {len(mms_ids)}")
+            self.logger.debug(f"  Columns: {len(self.config['columns'])}")
             
             return full_path
             
@@ -236,9 +240,9 @@ class TSVGenerator:
                     raise ValueError(f"Row {i} has {len(row)} columns, expected {expected_columns}")
             
             actual_data_rows = len(rows) - (1 if include_headers else 0)
-            print(f"✓ TSV file validation passed")
-            print(f"  Data rows: {actual_data_rows}")
-            print(f"  Columns per row: {expected_columns}")
+            self.logger.info(f"✓ TSV file validation passed")
+            self.logger.debug(f"  Data rows: {actual_data_rows}")
+            self.logger.debug(f"  Columns per row: {expected_columns}")
             
         except Exception as e:
             raise RuntimeError(f"TSV file validation failed: {e}")
@@ -254,8 +258,8 @@ class TSVGenerator:
         Returns:
             Path to the created TSV file
         """
-        print(f"\n=== TSV Generation Started ===")
-        print(f"Config file: {self.config_path}")
+        self.logger.info(f"\n=== TSV Generation Started ===")
+        self.logger.info(f"Config file: {self.config_path}")
         
         try:
             # Step 1: Initialize Alma clients
@@ -276,38 +280,38 @@ class TSVGenerator:
             # Step 5: Validate the created file
             self._validate_tsv_file(tsv_path)
             
-            print(f"\n=== TSV Generation Completed Successfully ===")
-            print(f"Output file: {tsv_path}")
+            self.logger.info(f"\n=== TSV Generation Completed Successfully ===")
+            self.logger.info(f"Output file: {tsv_path}")
             
             return tsv_path
             
         except Exception as e:
-            print(f"\n✗ TSV Generation Failed: {e}")
+            self.logger.exception(f"\n✗ TSV Generation Failed: {e}")
             raise
     
     def preview_config(self) -> None:
         """Print a preview of the current configuration."""
-        print(f"\n=== Configuration Preview ===")
-        print(f"Config file: {self.config_path}")
-        print(f"Alma Set ID: {self.config['input']['alma_set_id']}")
-        print(f"Environment: {self.config['input']['environment']}")
-        print(f"Number of columns: {len(self.config['columns'])}")
+        self.logger.info(f"\n=== Configuration Preview ===")
+        self.logger.info(f"Config file: {self.config_path}")
+        self.logger.info(f"Alma Set ID: {self.config['input']['alma_set_id']}")
+        self.logger.info(f"Environment: {self.config['input']['environment']}")
+        self.logger.info(f"Number of columns: {len(self.config['columns'])}")
         
-        print(f"\nColumns:")
+        self.logger.info(f"\nColumns:")
         for i, col in enumerate(self.config['columns'], 1):
             name = col.get('name', f'Column_{i}')
             source = col.get('source', 'default_value')
             default = col.get('default_value', '')
             if source == 'alma_set':
-                print(f"  {i}. {name}: [MMS IDs from Alma set]")
+                self.logger.debug(f"  {i}. {name}: [MMS IDs from Alma set]")
             else:
-                print(f"  {i}. {name}: '{default}'")
+                self.logger.debug(f"  {i}. {name}: '{default}'")
         
         output_settings = self.config['output_settings']
-        print(f"\nOutput Settings:")
-        print(f"  Directory: {output_settings.get('output_directory', './output')}")
-        print(f"  File prefix: {output_settings.get('file_prefix', 'alma_output')}")
-        print(f"  Include headers: {output_settings.get('include_headers', False)}")
+        self.logger.info(f"\nOutput Settings:")
+        self.logger.debug(f"  Directory: {output_settings.get('output_directory', './output')}")
+        self.logger.debug(f"  File prefix: {output_settings.get('file_prefix', 'alma_output')}")
+        self.logger.debug(f"  Include headers: {output_settings.get('include_headers', False)}")
 
 
 # Convenience functions for easy usage
@@ -383,7 +387,7 @@ def create_sample_config(output_path: str = "alma_tsv_config.json") -> str:
         with open(output_path, 'w', encoding='utf-8') as f:
             json.dump(sample_config, f, indent=2)
         
-        print(f"✓ Sample configuration created: {output_path}")
+        self.logger.info(f"✓ Sample configuration created: {output_path}")
         return output_path
         
     except Exception as e:
@@ -395,6 +399,16 @@ if __name__ == "__main__":
     """
     Example usage of the TSV Generator.
     """
+    # Mirror INFO+ logger output to stderr so CLI users see the
+    # progress messages that the alma_logging file handlers also
+    # capture. Library code itself emits no raw stdout (issue #14).
+    import logging as _logging
+    import sys as _sys
+    _stderr_handler = _logging.StreamHandler(_sys.stderr)
+    _stderr_handler.setFormatter(_logging.Formatter("%(levelname)s %(name)s: %(message)s"))
+    _logging.getLogger("almapi").addHandler(_stderr_handler)
+    _logging.getLogger("almapi").setLevel(_logging.INFO)
+
     try:
         print("=== TSV Generator Test ===")
         

--- a/tests/integration/client/test_alma_client.py
+++ b/tests/integration/client/test_alma_client.py
@@ -215,33 +215,6 @@ def test_environment_switching(clients):
             print(f"✗ Environment switching failed: {e}")
 
 
-def test_safe_request_method(clients):
-    """Test the safe_request utility method"""
-    print("\n=== Testing Safe Request Method ===")
-    
-    if 'SANDBOX' in clients:
-        client = clients['SANDBOX']
-        
-        # Test successful request
-        print("Testing successful request...")
-        result = client.safe_request('GET', 'almaws/v1/conf/libraries')
-        if result:
-            if isinstance(result, dict):
-                print(f"✓ Got {result.get('total_record_count', 0)} libraries")
-            else:
-                print("✓ Got response data")
-        else:
-            print("✗ Safe request returned None")
-        
-        # Test failed request
-        print("Testing failed request...")
-        result = client.safe_request('GET', 'almaws/v1/bibs/invalid_mms_id')
-        if result is None:
-            print("✓ Safe request correctly handled error")
-        else:
-            print("✗ Expected None for invalid request")
-
-
 def main():
     """Run all tests"""
     print("AlmaAPIClient Test Suite - FIXED VERSION")
@@ -271,10 +244,7 @@ def main():
     
     # Test environment switching
     test_environment_switching(clients)
-    
-    # Test safe request method
-    test_safe_request_method(clients)
-    
+
     # Test bib record (with your test MMS ID)
     test_bib_record(clients, "990022169340204146")
     

--- a/tests/meta/test_logging_policy.py
+++ b/tests/meta/test_logging_policy.py
@@ -1,0 +1,84 @@
+"""Structural guards for the toolkit's logging policy.
+
+CLAUDE.md mandates "Use almaapitk.alma_logging framework — never print
+statements". These tests fail loudly if a future change reintroduces
+``print()`` to library code or restores the deleted ``safe_request()``
+shim. Issue #14.
+
+Detection uses ``ast`` (not grep) so that:
+
+* docstring examples (``>>> print(...)``) are correctly skipped — they
+  live inside string literals, not as executable calls;
+* prints inside ``if __name__ == "__main__":`` demo blocks are skipped
+  per the issue's acceptance criteria.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from almaapitk import AlmaAPIClient
+
+
+SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "almaapitk"
+
+
+def _is_main_guard(node: ast.AST) -> bool:
+    """``True`` for an ``if __name__ == "__main__":`` node."""
+    if not isinstance(node, ast.If):
+        return False
+    test = node.test
+    if not isinstance(test, ast.Compare) or len(test.ops) != 1:
+        return False
+    if not isinstance(test.ops[0], ast.Eq):
+        return False
+    left, right = test.left, test.comparators[0]
+    name_node = left if isinstance(left, ast.Name) else right
+    str_node = right if name_node is left else left
+    if not (isinstance(name_node, ast.Name) and name_node.id == '__name__'):
+        return False
+    return isinstance(str_node, ast.Constant) and str_node.value == '__main__'
+
+
+def _print_call_lines(file_path: Path) -> list[int]:
+    """Return line numbers of ``print(...)`` calls in this file, excluding
+    anything inside ``if __name__ == "__main__":`` blocks."""
+    tree = ast.parse(file_path.read_text(), filename=str(file_path))
+    main_lines: set[int] = set()
+    for top_node in tree.body:
+        if _is_main_guard(top_node):
+            for child in ast.walk(top_node):
+                if hasattr(child, 'lineno'):
+                    main_lines.add(child.lineno)
+
+    offenders: list[int] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name) and func.id == 'print':
+            if node.lineno not in main_lines:
+                offenders.append(node.lineno)
+    return sorted(offenders)
+
+
+def test_no_print_in_library() -> None:
+    offenders: list[str] = []
+    for py_file in sorted(SRC_ROOT.rglob("*.py")):
+        for line_no in _print_call_lines(py_file):
+            rel = py_file.relative_to(SRC_ROOT.parent.parent)
+            offenders.append(f"{rel}:{line_no}")
+    assert not offenders, (
+        f"Found {len(offenders)} print() call(s) in library code "
+        f"(must be replaced with logger calls per CLAUDE.md):\n  "
+        + "\n  ".join(offenders)
+    )
+
+
+def test_safe_request_removed() -> None:
+    assert not hasattr(AlmaAPIClient, "safe_request"), (
+        "AlmaAPIClient.safe_request was deleted in issue #14 (it swallowed "
+        "exceptions and returned None, making error handling impossible). "
+        "Use the typed verb methods (get/post/put/delete) and catch "
+        "AlmaAPIError instead."
+    )

--- a/tests/unit/client/test_no_stdout_during_request.py
+++ b/tests/unit/client/test_no_stdout_during_request.py
@@ -1,0 +1,105 @@
+"""Runtime guard: zero raw stdout writes during normal client lifecycle.
+
+Issue #14: every ``print()`` in the library was replaced with a
+``self.logger.x(...)`` call. This test pins the behavioral half of that
+contract: constructing an ``AlmaAPIClient`` and exercising each HTTP
+verb must not emit any *raw* stdout writes (i.e., stray ``print()``,
+``sys.stdout.write()``, etc.).
+
+The alma_logging framework currently routes its console handler to
+stdout (``alma_logging/logger.py``); that destination choice is a
+separate design concern and out of scope for #14. To isolate the
+"no print() in library code" invariant we want to assert here, the
+test temporarily removes the alma_logging console handlers for the
+duration of the assertion window. Anything left in stdout afterwards
+is, by elimination, a raw write from library code.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import unittest
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+import requests
+
+from almaapitk import AlmaAPIClient
+
+
+def _make_mock_response(status_code: int = 200, json_body=None) -> MagicMock:
+    response = MagicMock(spec=requests.Response)
+    response.status_code = status_code
+    response.ok = status_code < 400
+    response.headers = {'content-type': 'application/json'}
+    response.text = ''
+    response.json.return_value = json_body if json_body is not None else {}
+    return response
+
+
+class TestNoStdoutDuringRequest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._env_patcher = patch.dict(
+            os.environ, {'ALMA_SB_API_KEY': 'test-sandbox-key'}, clear=False
+        )
+        self._env_patcher.start()
+        self.addCleanup(self._env_patcher.stop)
+
+    def _mute_almapi_console_handlers(self) -> list[tuple[logging.Logger, list]]:
+        """Strip console handlers from every ``almapi.*`` logger; return
+        a saved list so the caller can restore them."""
+        saved: list[tuple[logging.Logger, list]] = []
+        for name in list(logging.Logger.manager.loggerDict):
+            if not name.startswith('almapi'):
+                continue
+            lg = logging.getLogger(name)
+            saved.append((lg, lg.handlers[:]))
+            lg.handlers = [
+                h for h in lg.handlers
+                if not (isinstance(h, logging.StreamHandler)
+                        and getattr(h, 'stream', None) in (sys.stdout, sys.stderr))
+            ]
+        return saved
+
+    def _restore_handlers(self, saved: list[tuple[logging.Logger, list]]) -> None:
+        for lg, handlers in saved:
+            lg.handlers = handlers
+
+    def test_no_raw_stdout_during_init_and_all_verbs(self) -> None:
+        # Construct the client first so its loggers register, then mute their
+        # console handlers (otherwise we'd be muting handlers that haven't
+        # been added yet).
+        with patch.object(
+            requests.Session, 'request', return_value=_make_mock_response()
+        ):
+            AlmaAPIClient('SANDBOX')  # warm up logger registration
+
+        saved = self._mute_almapi_console_handlers()
+        captured = StringIO()
+        original_stdout = sys.stdout
+        sys.stdout = captured
+        try:
+            with patch.object(
+                requests.Session, 'request', return_value=_make_mock_response()
+            ):
+                client = AlmaAPIClient('SANDBOX')
+                client.get('almaws/v1/bibs/test-mms')
+                client.post('almaws/v1/bibs/test-mms', data={'k': 'v'})
+                client.put('almaws/v1/bibs/test-mms', data={'k': 'v'})
+                client.delete('almaws/v1/bibs/test-mms')
+        finally:
+            sys.stdout = original_stdout
+            self._restore_handlers(saved)
+
+        output = captured.getvalue()
+        self.assertEqual(
+            output,
+            '',
+            f"Expected zero raw stdout writes during client lifecycle "
+            f"(logger output was muted to isolate print() detection); got:\n{output}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Replaces 167 ``print()`` calls across three files (`client/AlmaAPIClient.py`, `domains/acquisition.py`, `utils/tsv_generator.py`) with `self.logger.x(...)` calls so the toolkit conforms to its own CLAUDE.md rule (\"Use almaapitk.alma_logging framework — never print statements\").
- Removes `AlmaAPIClient.safe_request()` outright (introduced ad-hoc in commit 178bf18, never used by any production code, swallowed every exception, and returned None — making error handling impossible for callers).
- Closes #14.

## Scope discovery

The issue's AC said the fix targets `client/`, but a CLAUDE.md-aligned reading required the whole toolkit. An ast-based scan (skipping docstring `>>>` examples and `if __name__ == \"__main__\":` blocks per the issue's exemption) revealed only 167 real prints in 3 files — much smaller than the naive grep estimate of 272.

| File | Real prints | Action |
|---|---|---|
| `domains/acquisition.py` | 124 | Replace with `self.logger.x(...)` |
| `utils/tsv_generator.py` | 36 | Replace + add `self.logger = get_logger(\"tsv_generator\")` (had no logger before) |
| `client/AlmaAPIClient.py` | 7 | Replace + delete `safe_request()` + reorder `__init__` so logger is set up before `_load_configuration` |
| Other 4 files | 0 | Already print-free outside `__main__` |

## Replacement rules

| Pattern in source | New call |
|---|---|
| `print(\"✓ ...\")` / status / progress | `logger.info(...)` |
| `print(\"✗ ...\")` / Failed / Error | `logger.error(...)` (or `logger.exception(...)` inside `except`) |
| `print(\"⚠️ ...\")` / Warning / Note | `logger.warning(...)` |
| `print(\"  ...\")` (indented diagnostic) / Processing N/M | `logger.debug(...)` |

## CLI affordance

The three files with `__main__` demo blocks each get a 7-line stderr-handler attachment so users running `python -m ...` still see real-time progress (the alma_logging framework's own console handler writes to stdout — a separate destination concern out of scope for #14):

```python
if __name__ == \"__main__\":
    import logging as _logging
    import sys as _sys
    _stderr_handler = _logging.StreamHandler(_sys.stderr)
    _stderr_handler.setFormatter(_logging.Formatter(\"%(levelname)s %(name)s: %(message)s\"))
    _logging.getLogger(\"almapi\").addHandler(_stderr_handler)
    _logging.getLogger(\"almapi\").setLevel(_logging.INFO)
    # ... existing demo flow ...
```

## `safe_request` removal — context

Investigation of git history showed `safe_request` was introduced ad-hoc on **2026-03-11** in commit 178bf18 (\"Full package restructure for proper pip/wheel installation\", co-authored by Claude Opus 4.5). The pre-restructure source contains zero references to `def safe_request` — it was added fresh during the restructure with no design discussion, no spec, and no GitHub issue requesting it. There were never any production callers; only a single integration test exercised it (deleted in this PR).

It predates the chunks pipeline by ~2 months, so it never went through R7 scope check or SANDBOX validation.

## New tests

- **`tests/meta/test_logging_policy.py`** — ast-based structural guard. Fails loudly if a future change re-introduces `print()` to library code or restores `safe_request`. Two test functions, both passing.
- **`tests/unit/client/test_no_stdout_during_request.py`** — runtime guard. Constructs the client + exercises all four HTTP verbs; asserts zero stdout writes. Logger handlers are temporarily muted during the assertion window so the test isolates raw print() detection from logger-output destination concerns.

## Verification

- 105 unit/contract/logging/meta tests pass (was 102 + 3 new).
- `scripts/smoke_import.py` passes.
- ast scan: zero real prints remain in `src/almaapitk/`.
- Integration tests not run (require live SANDBOX/PROD credentials; one of them — `test_safe_request_method` — is deleted by this PR since the method it tested no longer exists).

## Notes for the reviewer / next release notes

- **Breaking change:** `AlmaAPIClient.safe_request()` is gone. Callers (none in this codebase, but external consumers might exist) should switch to the typed verb methods (`get`, `post`, `put`, `delete`) and catch `AlmaAPIError`. Worth a line in the next `docs/releases/X.Y.Z.md`.
- **No version bump in this PR** — happy to add one (0.3.1 → 0.3.2 patch, or 0.3.1 → 0.4.0 minor) if you'd like consumers to see this as a SemVer signal.
- The `acquisition.py` migration left a few sites where the new `logger.info(...)` is adjacent to an existing structured `self.logger.info(\"…\", invoice_id=…, …)` call — duplicate-ish but they serve different audiences (one is the CLI-style message, one is the structured-data message). Left as-is to keep this PR purely additive; a separate dedup pass can remove the redundant lines later if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)