### PR TITLE
chunk: errors-mapping (#9, #10)

### DIFF
--- a/src/almaapitk/__init__.py
+++ b/src/almaapitk/__init__.py
@@ -65,6 +65,13 @@ __all__ = [
     "AlmaResponse",
     "AlmaAPIError",
     "AlmaValidationError",
+    # Typed AlmaAPIError subclasses (issue #9)
+    "AlmaAuthenticationError",
+    "AlmaRateLimitError",
+    "AlmaServerError",
+    "AlmaResourceNotFoundError",
+    "AlmaDuplicateInvoiceError",
+    "AlmaInvalidPolModeError",
     # Domain classes
     "Admin",
     "Users",
@@ -85,6 +92,13 @@ _lazy_imports = {
     "AlmaResponse": ("almaapitk._internal", "AlmaResponse"),
     "AlmaAPIError": ("almaapitk._internal", "AlmaAPIError"),
     "AlmaValidationError": ("almaapitk._internal", "AlmaValidationError"),
+    # Typed AlmaAPIError subclasses (issue #9)
+    "AlmaAuthenticationError": ("almaapitk._internal", "AlmaAuthenticationError"),
+    "AlmaRateLimitError": ("almaapitk._internal", "AlmaRateLimitError"),
+    "AlmaServerError": ("almaapitk._internal", "AlmaServerError"),
+    "AlmaResourceNotFoundError": ("almaapitk._internal", "AlmaResourceNotFoundError"),
+    "AlmaDuplicateInvoiceError": ("almaapitk._internal", "AlmaDuplicateInvoiceError"),
+    "AlmaInvalidPolModeError": ("almaapitk._internal", "AlmaInvalidPolModeError"),
     # Domains
     "Admin": ("almaapitk._internal", "Admin"),
     "Users": ("almaapitk._internal", "Users"),

--- a/src/almaapitk/_internal/__init__.py
+++ b/src/almaapitk/_internal/__init__.py
@@ -11,7 +11,16 @@ WARNING: This is an internal module. Do not import from here directly.
 # Core client and response classes
 from .client import AlmaAPIClient
 from .response import AlmaResponse
-from .exceptions import AlmaAPIError, AlmaValidationError
+from .exceptions import (
+    AlmaAPIError,
+    AlmaValidationError,
+    AlmaAuthenticationError,
+    AlmaRateLimitError,
+    AlmaServerError,
+    AlmaResourceNotFoundError,
+    AlmaDuplicateInvoiceError,
+    AlmaInvalidPolModeError,
+)
 
 # Domain classes
 from .domains import (
@@ -29,6 +38,13 @@ __all__ = [
     "AlmaResponse",
     "AlmaAPIError",
     "AlmaValidationError",
+    # Typed AlmaAPIError subclasses (issue #9)
+    "AlmaAuthenticationError",
+    "AlmaRateLimitError",
+    "AlmaServerError",
+    "AlmaResourceNotFoundError",
+    "AlmaDuplicateInvoiceError",
+    "AlmaInvalidPolModeError",
     # Domains
     "Admin",
     "Users",

--- a/src/almaapitk/_internal/exceptions.py
+++ b/src/almaapitk/_internal/exceptions.py
@@ -4,6 +4,24 @@ Internal re-export module for Alma exceptions.
 This module is part of the internal namespace and should not be imported directly.
 Use `from almaapitk import AlmaAPIError, AlmaValidationError` instead.
 """
-from almaapitk.client.AlmaAPIClient import AlmaAPIError, AlmaValidationError
+from almaapitk.client.AlmaAPIClient import (
+    AlmaAPIError,
+    AlmaValidationError,
+    AlmaAuthenticationError,
+    AlmaRateLimitError,
+    AlmaServerError,
+    AlmaResourceNotFoundError,
+    AlmaDuplicateInvoiceError,
+    AlmaInvalidPolModeError,
+)
 
-__all__ = ["AlmaAPIError", "AlmaValidationError"]
+__all__ = [
+    "AlmaAPIError",
+    "AlmaValidationError",
+    "AlmaAuthenticationError",
+    "AlmaRateLimitError",
+    "AlmaServerError",
+    "AlmaResourceNotFoundError",
+    "AlmaDuplicateInvoiceError",
+    "AlmaInvalidPolModeError",
+]

--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -109,7 +109,7 @@ class AlmaResponse:
 
 class AlmaAPIError(Exception):
     """General Alma API error."""
-    
+
     def __init__(self, message: str, status_code: int = None, response=None):
         super().__init__(message)
         self.status_code = status_code
@@ -118,6 +118,60 @@ class AlmaAPIError(Exception):
 class AlmaValidationError(ValueError):
     """Validation error for Alma API requests."""
     pass
+
+
+# -----------------------------------------------------------------------------
+# Typed AlmaAPIError subclasses (issue #9)
+#
+# These specialise ``AlmaAPIError`` so domain code can branch on exception
+# *type* instead of inspecting error message strings or status codes inline.
+# Every subclass keeps the same ``(message, status_code, response)``
+# constructor signature as ``AlmaAPIError`` so existing
+# ``except AlmaAPIError:`` blocks continue to catch them transparently.
+# -----------------------------------------------------------------------------
+
+class AlmaAuthenticationError(AlmaAPIError):
+    """API authentication failed (HTTP 401)."""
+    pass
+
+
+class AlmaRateLimitError(AlmaAPIError):
+    """Alma API rate limit exceeded (HTTP 429)."""
+    pass
+
+
+class AlmaServerError(AlmaAPIError):
+    """Alma server-side error (HTTP 5xx)."""
+    pass
+
+
+class AlmaResourceNotFoundError(AlmaAPIError):
+    """Requested Alma resource was not found (HTTP 404)."""
+    pass
+
+
+class AlmaDuplicateInvoiceError(AlmaAPIError):
+    """Invoice already exists for the given vendor (Alma error code 402459)."""
+    pass
+
+
+class AlmaInvalidPolModeError(AlmaAPIError):
+    """POL is not in the right mode for the requested operation (Alma error code 40166411)."""
+    pass
+
+
+# Mapping of Alma-specific error codes to typed exception subclasses.
+# When the Alma response payload carries an ``errorList.error[].errorCode``
+# entry that lives in this registry, ``_classify_error`` routes the raised
+# exception to the mapped class. HTTP-status fallbacks (401, 404, 429, 5xx)
+# are handled separately in ``_classify_error`` itself.
+#
+# Pattern source: GitHub issue #9 (errors: map Alma error codes to
+# specific exception subclasses).
+ERROR_CODE_REGISTRY: Dict[str, type] = {
+    "402459":   AlmaDuplicateInvoiceError,
+    "40166411": AlmaInvalidPolModeError,
+}
 
 
 class AlmaAPIClient:
@@ -417,40 +471,103 @@ class AlmaAPIClient:
                 headers['Accept'] = 'application/xml'
         return headers
     
+    def _classify_error(
+        self, status_code: int, alma_code: Optional[str]
+    ) -> type:
+        """Pick the most specific ``AlmaAPIError`` subclass for an error.
+
+        Resolution order:
+
+        1. If ``alma_code`` is in ``ERROR_CODE_REGISTRY``, return the mapped
+           subclass — Alma error codes are more specific than HTTP status
+           and should always win when both are available.
+        2. Otherwise, dispatch by HTTP ``status_code``:
+
+           - ``401`` -> ``AlmaAuthenticationError``
+           - ``404`` -> ``AlmaResourceNotFoundError``
+           - ``429`` -> ``AlmaRateLimitError``
+           - ``5xx`` -> ``AlmaServerError``
+           - anything else -> bare ``AlmaAPIError``
+
+        Args:
+            status_code: HTTP status code of the failing response.
+            alma_code: Alma-specific error code extracted from the
+                response body's ``errorList.error[0].errorCode``, or
+                ``None`` if no such code was present.
+
+        Returns:
+            The most specific ``AlmaAPIError`` subclass to raise.
+
+        Pattern source: GitHub issue #9.
+        """
+        if alma_code is not None and alma_code in ERROR_CODE_REGISTRY:
+            return ERROR_CODE_REGISTRY[alma_code]
+
+        if status_code == 401:
+            return AlmaAuthenticationError
+        if status_code == 404:
+            return AlmaResourceNotFoundError
+        if status_code == 429:
+            return AlmaRateLimitError
+        if 500 <= status_code < 600:
+            return AlmaServerError
+        return AlmaAPIError
+
     def _handle_response(self, response):
         """
         Handle response and convert to AlmaResponse for compatibility.
-        
+
         Args:
             response: requests.Response object
-            
+
         Returns:
             AlmaResponse object
-            
+
         Raises:
-            AlmaAPIError: If the response indicates an error
+            AlmaAPIError: If the response indicates an error. The actual
+                exception class raised is selected by ``_classify_error``
+                based on Alma error code (when present) or HTTP status,
+                so callers can branch on type via ``except`` clauses
+                without parsing message strings (issue #9).
         """
         alma_response = AlmaResponse(response)
-        
+
         if not alma_response.success:
-            # Try to extract error message from response
+            # Try to extract error message and Alma-specific error code
+            # from response body. ``alma_code`` stays ``None`` if the body
+            # is non-JSON or doesn't contain the expected ``errorList``
+            # structure -- ``_classify_error`` then falls back to HTTP
+            # status dispatch.
             error_msg = f"HTTP {response.status_code}"
+            alma_code: Optional[str] = None
             try:
                 if 'application/json' in response.headers.get('content-type', ''):
                     error_data = response.json()
                     if 'errorList' in error_data and 'error' in error_data['errorList']:
                         errors = error_data['errorList']['error']
                         if isinstance(errors, list) and errors:
-                            error_msg = errors[0].get('errorMessage', error_msg)
+                            first_error = errors[0]
                         elif isinstance(errors, dict):
-                            error_msg = errors.get('errorMessage', error_msg)
+                            first_error = errors
+                        else:
+                            first_error = None
+                        if isinstance(first_error, dict):
+                            error_msg = first_error.get('errorMessage', error_msg)
+                            raw_code = first_error.get('errorCode')
+                            # Alma sometimes returns numeric codes; normalise
+                            # to ``str`` so registry lookups are uniform.
+                            if raw_code is not None:
+                                alma_code = str(raw_code)
                 else:
                     error_msg = response.text[:200] if response.text else error_msg
-            except:
+            except Exception:
+                # Defensive: never let response-parsing errors mask the
+                # original API error. Fall back to whatever text we have.
                 error_msg = response.text[:200] if response.text else error_msg
-            
-            raise AlmaAPIError(error_msg, response.status_code, response)
-        
+
+            exc_class = self._classify_error(response.status_code, alma_code)
+            raise exc_class(error_msg, response.status_code, response)
+
         return alma_response
 
 

--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -202,6 +202,11 @@ class AlmaInvalidPolModeError(AlmaAPIError):
 ERROR_CODE_REGISTRY: Dict[str, type] = {
     "402459":   AlmaDuplicateInvoiceError,
     "40166411": AlmaInvalidPolModeError,
+    # Alma returns HTTP 400 + errorCode 401861 ("User with identifier ... was not
+    # found") for a missing user_primary_id — NOT HTTP 404 — so status-fallback
+    # never fires. Map the code explicitly. Discovered via SANDBOX smoke test
+    # t-9-1 (chunk errors-mapping, 2026-05-04).
+    "401861":   AlmaResourceNotFoundError,
 }
 
 

--- a/src/almaapitk/client/AlmaAPIClient.py
+++ b/src/almaapitk/client/AlmaAPIClient.py
@@ -108,12 +108,43 @@ class AlmaResponse:
         return self.json()
 
 class AlmaAPIError(Exception):
-    """General Alma API error."""
+    """General Alma API error.
 
-    def __init__(self, message: str, status_code: int = None, response=None):
+    Carries the HTTP status, the underlying ``requests.Response``, and --
+    when the failing response body included an Alma ``errorList`` payload --
+    the per-error ``trackingId`` and ``errorCode`` Ex Libris support uses
+    to investigate cases (issue #10). Both fields default to safe
+    sentinels (``None`` / ``""``) so call sites that construct exceptions
+    without a parsed body (tests, the typed-subclass constructors, the
+    legacy ``(message, status_code, response)`` positional path used
+    pre-#10) keep working unchanged.
+
+    Attributes:
+        status_code: HTTP status code of the failing response, or ``None``
+            for synthetic errors raised outside the response handler.
+        response: The underlying ``requests.Response`` (or test double).
+        tracking_id: The ``trackingId`` field from
+            ``errorList.error[0]``. ``None`` when the body had no
+            ``errorList`` or no trackingId entry.
+        alma_code: The ``errorCode`` field from ``errorList.error[0]``,
+            normalised to ``str``. Empty string when no code was present
+            -- chosen over ``None`` so log formatters can interpolate it
+            without a falsy guard.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        status_code: int = None,
+        response=None,
+        tracking_id: Optional[str] = None,
+        alma_code: str = "",
+    ):
         super().__init__(message)
         self.status_code = status_code
         self.response = response
+        self.tracking_id = tracking_id
+        self.alma_code = alma_code
 
 class AlmaValidationError(ValueError):
     """Validation error for Alma API requests."""
@@ -513,6 +544,68 @@ class AlmaAPIClient:
             return AlmaServerError
         return AlmaAPIError
 
+    @staticmethod
+    def _extract_alma_error_fields(response):
+        """Pull ``(error_msg, alma_code, tracking_id)`` from an error response.
+
+        Centralises the JSON-body / ``errorList.error[0]`` traversal that
+        used to live inline in ``_handle_response``. Splitting it out lets
+        ``_handle_response`` stay readable and gives the parsing logic a
+        single, unit-testable home.
+
+        Returns:
+            Tuple of ``(error_msg, alma_code, tracking_id)``:
+
+            - ``error_msg``: human-readable message; falls back to
+              ``"HTTP <status>"`` when no message can be extracted.
+            - ``alma_code``: ``str`` form of ``errorList.error[0].errorCode``,
+              or ``None`` when no recognisable code is present. Always
+              normalised to ``str`` so ``ERROR_CODE_REGISTRY`` lookups
+              don't hinge on whether Alma returned a number or a string.
+            - ``tracking_id``: ``trackingId`` value from the same payload,
+              or ``None``. Ex Libris support uses this to look up the
+              individual server-side request when investigating a case
+              (issue #10).
+
+        The parsing is best-effort: any exception while traversing the
+        body collapses to ``(error_msg-from-text, None, None)`` so that a
+        malformed response can never mask the original API error.
+        """
+        error_msg = f"HTTP {response.status_code}"
+        alma_code: Optional[str] = None
+        tracking_id: Optional[str] = None
+        try:
+            if 'application/json' in response.headers.get('content-type', ''):
+                error_data = response.json()
+                if 'errorList' in error_data and 'error' in error_data['errorList']:
+                    errors = error_data['errorList']['error']
+                    if isinstance(errors, list) and errors:
+                        first_error = errors[0]
+                    elif isinstance(errors, dict):
+                        first_error = errors
+                    else:
+                        first_error = None
+                    if isinstance(first_error, dict):
+                        error_msg = first_error.get('errorMessage', error_msg)
+                        raw_code = first_error.get('errorCode')
+                        # Alma sometimes returns numeric codes; normalise
+                        # to ``str`` so registry lookups are uniform.
+                        if raw_code is not None:
+                            alma_code = str(raw_code)
+                        # ``trackingId`` is opaque -- keep it verbatim so
+                        # operators can quote it back to Ex Libris support.
+                        raw_tracking = first_error.get('trackingId')
+                        if raw_tracking is not None:
+                            tracking_id = raw_tracking
+            else:
+                error_msg = response.text[:200] if response.text else error_msg
+        except Exception:
+            # Defensive: never let response-parsing errors mask the
+            # original API error. Fall back to whatever text we have.
+            error_msg = response.text[:200] if response.text else error_msg
+
+        return error_msg, alma_code, tracking_id
+
     def _handle_response(self, response):
         """
         Handle response and convert to AlmaResponse for compatibility.
@@ -528,45 +621,31 @@ class AlmaAPIClient:
                 exception class raised is selected by ``_classify_error``
                 based on Alma error code (when present) or HTTP status,
                 so callers can branch on type via ``except`` clauses
-                without parsing message strings (issue #9).
+                without parsing message strings (issue #9). The raised
+                exception also carries ``tracking_id`` and ``alma_code``
+                attributes extracted from the same ``errorList.error[0]``
+                payload so log lines and operator hand-offs to Ex Libris
+                support can quote the per-request trackingId (issue #10).
         """
         alma_response = AlmaResponse(response)
 
         if not alma_response.success:
-            # Try to extract error message and Alma-specific error code
-            # from response body. ``alma_code`` stays ``None`` if the body
-            # is non-JSON or doesn't contain the expected ``errorList``
-            # structure -- ``_classify_error`` then falls back to HTTP
-            # status dispatch.
-            error_msg = f"HTTP {response.status_code}"
-            alma_code: Optional[str] = None
-            try:
-                if 'application/json' in response.headers.get('content-type', ''):
-                    error_data = response.json()
-                    if 'errorList' in error_data and 'error' in error_data['errorList']:
-                        errors = error_data['errorList']['error']
-                        if isinstance(errors, list) and errors:
-                            first_error = errors[0]
-                        elif isinstance(errors, dict):
-                            first_error = errors
-                        else:
-                            first_error = None
-                        if isinstance(first_error, dict):
-                            error_msg = first_error.get('errorMessage', error_msg)
-                            raw_code = first_error.get('errorCode')
-                            # Alma sometimes returns numeric codes; normalise
-                            # to ``str`` so registry lookups are uniform.
-                            if raw_code is not None:
-                                alma_code = str(raw_code)
-                else:
-                    error_msg = response.text[:200] if response.text else error_msg
-            except Exception:
-                # Defensive: never let response-parsing errors mask the
-                # original API error. Fall back to whatever text we have.
-                error_msg = response.text[:200] if response.text else error_msg
-
+            error_msg, alma_code, tracking_id = self._extract_alma_error_fields(
+                response
+            )
             exc_class = self._classify_error(response.status_code, alma_code)
-            raise exc_class(error_msg, response.status_code, response)
+            # ``alma_code`` is normalised to "" on the exception (the
+            # default in ``AlmaAPIError.__init__``) so log formatters can
+            # interpolate it without a None-guard. ``tracking_id`` stays
+            # ``None`` when missing because there's no sensible empty
+            # tracking value to hand to support.
+            raise exc_class(
+                error_msg,
+                response.status_code,
+                response,
+                tracking_id=tracking_id,
+                alma_code=alma_code if alma_code is not None else "",
+            )
 
         return alma_response
 

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -98,6 +98,52 @@ class TestPublicAPIContract(unittest.TestCase):
         # It should be a ValueError subclass
         self.assertTrue(issubclass(AlmaValidationError, ValueError))
 
+    def test_typed_error_subclasses_importable(self):
+        """Test that typed AlmaAPIError subclasses are importable from almaapitk (issue #9)."""
+        from almaapitk import (
+            AlmaAPIError,
+            AlmaAuthenticationError,
+            AlmaRateLimitError,
+            AlmaServerError,
+            AlmaResourceNotFoundError,
+            AlmaDuplicateInvoiceError,
+            AlmaInvalidPolModeError,
+        )
+        # Each must be a non-None class.
+        for cls in (
+            AlmaAuthenticationError,
+            AlmaRateLimitError,
+            AlmaServerError,
+            AlmaResourceNotFoundError,
+            AlmaDuplicateInvoiceError,
+            AlmaInvalidPolModeError,
+        ):
+            self.assertIsNotNone(cls)
+            # All typed subclasses must remain ``AlmaAPIError`` so existing
+            # ``except AlmaAPIError:`` blocks continue to catch them.
+            self.assertTrue(
+                issubclass(cls, AlmaAPIError),
+                f"{cls.__name__} must subclass AlmaAPIError for backwards-compat",
+            )
+
+    def test_typed_error_subclasses_in_all(self):
+        """Test that typed AlmaAPIError subclasses are in __all__ (issue #9)."""
+        import almaapitk
+        expected_typed_errors = [
+            'AlmaAuthenticationError',
+            'AlmaRateLimitError',
+            'AlmaServerError',
+            'AlmaResourceNotFoundError',
+            'AlmaDuplicateInvoiceError',
+            'AlmaInvalidPolModeError',
+        ]
+        for symbol in expected_typed_errors:
+            self.assertIn(
+                symbol,
+                almaapitk.__all__,
+                f"Expected typed-error symbol '{symbol}' to be in __all__",
+            )
+
     def test_admin_importable(self):
         """Test that Admin domain class is importable from almaapitk."""
         from almaapitk import Admin

--- a/tests/unit/client/test_error_classification.py
+++ b/tests/unit/client/test_error_classification.py
@@ -213,6 +213,30 @@ class TestErrorClassificationByAlmaCode(_AlmaAPIClientErrorTestBase):
         self.assertIsInstance(ctx.exception, AlmaAPIError)
         self.assertEqual(ctx.exception.status_code, 400)
 
+    def test_code_401861_raises_resource_not_found_error(self):
+        """Alma returns HTTP 400 + errorCode 401861 (not HTTP 404) for a missing
+        user_primary_id. The registry maps the code to ``AlmaResourceNotFoundError``
+        so callers can write ``except AlmaResourceNotFoundError`` instead of
+        inspecting the message string. Discovered via SANDBOX smoke (chunk
+        errors-mapping)."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "401861", "User with identifier xxxxx was not found."
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaResourceNotFoundError) as ctx:
+                client.get('almaws/v1/users/xxxxx')
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        # The response was HTTP 400; subclass dispatch came from the alma_code,
+        # not the status code — so status_code on the raised exception still
+        # reflects the original HTTP value.
+        self.assertEqual(ctx.exception.status_code, 400)
+        self.assertEqual(ctx.exception.alma_code, "401861")
+
     def test_400_with_unrecognized_code_raises_bare_alma_api_error(self):
         """A 400 with an unknown Alma code falls through to bare ``AlmaAPIError``."""
         client = AlmaAPIClient('SANDBOX')

--- a/tests/unit/client/test_error_classification.py
+++ b/tests/unit/client/test_error_classification.py
@@ -1,0 +1,357 @@
+"""
+Unit tests for AlmaAPIClient error classification (issue #9).
+
+These tests verify that ``AlmaAPIClient._handle_response`` raises the most
+specific ``AlmaAPIError`` subclass for each error condition, instead of
+the previous behaviour of always raising a bare ``AlmaAPIError`` and
+forcing domain code to inspect the message string.
+
+Pattern source: GitHub issue #9 acceptance criteria. Mocking style follows
+``tests/unit/client/test_alma_api_client.py`` (``_AlmaAPIClientTestBase``
++ ``_make_mock_response`` helper, ``patch.object(client._session, 'request', ...)``).
+"""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from almaapitk import AlmaAPIClient
+from almaapitk.client.AlmaAPIClient import (
+    AlmaAPIError,
+    AlmaAuthenticationError,
+    AlmaRateLimitError,
+    AlmaServerError,
+    AlmaResourceNotFoundError,
+    AlmaDuplicateInvoiceError,
+    AlmaInvalidPolModeError,
+    ERROR_CODE_REGISTRY,
+)
+
+
+def _make_mock_error_response(
+    status_code: int,
+    json_body=None,
+    content_type: str = 'application/json',
+    text: str = '',
+):
+    """Build a minimal ``requests.Response``-like mock for error tests.
+
+    Mirrors the ``_make_mock_response`` helper in
+    ``tests/unit/client/test_alma_api_client.py`` but defaults to error
+    semantics (``ok = False``) so the tests below stay terse.
+    """
+    mock_response = MagicMock(spec=requests.Response)
+    mock_response.status_code = status_code
+    mock_response.ok = status_code < 400
+    mock_response.headers = {'content-type': content_type}
+    mock_response.text = text
+    if json_body is None:
+        json_body = {}
+    mock_response.json.return_value = json_body
+    return mock_response
+
+
+def _alma_error_payload(error_code: str, message: str = "synthetic error") -> dict:
+    """Construct the standard Alma errorList payload for tests.
+
+    The shape mirrors what Alma actually returns, so registry-lookup
+    tests exercise the same parsing path as live responses:
+
+        {
+            "errorsExist": true,
+            "errorList": {
+                "error": [{"errorCode": "<code>", "errorMessage": "...", "trackingId": "..."}]
+            }
+        }
+    """
+    return {
+        "errorsExist": True,
+        "errorList": {
+            "error": [
+                {
+                    "errorCode": error_code,
+                    "errorMessage": message,
+                    "trackingId": "test-tracking-id",
+                }
+            ]
+        },
+    }
+
+
+class _AlmaAPIClientErrorTestBase(unittest.TestCase):
+    """Shared setUp that injects a fake API key into the environment.
+
+    Mirrors ``_AlmaAPIClientTestBase`` in ``test_alma_api_client.py``.
+    """
+
+    def setUp(self):
+        self._env_patcher = patch.dict(
+            os.environ, {'ALMA_SB_API_KEY': 'test-sandbox-key'}, clear=False
+        )
+        self._env_patcher.start()
+        self.addCleanup(self._env_patcher.stop)
+
+
+class TestErrorClassificationByStatus(_AlmaAPIClientErrorTestBase):
+    """Tests that HTTP-status fallbacks raise the right typed subclass."""
+
+    def test_401_raises_authentication_error(self):
+        """HTTP 401 must raise ``AlmaAuthenticationError``."""
+        client = AlmaAPIClient('SANDBOX')
+        # 401 with no errorList payload exercises the status-only fallback.
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(401, json_body={}),
+        ):
+            with self.assertRaises(AlmaAuthenticationError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 401)
+
+    def test_404_raises_resource_not_found_error(self):
+        """HTTP 404 must raise ``AlmaResourceNotFoundError``."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(404, json_body={}),
+        ):
+            with self.assertRaises(AlmaResourceNotFoundError) as ctx:
+                client.get('almaws/v1/bibs/does-not-exist')
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 404)
+
+    def test_429_raises_rate_limit_error(self):
+        """HTTP 429 must raise ``AlmaRateLimitError``."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(429, json_body={}),
+        ):
+            with self.assertRaises(AlmaRateLimitError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 429)
+
+    def test_503_raises_server_error(self):
+        """HTTP 503 (any 5xx) must raise ``AlmaServerError``."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(503, json_body={}),
+        ):
+            with self.assertRaises(AlmaServerError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 503)
+
+    def test_500_also_raises_server_error(self):
+        """HTTP 500 must also map to ``AlmaServerError`` (5xx band guard)."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(500, json_body={}),
+        ):
+            with self.assertRaises(AlmaServerError):
+                client.get('almaws/v1/conf/libraries')
+
+    def test_502_also_raises_server_error(self):
+        """HTTP 502 must also map to ``AlmaServerError`` (5xx band guard)."""
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(502, json_body={}),
+        ):
+            with self.assertRaises(AlmaServerError):
+                client.get('almaws/v1/conf/libraries')
+
+
+class TestErrorClassificationByAlmaCode(_AlmaAPIClientErrorTestBase):
+    """Tests that registry-driven Alma error codes pick the right subclass."""
+
+    def test_code_402459_raises_duplicate_invoice_error(self):
+        """Alma error code 402459 must raise ``AlmaDuplicateInvoiceError``."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "402459", "Invoice with the same number already exists for this vendor"
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaDuplicateInvoiceError) as ctx:
+                client.post('almaws/v1/acq/invoices', data={'foo': 'bar'})
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 400)
+        # The message should preserve Alma's text so log output is intact.
+        self.assertIn("Invoice", str(ctx.exception))
+
+    def test_code_40166411_raises_invalid_pol_mode_error(self):
+        """Alma error code 40166411 must raise ``AlmaInvalidPolModeError``."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "40166411", "PO Line is not in the right mode for this operation"
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaInvalidPolModeError) as ctx:
+                client.post(
+                    'almaws/v1/acq/po-lines/POL-1/items',
+                    data={'foo': 'bar'},
+                )
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_400_with_unrecognized_code_raises_bare_alma_api_error(self):
+        """A 400 with an unknown Alma code falls through to bare ``AlmaAPIError``."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "999999", "Some other validation problem"
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.post('almaws/v1/acq/invoices', data={'foo': 'bar'})
+        # Must be the *bare* base class -- not any of the typed subclasses.
+        self.assertIs(type(ctx.exception), AlmaAPIError)
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_alma_code_overrides_status_dispatch(self):
+        """When both an Alma code and a status would map, the code wins.
+
+        A 404 response that *also* carries a registered Alma code should
+        be classified by the code (more specific), not by the status.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload("402459", "Duplicate invoice")
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(404, json_body=payload),
+        ):
+            with self.assertRaises(AlmaDuplicateInvoiceError) as ctx:
+                client.post('almaws/v1/acq/invoices', data={'foo': 'bar'})
+        # status_code is preserved as-is on the exception even though the
+        # type was picked from the registry.
+        self.assertEqual(ctx.exception.status_code, 404)
+
+
+class TestBackwardsCompatibility(_AlmaAPIClientErrorTestBase):
+    """Tests that all typed subclasses remain catchable as ``AlmaAPIError``."""
+
+    def test_all_typed_errors_are_alma_api_errors(self):
+        """Every registry entry + status-mapped class must subclass AlmaAPIError."""
+        for code, cls in ERROR_CODE_REGISTRY.items():
+            with self.subTest(code=code):
+                self.assertTrue(
+                    issubclass(cls, AlmaAPIError),
+                    f"Registry entry {code} -> {cls.__name__} must subclass AlmaAPIError",
+                )
+
+        for cls in (
+            AlmaAuthenticationError,
+            AlmaRateLimitError,
+            AlmaServerError,
+            AlmaResourceNotFoundError,
+            AlmaDuplicateInvoiceError,
+            AlmaInvalidPolModeError,
+        ):
+            with self.subTest(cls=cls.__name__):
+                self.assertTrue(issubclass(cls, AlmaAPIError))
+
+    def test_existing_except_alma_api_error_still_catches_typed_subclasses(self):
+        """Existing ``except AlmaAPIError`` blocks must keep working.
+
+        This is the core backwards-compat guarantee: callers that catch
+        the broad base type should not need to update for issue #9.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(429, json_body={}),
+        ):
+            try:
+                client.get('almaws/v1/conf/libraries')
+                self.fail("Expected an exception")
+            except AlmaAPIError as e:
+                # Specifically the rate-limit subclass, but caught by the
+                # base type -- which is exactly the contract we promise.
+                self.assertIsInstance(e, AlmaRateLimitError)
+
+    def test_typed_exception_preserves_constructor_signature(self):
+        """All typed subclasses must accept ``(message, status_code, response)``.
+
+        ``_handle_response`` calls them with three positional args, so any
+        subclass that breaks the signature would crash on first use.
+        """
+        sentinel_response = object()
+        for cls in (
+            AlmaAuthenticationError,
+            AlmaRateLimitError,
+            AlmaServerError,
+            AlmaResourceNotFoundError,
+            AlmaDuplicateInvoiceError,
+            AlmaInvalidPolModeError,
+        ):
+            with self.subTest(cls=cls.__name__):
+                exc = cls("test message", 418, sentinel_response)
+                self.assertEqual(str(exc), "test message")
+                self.assertEqual(exc.status_code, 418)
+                self.assertIs(exc.response, sentinel_response)
+
+
+class TestClassifyErrorMethod(_AlmaAPIClientErrorTestBase):
+    """Direct unit tests for ``AlmaAPIClient._classify_error``."""
+
+    def test_classify_picks_registry_for_known_code(self):
+        client = AlmaAPIClient('SANDBOX')
+        self.assertIs(
+            client._classify_error(400, "402459"),
+            AlmaDuplicateInvoiceError,
+        )
+        self.assertIs(
+            client._classify_error(400, "40166411"),
+            AlmaInvalidPolModeError,
+        )
+
+    def test_classify_falls_back_to_status_when_code_unknown(self):
+        client = AlmaAPIClient('SANDBOX')
+        self.assertIs(client._classify_error(401, None), AlmaAuthenticationError)
+        self.assertIs(client._classify_error(404, None), AlmaResourceNotFoundError)
+        self.assertIs(client._classify_error(429, None), AlmaRateLimitError)
+        self.assertIs(client._classify_error(500, None), AlmaServerError)
+        self.assertIs(client._classify_error(599, None), AlmaServerError)
+
+    def test_classify_returns_base_for_unmapped_status(self):
+        client = AlmaAPIClient('SANDBOX')
+        # 400 with no Alma code falls through to the base class.
+        self.assertIs(client._classify_error(400, None), AlmaAPIError)
+        # Any other unmapped status is also base.
+        self.assertIs(client._classify_error(418, None), AlmaAPIError)
+
+    def test_classify_unknown_code_falls_back_to_status(self):
+        client = AlmaAPIClient('SANDBOX')
+        # Unknown Alma code + 401 status should still pick auth error.
+        self.assertIs(
+            client._classify_error(401, "999999"),
+            AlmaAuthenticationError,
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/client/test_tracking_id_propagation.py
+++ b/tests/unit/client/test_tracking_id_propagation.py
@@ -1,0 +1,354 @@
+"""
+Unit tests for AlmaAPIClient tracking_id / alma_code propagation (issue #10).
+
+Alma error responses include ``errorList.error[0].trackingId`` and
+``errorList.error[0].errorCode``, which Ex Libris support uses to look up
+the individual server-side request when investigating a case. Domain
+logging code (e.g. ``users.py``) already references
+``tracking_id=getattr(e, 'tracking_id', None)`` -- before issue #10 that
+attribute was always ``None`` because ``_handle_response`` never extracted
+the field. These tests pin the post-#10 behaviour so the attribute can
+never silently regress to dead-code again.
+
+Pattern source: GitHub issue #10 acceptance criteria. Mocking style mirrors
+``tests/unit/client/test_alma_api_client.py`` (env-var patcher +
+``_make_mock_response`` with ``spec=requests.Response``).
+"""
+
+import os
+import unittest
+from unittest.mock import patch, MagicMock
+
+import requests
+
+from almaapitk import AlmaAPIClient
+from almaapitk.client.AlmaAPIClient import (
+    AlmaAPIError,
+    AlmaAuthenticationError,
+    AlmaDuplicateInvoiceError,
+    AlmaResourceNotFoundError,
+)
+
+
+def _make_mock_error_response(
+    status_code: int,
+    json_body=None,
+    content_type: str = 'application/json',
+    text: str = '',
+):
+    """Build a minimal ``requests.Response``-like mock for error tests.
+
+    Mirrors the helper in ``test_alma_api_client.py`` /
+    ``test_error_classification.py`` so the three test files share an
+    interchangeable mocking idiom.
+    """
+    mock_response = MagicMock(spec=requests.Response)
+    mock_response.status_code = status_code
+    mock_response.ok = status_code < 400
+    mock_response.headers = {'content-type': content_type}
+    mock_response.text = text
+    if json_body is None:
+        json_body = {}
+    mock_response.json.return_value = json_body
+    return mock_response
+
+
+def _alma_error_payload(
+    error_code: str,
+    message: str = "synthetic error",
+    tracking_id: str = "TRK-12345",
+) -> dict:
+    """Construct the standard Alma errorList payload for tests.
+
+    The shape mirrors what Alma actually returns so that the parsing path
+    exercised here is the same one live responses traverse:
+
+        {
+            "errorsExist": True,
+            "errorList": {
+                "error": [
+                    {
+                        "errorCode": "<code>",
+                        "errorMessage": "<message>",
+                        "trackingId": "<tracking_id>",
+                    }
+                ]
+            },
+        }
+    """
+    return {
+        "errorsExist": True,
+        "errorList": {
+            "error": [
+                {
+                    "errorCode": error_code,
+                    "errorMessage": message,
+                    "trackingId": tracking_id,
+                }
+            ]
+        },
+    }
+
+
+class _AlmaAPIClientTrackingTestBase(unittest.TestCase):
+    """Shared setUp that injects a fake API key into the environment.
+
+    Mirrors ``_AlmaAPIClientTestBase`` / ``_AlmaAPIClientErrorTestBase`` so
+    the test bases stay interchangeable across the client test files.
+    """
+
+    def setUp(self):
+        self._env_patcher = patch.dict(
+            os.environ, {'ALMA_SB_API_KEY': 'test-sandbox-key'}, clear=False
+        )
+        self._env_patcher.start()
+        self.addCleanup(self._env_patcher.stop)
+
+
+class TestTrackingIdPropagation(_AlmaAPIClientTrackingTestBase):
+    """Tests that ``trackingId`` from the response body lands on the exception."""
+
+    def test_tracking_id_from_payload_lands_on_exception(self):
+        """Given a payload with ``trackingId``, ``exc.tracking_id`` must match."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "999999",
+            "synthetic error",
+            tracking_id="E01-2026-05-04-abc",
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        self.assertEqual(ctx.exception.tracking_id, "E01-2026-05-04-abc")
+
+    def test_missing_tracking_id_defaults_to_none(self):
+        """Without a ``trackingId`` field, ``exc.tracking_id`` is ``None``.
+
+        Crucially, the absence must NOT crash the parser -- the rest of
+        the error pipeline still has to deliver a typed exception.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        payload = {
+            "errorsExist": True,
+            "errorList": {
+                "error": [
+                    {
+                        "errorCode": "999999",
+                        "errorMessage": "no tracking field here",
+                        # trackingId deliberately omitted
+                    }
+                ]
+            },
+        }
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        self.assertIsNone(ctx.exception.tracking_id)
+
+    def test_no_error_list_defaults_tracking_id_to_none(self):
+        """A response with no ``errorList`` at all must still populate the attr.
+
+        Pre-#10 the ``tracking_id`` attribute didn't exist on the
+        exception class, so ``getattr(e, 'tracking_id', None)`` was the
+        only safe access pattern in domain code. Post-#10 the attribute
+        is always present (default ``None``), and this test guards that
+        invariant for the bare-status error path.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(401, json_body={}),
+        ):
+            with self.assertRaises(AlmaAuthenticationError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        # Attribute must exist on the exception even when no payload was
+        # parsed -- direct attribute access (not getattr-with-default).
+        self.assertIsNone(ctx.exception.tracking_id)
+        self.assertEqual(ctx.exception.alma_code, "")
+
+    def test_non_json_error_body_defaults_both_fields(self):
+        """A text/HTML error body must still produce safe defaults."""
+        client = AlmaAPIClient('SANDBOX')
+        text_response = _make_mock_error_response(
+            500,
+            json_body=None,
+            content_type='text/html',
+            text='<html>Internal Server Error</html>',
+        )
+        with patch.object(
+            client._session, 'request', return_value=text_response
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        self.assertIsNone(ctx.exception.tracking_id)
+        self.assertEqual(ctx.exception.alma_code, "")
+
+
+class TestAlmaCodePropagation(_AlmaAPIClientTrackingTestBase):
+    """Tests that ``errorCode`` from the response body lands on the exception."""
+
+    def test_alma_code_from_payload_lands_on_exception(self):
+        """Given a payload with ``errorCode``, ``exc.alma_code`` must match."""
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload("999999", "Some error")
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        self.assertEqual(ctx.exception.alma_code, "999999")
+
+    def test_numeric_alma_code_normalised_to_str(self):
+        """Numeric ``errorCode`` from Alma must be normalised to ``str``.
+
+        Alma's API has been observed to return the same code as either
+        a JSON number or a JSON string depending on the endpoint. The
+        client normalises to ``str`` so registry lookups and log lines
+        are uniform regardless of upstream representation.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        payload = {
+            "errorsExist": True,
+            "errorList": {
+                "error": [
+                    {
+                        "errorCode": 999999,  # NB: int, not str
+                        "errorMessage": "numeric code from Alma",
+                        "trackingId": "TRK-NUM",
+                    }
+                ]
+            },
+        }
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaAPIError) as ctx:
+                client.get('almaws/v1/conf/libraries')
+
+        # Stringified, not the int.
+        self.assertEqual(ctx.exception.alma_code, "999999")
+        self.assertIsInstance(ctx.exception.alma_code, str)
+
+
+class TestTypedSubclassPropagation(_AlmaAPIClientTrackingTestBase):
+    """Tests that typed subclasses (issue #9) ALSO carry tracking_id + alma_code."""
+
+    def test_duplicate_invoice_error_carries_tracking_and_code(self):
+        """``AlmaDuplicateInvoiceError`` must still expose both attributes.
+
+        This is the load-bearing acceptance criterion for #10: the
+        propagation has to flow through ``_classify_error``'s
+        registry-driven dispatch path, not just the bare ``AlmaAPIError``
+        fallback.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        payload = _alma_error_payload(
+            "402459",
+            "Invoice with the same number already exists for this vendor",
+            tracking_id="E01-DUP-INV-001",
+        )
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(400, json_body=payload),
+        ):
+            with self.assertRaises(AlmaDuplicateInvoiceError) as ctx:
+                client.post('almaws/v1/acq/invoices', data={'foo': 'bar'})
+
+        # Type was correctly picked from the registry...
+        self.assertIsInstance(ctx.exception, AlmaDuplicateInvoiceError)
+        self.assertIsInstance(ctx.exception, AlmaAPIError)
+        # ...and the per-request fields propagated through the typed
+        # subclass via the inherited ``AlmaAPIError.__init__`` -- no
+        # subclass-specific ``__init__`` overrides are needed.
+        self.assertEqual(ctx.exception.tracking_id, "E01-DUP-INV-001")
+        self.assertEqual(ctx.exception.alma_code, "402459")
+        self.assertEqual(ctx.exception.status_code, 400)
+
+    def test_status_dispatched_subclass_also_carries_fields(self):
+        """A status-dispatched subclass (e.g. 404) must carry the fields too.
+
+        Even though the registry didn't pick the type here -- the choice
+        came from the HTTP status fallback -- the parsed body still has a
+        ``trackingId``, and that value must land on the exception.
+        """
+        client = AlmaAPIClient('SANDBOX')
+        payload = {
+            "errorsExist": True,
+            "errorList": {
+                "error": [
+                    {
+                        # Unknown code so registry doesn't match -- forces
+                        # the status-fallback branch in ``_classify_error``.
+                        "errorCode": "401652",
+                        "errorMessage": "Resource not found",
+                        "trackingId": "TRK-404",
+                    }
+                ]
+            },
+        }
+        with patch.object(
+            client._session,
+            'request',
+            return_value=_make_mock_error_response(404, json_body=payload),
+        ):
+            with self.assertRaises(AlmaResourceNotFoundError) as ctx:
+                client.get('almaws/v1/bibs/missing')
+
+        self.assertIsInstance(ctx.exception, AlmaResourceNotFoundError)
+        self.assertEqual(ctx.exception.tracking_id, "TRK-404")
+        self.assertEqual(ctx.exception.alma_code, "401652")
+
+
+class TestBackwardsCompatibleConstructor(_AlmaAPIClientTrackingTestBase):
+    """Tests that the ``(message, status_code, response)`` signature still works.
+
+    Pre-#10 callers (and the entire issue #9 typed-subclass test suite)
+    rely on the three-positional-arg constructor. The new ``tracking_id``
+    and ``alma_code`` kwargs are additive and must default to safe values.
+    """
+
+    def test_legacy_three_arg_construction_still_works(self):
+        """Pre-#10 ``cls(msg, status, response)`` must still construct cleanly."""
+        sentinel_response = object()
+        exc = AlmaAPIError("legacy message", 418, sentinel_response)
+        self.assertEqual(str(exc), "legacy message")
+        self.assertEqual(exc.status_code, 418)
+        self.assertIs(exc.response, sentinel_response)
+        # New attributes default to safe sentinels even when omitted.
+        self.assertIsNone(exc.tracking_id)
+        self.assertEqual(exc.alma_code, "")
+
+    def test_typed_subclass_inherits_init(self):
+        """Subclasses must transparently accept the new kwargs via inheritance."""
+        exc = AlmaDuplicateInvoiceError(
+            "dup",
+            400,
+            None,
+            tracking_id="TRK-X",
+            alma_code="402459",
+        )
+        self.assertEqual(exc.tracking_id, "TRK-X")
+        self.assertEqual(exc.alma_code, "402459")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Chunk: `errors-mapping`

Closes #9
Closes #10

## Implementation summary

Issue #9 added 6 typed AlmaAPIError subclasses + ERROR_CODE_REGISTRY + _classify_error helper; #10 added tracking_id/alma_code propagation onto raised exceptions. 27 unit tests covering all classification paths, registry dispatch, and field propagation; backward-compat preserved via inherited AlmaAPIError constructor.

## SANDBOX test summary

2 SANDBOX smokes (t-9-1, t-10-1) executed against live Alma SANDBOX with synthetic invalid user_primary_id and invalid mms_id, both passed. Discovery: Alma uses HTTP 400 + errorCode 401861 for missing users (not 404); registry mechanism works as designed but coverage of 401861 is a follow-up.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/errors-mapping/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
