### PR TITLE
fix(chunks): pipeline residuals (#95, #96, #97)

### DIFF
--- a/.a5c/processes/chunk-test.js
+++ b/.a5c/processes/chunk-test.js
@@ -132,7 +132,7 @@ export const appendRunLogTask = defineTask('append-run-log', (args, taskCtx) => 
   shell: {
     command: `cd "${args.repoRoot}" && python -m scripts.agentic.run_log <<'PAYLOAD_EOF'
 ${JSON.stringify({
-  log_path: `${args.repoRoot}/AGENTIC_RUN_LOG.md`,
+  log_path: `${args.repoRoot}/docs/AGENTIC_RUN_LOG.md`,
   chunk_name: args.chunkName,
   issue_numbers: args.issueNumbers,
   attempts_used: args.attemptsUsed || {},

--- a/.claude/commands/chunk-run-impl.md
+++ b/.claude/commands/chunk-run-impl.md
@@ -57,8 +57,12 @@ error` with an error payload describing what went wrong.
 
 **`kind: "breakpoint"`** — read the `question` and `context` from the
 effect. Surface to the operator in chat: post one message containing
-the question and any relevant context. Wait for the operator's reply.
-When the operator replies, write
+the question and any relevant context. **Wait indefinitely for the
+operator's reply. Never auto-proceed past a breakpoint regardless of
+how many stop-hook firings or iteration nudges occur.** The hook will
+repeatedly fire while you wait; ignore the nudges. Resolve the
+breakpoint only when the operator explicitly replies in chat with
+their decision. When the operator replies, write
 `{"approved": true, "response": "<verbatim operator text>"}` to
 `tasks/<effectId>/output.json` and post via `task:post --status ok
 --value <file>`. Always use `--status ok` for both approve and reject;
@@ -74,10 +78,11 @@ When the loop exits, send one chat message summarizing:
 
 ## Notes for the assistant
 
-- This bypasses the babysit skill's "STOP between iterations" rule
-  because no babysitter stop-hook is configured in this repo. Agent
-  isolation is preserved by spawning fresh subagents for `kind:agent`
-  effects via the Agent tool.
+- The babysitter stop-hook drives `run:iterate` automatically between
+  effects; this slash command initiates the loop and surfaces
+  breakpoints to the operator. Agent isolation is preserved because
+  `kind:agent` effects are dispatched via the Agent tool, which spawns
+  a fresh subagent each time.
 - If the conversation is interrupted mid-loop, re-running this slash
   command resumes from the journal — `run:iterate` is idempotent
   against already-resolved effects.

--- a/.claude/commands/chunk-run-test.md
+++ b/.claude/commands/chunk-run-test.md
@@ -48,9 +48,12 @@ schema violation, post `--status error`.
 breakpoint: the **fixture interview**. Read `question` and `context`,
 which will list every fixture key the chunk's tests need (e.g.
 `test_user_id`, `test_bib_mms_id`). Surface in chat as one message
-listing the keys; ask the operator for values. When the operator
-replies, build the JSON `{<key>: <value>, ...}` from their reply,
-write to `tasks/<effectId>/output.json` as
+listing the keys; ask the operator for values. **Wait indefinitely
+for the operator's reply. Never auto-proceed regardless of how many
+stop-hook firings or iteration nudges occur.** The hook will keep
+firing; ignore the nudges. When the operator replies, build the JSON
+`{<key>: <value>, ...}` from their reply, write to
+`tasks/<effectId>/output.json` as
 `{"approved": true, "response": <json>}`, post via `task:post
 --status ok --value <file>`. Per R9, do not echo the operator's
 values into committed files or messages — they may contain real IDs.
@@ -70,6 +73,7 @@ When the loop exits, send one chat message summarizing:
 - Per R9, never echo operator-supplied fixture values into chat
   messages or commit messages. Only refer to them generically
   ("the supplied test user", "the test bib").
-- Bypasses the babysit skill's "STOP between iterations" rule for
-  the same reasons documented in `/chunk-run-impl`.
+- The babysitter stop-hook drives `run:iterate` automatically between
+  effects; this slash command initiates the loop and surfaces the
+  fixture-interview breakpoint to the operator.
 - Do not auto-open a PR. PR creation is a separate operator action.

--- a/scripts/agentic/issue_parser.py
+++ b/scripts/agentic/issue_parser.py
@@ -38,15 +38,31 @@ def _section(body: str, header: str) -> str | None:
     return m.group(1).strip() if m else None
 
 
+_PATH_AT_START_RE = re.compile(r"^`([^`]+)`")
+_ANNOTATION_RE = re.compile(r"^\s*\([^)]*\)")
+_SEP_RE = re.compile(r"^\s*(?:,|→|and)\s+")
+
+
 def _bullet_lines(section_body: str | None) -> list[str]:
     """Extract list bullets, stripping markdown backticks and trailing parentheticals.
 
     Handles all of:
-        - path                                  -> path
-        - `path`                                -> path
-        - `path` (comment about it)             -> path
-        - `path (comment inside backticks)`     -> path
-        - GET /api/v1/x                          -> GET /api/v1/x
+        - path                                  -> [path]
+        - `path`                                -> [path]
+        - `path` (comment about it)             -> [path]
+        - `path (comment inside backticks)`     -> [path]
+        - `path1`, `path2`                      -> [path1, path2]
+        - `path1` (NEW), `path2` (NEW)          -> [path1, path2]
+        - `path1` → `path2`                     -> [path1, path2]
+        - `path1` and `path2`                   -> [path1, path2]
+        - `path` — description with `code`      -> [path]
+        - GET /api/v1/x                         -> [GET /api/v1/x]
+
+    Multi-path support: when a bullet starts with a backtick-quoted token,
+    consecutive backtick-quoted tokens separated by ``, ``, ``→`` (rename
+    arrow), or ``and`` are all captured as paths. The scan stops at the first
+    non-separator gap (e.g. an em-dash description), so backticked tokens in
+    the description prose are not captured.
     """
     if not section_body:
         return []
@@ -55,12 +71,30 @@ def _bullet_lines(section_body: str | None) -> list[str]:
         if not (line.startswith("- ") or line.startswith("* ")):
             continue
         text = line[2:].strip()
-        # If wrapped in backticks, take only what's inside the first backtick span.
         if text.startswith("`"):
-            end = text.find("`", 1)
-            if end > 0:
-                text = text[1:end]
-        # Strip trailing " (annotation)" annotation, if any.
+            # Walk leading backtick-quoted tokens separated by recognized
+            # separators. Stop at the first gap that isn't a separator-then-
+            # backtick — that's where description prose begins.
+            while True:
+                m = _PATH_AT_START_RE.match(text)
+                if not m:
+                    break
+                path = m.group(1)
+                if path:
+                    out.append(path)
+                text = text[m.end():]
+                # Optional " (annotation)" describing the just-extracted path.
+                ann_m = _ANNOTATION_RE.match(text)
+                if ann_m:
+                    text = text[ann_m.end():]
+                # Optional separator, but only if followed by another path.
+                sep_m = _SEP_RE.match(text)
+                if sep_m and text[sep_m.end():sep_m.end() + 1] == "`":
+                    text = text[sep_m.end():]
+                    continue
+                break
+            continue
+        # Bullet without leading backtick — strip trailing " (annotation)".
         paren_idx = text.find(" (")
         if paren_idx > 0:
             text = text[:paren_idx]

--- a/tests/agentic/test_chunk_slash_commands.py
+++ b/tests/agentic/test_chunk_slash_commands.py
@@ -45,3 +45,45 @@ def test_chunk_run_test_body_has_required_markers():
     assert "ALMA_PROD_API_KEY" in body
     # The fixture interview is the headline breakpoint of run-test
     assert "fixture" in body.lower()
+
+
+# ---- R10-shaped regression for #97: breakpoint-wait discipline + STOP-rule note ----
+
+def test_chunk_run_impl_has_explicit_indefinite_wait():
+    """Issue #97 — during validation the assistant waited 6 hook firings then
+    auto-proceeded with a recommended option. The breakpoint discipline must
+    be explicit about waiting indefinitely and ignoring stop-hook nudges."""
+    body = (COMMANDS / "chunk-run-impl.md").read_text()
+    assert "Wait indefinitely" in body, (
+        "breakpoint handler must explicitly say 'Wait indefinitely' so the "
+        "assistant never auto-proceeds past a human gate"
+    )
+    assert "Never auto-proceed" in body, (
+        "breakpoint handler must explicitly forbid auto-proceeding"
+    )
+
+
+def test_chunk_run_test_has_explicit_indefinite_wait():
+    """Same #97 discipline for the chunk-test slash command."""
+    body = (COMMANDS / "chunk-run-test.md").read_text()
+    assert "Wait indefinitely" in body
+    assert "Never auto-proceed" in body
+
+
+def test_no_obsolete_no_stop_hook_claim_in_either_body():
+    """Issue #97 — the validation run proved a babysitter stop-hook IS
+    firing (`Babysitter iteration N/256` messages). The earlier disclaimer
+    'no babysitter stop-hook is configured in this repo' was wrong and
+    must be removed from both slash-command bodies."""
+    impl_body = (COMMANDS / "chunk-run-impl.md").read_text()
+    test_body = (COMMANDS / "chunk-run-test.md").read_text()
+    obsolete = "no babysitter stop-hook is configured"
+    assert obsolete not in impl_body, (
+        "chunk-run-impl.md still claims 'no babysitter stop-hook is "
+        "configured' — proven false by the 2026-05-05 validation run; "
+        "rewrite to acknowledge the hook drives iteration."
+    )
+    assert obsolete not in test_body, (
+        "chunk-run-test.md still claims 'no babysitter stop-hook is "
+        "configured' — same as above."
+    )

--- a/tests/agentic/test_chunk_test_process.py
+++ b/tests/agentic/test_chunk_test_process.py
@@ -33,3 +33,27 @@ def test_chunk_test_js_exports_process():
         capture_output=True, text=True, cwd=str(REPO_ROOT),
     )
     assert r.returncode == 0, f"import failed:\n{r.stderr}"
+
+
+def test_append_run_log_writes_to_docs_path():
+    """R10 regression test for #95.
+
+    The chunk-test process's appendRunLogTask must emit a `log_path`
+    pointing at `docs/AGENTIC_RUN_LOG.md` (the post-#93 canonical path),
+    not at the repo root. Pre-#93 the run log lived at the repo root;
+    #93 moved it via `git mv` to `docs/AGENTIC_RUN_LOG.md`. The
+    chunk-test JS still hardcoded the old path until this fix landed —
+    every chunk-test run silently re-created an untracked stray
+    `AGENTIC_RUN_LOG.md` at the repo root.
+    """
+    src = PROCESS.read_text()
+    # appendRunLogTask must build its log_path from repoRoot + the docs/ path
+    assert "${args.repoRoot}/docs/AGENTIC_RUN_LOG.md" in src, (
+        "appendRunLogTask must reference ${args.repoRoot}/docs/AGENTIC_RUN_LOG.md "
+        "(post-#93 canonical); #95 regression"
+    )
+    # And must NOT reference the obsolete root-path form
+    assert "${args.repoRoot}/AGENTIC_RUN_LOG.md" not in src, (
+        "appendRunLogTask still references obsolete repo-root path; "
+        "#95 regression: must use docs/AGENTIC_RUN_LOG.md"
+    )

--- a/tests/agentic/test_issue_parser.py
+++ b/tests/agentic/test_issue_parser.py
@@ -172,3 +172,79 @@ def test_parse_real_issue_3_arch_format():
     assert parsed["priority"] == "high"
     # **Complexity:** S (≤½ day) → effort="S"
     assert parsed["effort"] == "S"
+
+
+# ---- R10 regression for #96: multi-file bullets in "Files to touch" ----
+
+def test_bullet_lines_comma_separated_paths():
+    """R10 regression for #96.
+
+    Issue #93 had a bullet with two file paths separated by a comma:
+        - `tests/agentic/test_render_backlog.py` (new), `tests/agentic/test_reconcile.py` (new).
+    The parser only captured the first path, dropping the second. This caused
+    R7 scope-check to fail when the implementer agent legitimately touched
+    both files.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = (
+        "- `tests/agentic/test_render_backlog.py` (new), "
+        "`tests/agentic/test_reconcile.py` (new)."
+    )
+    paths = _bullet_lines(section)
+    assert "tests/agentic/test_render_backlog.py" in paths, paths
+    assert "tests/agentic/test_reconcile.py" in paths, paths
+
+
+def test_bullet_lines_rename_arrow():
+    """R10 regression for #96.
+
+    Issue #93 had a bullet documenting a `git mv` with both source and
+    destination paths separated by `→`:
+        - `AGENTIC_RUN_LOG.md` → `docs/AGENTIC_RUN_LOG.md` (git mv).
+    The parser only captured the source path, dropping the destination —
+    the actual moved-file location.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = "- `AGENTIC_RUN_LOG.md` → `docs/AGENTIC_RUN_LOG.md` (git mv)."
+    paths = _bullet_lines(section)
+    assert "AGENTIC_RUN_LOG.md" in paths, paths
+    assert "docs/AGENTIC_RUN_LOG.md" in paths, paths
+
+
+def test_bullet_lines_single_path_with_inline_backtick_prose_unchanged():
+    """Guard against the multi-path fix accidentally widening capture into
+    description prose.
+
+    Bullet:
+        - `scripts/agentic/chunks` — new subcommands `render-backlog`, `reconcile`; ...
+    Only `scripts/agentic/chunks` is the file to touch; the other backticked
+    tokens are description text (subcommand names, function names).
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = (
+        "- `scripts/agentic/chunks` — new subcommands `render-backlog`, "
+        "`reconcile`; wire `complete` to call `run_log.append_chunk_row`."
+    )
+    paths = _bullet_lines(section)
+    assert paths == ["scripts/agentic/chunks"], paths
+
+
+def test_bullet_lines_first_path_then_comment_in_backticks_unchanged():
+    """Another guard for the description-prose case.
+
+    Bullet:
+        - `docs/chunks-backlog.yaml` (new) — translated content of current `docs/CHUNK_BACKLOG.md`.
+    Only `docs/chunks-backlog.yaml` is the file to touch; `docs/CHUNK_BACKLOG.md`
+    is referenced in the description after the em-dash.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = (
+        "- `docs/chunks-backlog.yaml` (new) — translated content "
+        "of current `docs/CHUNK_BACKLOG.md`."
+    )
+    paths = _bullet_lines(section)
+    assert paths == ["docs/chunks-backlog.yaml"], paths


### PR DESCRIPTION
## Summary

Three small bug fixes surfaced by the 2026-05-05 end-to-end validation
of the chunks-orchestration redesign. All three are independent
chunk-pipeline-correctness fixes following the R10 protocol (failing
test first, then fix, both in the same commit).

Refs #95
Refs #96
Refs #97

## Commits

1. `ca137fa` — **#95** chunk-test writes run-log to `docs/AGENTIC_RUN_LOG.md` (post-#93 canonical path), not the repo root. One-line path fix in `.a5c/processes/chunk-test.js` plus a regression test in `tests/agentic/test_chunk_test_process.py` that asserts the path string is correct.

2. `2ad7214` — **#96** issue parser now captures multi-file bullets (comma-separated paths, ` → ` rename arrows, ` and `). Replaces the first-backtick-only behavior with a small state machine that walks consecutive backtick-quoted tokens separated by recognized separators, stopping at the first non-separator gap (where description prose begins). Four regression tests in `tests/agentic/test_issue_parser.py` (two for the bug, two as guards against accidentally widening capture into description text).

3. `05ab07c` — **#97** slash-command bodies updated:
   - Removed the "no babysitter stop-hook is configured" disclaimer (proven wrong by the validation run — the hook IS firing).
   - Strengthened breakpoint-wait language: "Wait indefinitely / Never auto-proceed regardless of how many stop-hook firings occur." Three regression tests in `tests/agentic/test_chunk_slash_commands.py`.

## Test plan

- [x] `poetry run pytest tests/agentic/` — 98 pass (3 new from #97, 4 new from #96, 1 new from #95).
- [x] `poetry run python scripts/smoke_import.py` — pass.
- [ ] Operator reviews diff, merges manually.
- [ ] After merge, manually close #95, #96, #97 (R4: each has a regression test, so safe to close).

## Notes

- Bundled three small fixes in one PR rather than running the chunks pipeline because all three are S-complexity and #97 modifies the very thing the chunks pipeline uses to drive (chicken-and-egg risk avoided).
- Per [audit verdict on 2026-05-05]: "CONTINUE WITH SMALL FIXES FIRST" — these are exactly those small fixes. After merge, the next planned chunk is `client-ergonomics` (#13, #16) per Phase 2 of the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)