### PR TITLE
chore(agentic): chunk-pipeline correctness fixes (Refs #N + headless run-test)

### DIFF
--- a/.a5c/processes/chunk-template-impl.js
+++ b/.a5c/processes/chunk-template-impl.js
@@ -174,6 +174,7 @@ export const implementTask = defineTask('implement', (args, taskCtx) => ({
         'Implement ONLY what the issue says.',
         'Do not modify any file not in Files to touch.',
         'Add unit tests under tests/unit/domains/ with mocked HTTP (responses or requests-mock).',
+        'When you commit, reference the issue with "Refs #N" — NEVER use "Closes #N", "Fixes #N", or "Resolves #N". GitHub auto-closes from any merged commit body, which would bypass R4 (auto-close only on perfect-green / no unmappable ACs). Issue closure is a manual operator step.',
         'When done, list every file you changed.',
       ],
       outputFormat: 'JSON: { filesChanged: string[], summary: string, testsAdded: string[] }',

--- a/.a5c/processes/chunk-test.js
+++ b/.a5c/processes/chunk-test.js
@@ -295,7 +295,34 @@ export async function process(inputs, ctx) {
   }
 
   let testData = {};
-  if (fixtures.size > 0) {
+
+  // Issue #86: if chunks/<name>/test-data.json already contains every required
+  // fixture key, skip the fixture-interview breakpoint and use the pre-supplied
+  // values directly. This lets `chunks run-test <name>` run headless from any
+  // terminal once the operator has populated test-data.json by hand.
+  let preloadedTestData = null;
+  try {
+    const raw = readFileSync(
+      `${repoRoot}/chunks/${chunkName}/test-data.json`, 'utf8'
+    );
+    preloadedTestData = JSON.parse(raw);
+  } catch (e) {
+    // missing or unreadable — fall through to the interview path.
+  }
+  const allFixtureKeysPreloaded = preloadedTestData &&
+    typeof preloadedTestData === 'object' &&
+    Array.from(fixtures.keys()).every(
+      k => Object.prototype.hasOwnProperty.call(preloadedTestData, k)
+    );
+
+  if (fixtures.size === 0) {
+    // No fixtures required at all — nothing to interview about.
+  } else if (allFixtureKeysPreloaded) {
+    ctx.log(
+      `fixture interview skipped: test-data.json supplies all ${fixtures.size} required key(s)`
+    );
+    testData = preloadedTestData;
+  } else {
     // The repo's existing breakpoint convention is question/title/context with
     // an `approved` + `response` reply. We render the fixture list inside the
     // question text and ask the operator to paste back a JSON object.

--- a/scripts/agentic/chunks
+++ b/scripts/agentic/chunks
@@ -197,24 +197,71 @@ PYEOF
   run-test)
     name="${1:?run-test: chunk name required}"
     cd "$REPO_ROOT"
+
+    # Issue #86: when test-data.json is pre-populated with every fixture key
+    # required by test-recommendation.json, skip the --harness claude-code
+    # binding so the run can proceed headless from any terminal. The
+    # fixture-interview breakpoint in chunk-test.js is a no-op in that case.
+    headless=0
+    if "$PY" - "$CHUNKS_DIR" "$name" <<'PYEOF'
+import json, sys
+from pathlib import Path
+try:
+    chunk_dir = Path(sys.argv[1]) / sys.argv[2]
+    rec_path = chunk_dir / "test-recommendation.json"
+    data_path = chunk_dir / "test-data.json"
+    if not rec_path.exists() or not data_path.exists():
+        sys.exit(1)
+    rec = json.loads(rec_path.read_text())
+    data = json.loads(data_path.read_text())
+    required = {
+        f["key"]
+        for issue in rec.get("issues", [])
+        for t in issue.get("tests", [])
+        for f in t.get("needsHumanInput", [])
+    }
+    sys.exit(0 if required.issubset(set(data.keys())) else 1)
+except Exception:
+    sys.exit(1)
+PYEOF
+    then
+      headless=1
+      echo "chunks: test-data.json is complete; launching headless run-test (no Claude Code session bound)"
+    fi
+
     inputs="$(mktemp --suffix=.json)"
     cat > "$inputs" <<EOF
 {"chunkName": "$name", "repoRoot": "$REPO_ROOT"}
 EOF
-    babysitter run:create \
-      --process-id "chunk-test-$name" \
-      --entry "$REPO_ROOT/.a5c/processes/chunk-test.js#process" \
-      --inputs "$inputs" \
-      --prompt "Run SANDBOX tests for chunk $name" \
-      --harness claude-code \
-      --json
-    "$PY" - "$CHUNKS_DIR" "$name" <<'PYEOF'
+    if [[ "$headless" -eq 1 ]]; then
+      babysitter run:create \
+        --process-id "chunk-test-$name" \
+        --entry "$REPO_ROOT/.a5c/processes/chunk-test.js#process" \
+        --inputs "$inputs" \
+        --prompt "Run SANDBOX tests for chunk $name" \
+        --json
+    else
+      babysitter run:create \
+        --process-id "chunk-test-$name" \
+        --entry "$REPO_ROOT/.a5c/processes/chunk-test.js#process" \
+        --inputs "$inputs" \
+        --prompt "Run SANDBOX tests for chunk $name" \
+        --harness claude-code \
+        --json
+    fi
+    "$PY" - "$CHUNKS_DIR" "$name" "$headless" <<'PYEOF'
 import sys
 from pathlib import Path
 from scripts.agentic.chunk_status import transition
+headless = sys.argv[3] == "1"
+if headless:
+    last_event = "test process started (headless: pre-supplied test-data.json)"
+    next_action = "monitor babysitter run; tests run automatically"
+else:
+    last_event = "test process started; awaiting fixture interview"
+    next_action = "answer the data interview when prompted"
 transition(Path(sys.argv[1]) / sys.argv[2], "test-data-pending",
-           "test process started; awaiting fixture interview",
-           "answer the data interview when prompted")
+           last_event, next_action)
 PYEOF
     ;;
 

--- a/scripts/agentic/prompts/implement.v1.md
+++ b/scripts/agentic/prompts/implement.v1.md
@@ -18,6 +18,7 @@ You are a senior Python developer maintaining the `almaapitk` package. Mirror th
 5. **No bare `except:`.**
 6. **Use `responses` or `requests-mock`** for HTTP in unit tests. Do NOT write integration tests in this PR — those live in the testing process.
 7. **Cite a pattern source** in your code comment when adding a method: which existing method's shape you mirrored.
+8. **Commit messages reference issues with `Refs #N`** — never `Closes #N`, `Fixes #N`, or `Resolves #N`. GitHub auto-closes issues from any merged commit body, which bypasses R4 (auto-close only on perfect-green / no unmappable ACs). Issue closure is a manual operator step.
 
 ## When `feedback` is non-null
 


### PR DESCRIPTION
## Summary

Two small chunk-pipeline correctness fixes, bundled because both modify
the orchestration system and neither is large enough to warrant a chunk.

### Refs #85 — per-issue commits use `Refs #N`, not `Closes #N`

The chunk-impl agent was producing per-issue feature commits with
`Closes #N` in the body, which GitHub honors on merge regardless of
PR-body wording. That bypassed R4 (auto-close only on perfect-green /
no unmappable ACs). On PR #84 this caused #7 to be auto-closed despite
having unmappable ACs; it had to be manually reopened.

- `.a5c/processes/chunk-template-impl.js` — added an explicit
  instruction to the implement-task agent prompt: use `Refs #N`, never
  `Closes` / `Fixes` / `Resolves`. Issue closure is a manual operator
  step (R4).
- `scripts/agentic/prompts/implement.v1.md` — mirrored the rule into
  the canonical inviolable-rules section, since the JS prompt directs
  the agent to follow that file strictly.
- `scripts/agentic/pr_open.py` is unchanged — its triage-driven
  `Closes` emission is the only sanctioned auto-close path.

### Refs #86 — headless `chunks run-test` when fixtures are pre-supplied

`chunks run-test <name>` previously always passed `--harness claude-code`,
requiring a Claude Code session ID for breakpoint routing. From a plain
terminal the run was created but session-binding failed silently and the
fixture-interview breakpoint had nowhere to surface.

- `scripts/agentic/chunks` `run-test` now probes whether
  `chunks/<name>/test-data.json` contains every `needsHumanInput[].key`
  declared in `test-recommendation.json`. If yes, the run is launched
  headless (no `--harness claude-code`, no session binding) and a
  one-line message tells the operator. The status-transition message
  also reflects the path taken.
- `.a5c/processes/chunk-test.js` reads `test-data.json` before
  invoking the fixture-interview breakpoint; if every required key is
  already present, the breakpoint is skipped and the pre-supplied JSON
  is used directly. The downstream `writeTestDataTask` is naturally
  idempotent.
- The interactive path (operator inside Claude Code) is preserved as
  the fallback when `test-data.json` is missing or incomplete — same
  behavior as before for first-run chunks.

## Verification

- `bash -n scripts/agentic/chunks` and `node --check` on both modified
  process files pass.
- `scripts/agentic/chunks list` and `chunks help` still work post-edit.
- The headless probe was validated against the existing
  `chunks/errors-mapping/` artifacts (returns exit 0 — complete) and
  against a missing chunk (returns exit 1 — falls back to interactive).
- The `Refs #N` rule applies prospectively to future chunks; this PR
  itself uses `Refs #85` / `Refs #86` to demonstrate (so this PR's merge
  will NOT auto-close either issue — closing remains a manual step).

## Test plan

- [ ] On the next chunk-impl run, verify per-issue feature commits land
      with `Refs #N` in the body.
- [ ] Confirm those issues are NOT auto-closed when the chunk's PR is
      merged.
- [ ] On a chunk where `test-data.json` was pre-populated, verify
      `chunks run-test <name>` from a plain terminal launches headless,
      skips the fixture interview, and runs to PR-opened.
- [ ] On a fresh chunk without `test-data.json`, verify the interactive
      Claude Code interview path still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)