### PR TITLE
fix(agentic): strip inline annotations inside backticked file paths (R10)

### DIFF
--- a/scripts/agentic/issue_parser.py
+++ b/scripts/agentic/issue_parser.py
@@ -41,6 +41,10 @@ def _section(body: str, header: str) -> str | None:
 _PATH_AT_START_RE = re.compile(r"^`([^`]+)`")
 _ANNOTATION_RE = re.compile(r"^\s*\([^)]*\)")
 _SEP_RE = re.compile(r"^\s*(?:,|→|and)\s+")
+# Trailing " (annotation)" embedded INSIDE the backticks. Requires a leading
+# whitespace before the open paren so a fully-parenthesized token like
+# "(no endpoints — foundation only)" is preserved as-is.
+_INNER_ANNOTATION_RE = re.compile(r"\s+\([^)]*\)\s*$")
 
 
 def _bullet_lines(section_body: str | None) -> list[str]:
@@ -79,7 +83,7 @@ def _bullet_lines(section_body: str | None) -> list[str]:
                 m = _PATH_AT_START_RE.match(text)
                 if not m:
                     break
-                path = m.group(1)
+                path = _INNER_ANNOTATION_RE.sub("", m.group(1))
                 if path:
                     out.append(path)
                 text = text[m.end():]

--- a/tests/agentic/test_issue_parser.py
+++ b/tests/agentic/test_issue_parser.py
@@ -248,3 +248,71 @@ def test_bullet_lines_first_path_then_comment_in_backticks_unchanged():
     )
     paths = _bullet_lines(section)
     assert paths == ["docs/chunks-backlog.yaml"], paths
+
+
+def test_bullet_lines_strips_annotation_inside_backticks():
+    """R10 regression for chunk config-bootstrap (issue #22).
+
+    Foundation tickets put the annotation INSIDE the backticks instead of
+    after the closing backtick:
+
+        - `src/almaapitk/domains/configuration.py (NEW)`
+
+    The parser previously captured the entire backtick content, leaving
+    the annotation embedded in the path string. Scope-check (R7) then
+    compared `"src/.../configuration.py (NEW)"` against the bare diff
+    path `"src/.../configuration.py"` via set membership and flagged
+    every file out-of-scope, even legitimately-touched ones.
+
+    The fix is to strip a trailing ` (annotation)` suffix from inside
+    the backticks, normalizing both formats to the same bare path.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = (
+        "- `src/almaapitk/domains/configuration.py (NEW)`\n"
+        "- `src/almaapitk/__init__.py (add to __all__ + lazy import map)`\n"
+        "- `src/almaapitk/_internal/__init__.py (re-export)`\n"
+        "- `tests/test_public_api_contract.py (assert new symbol exists)`"
+    )
+    paths = _bullet_lines(section)
+    assert paths == [
+        "src/almaapitk/domains/configuration.py",
+        "src/almaapitk/__init__.py",
+        "src/almaapitk/_internal/__init__.py",
+        "tests/test_public_api_contract.py",
+    ], paths
+
+
+def test_bullet_lines_strips_inside_annotation_with_external_annotation():
+    """Defense-in-depth: a bullet that has BOTH inside-backtick and
+    outside-backtick annotations should still normalize to the bare path.
+
+    Bullet:
+        - `path/to/file.py (NEW)` (also wired into __init__)
+
+    Both annotations are descriptive; only the path is the file to touch.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = "- `path/to/file.py (NEW)` (also wired into __init__)"
+    paths = _bullet_lines(section)
+    assert paths == ["path/to/file.py"], paths
+
+
+def test_bullet_lines_no_strip_when_paren_token_is_whole_content():
+    """Guard the strip from eating legitimate parenthesized content.
+
+    The 'API endpoints touched' section in foundation tickets sometimes has:
+        - `(no endpoints in this issue — foundation only)`
+
+    The entire backtick content is one parenthesized note (no leading
+    whitespace before the open paren). Stripping must not match here —
+    the result should preserve the parenthesized text as-is so callers
+    can recognize the sentinel.
+    """
+    from scripts.agentic.issue_parser import _bullet_lines
+
+    section = "- `(no endpoints in this issue — foundation only)`"
+    paths = _bullet_lines(section)
+    assert paths == ["(no endpoints in this issue — foundation only)"], paths


### PR DESCRIPTION
## Summary
- `_bullet_lines` in `scripts/agentic/issue_parser.py` now strips a trailing ` (annotation)` suffix from inside backticked tokens, so `` `path/to/file.py (NEW)` `` parses to `path/to/file.py` instead of `path/to/file.py (NEW)`.
- Three R10 regression tests in `tests/agentic/test_issue_parser.py` cover the new case, mixed inside+outside annotations, and a guard against stripping fully-parenthesized sentinel tokens.

## Why
Discovered while running `chunk-impl` for `config-bootstrap` (issue #22). Foundation tickets put descriptive annotations inside the backticks:

```
- `src/almaapitk/domains/configuration.py (NEW)`
- `src/almaapitk/__init__.py (add to __all__ + lazy import map)`
```

The parser captured the entire backtick content. R7 scope-check then compared `"src/.../configuration.py (NEW)"` against the bare git-diff path `"src/.../configuration.py"` via set membership and flagged every file out-of-scope, blocking the implementation loop structurally — no refinement attempt could ever pass. Chunk aborted; this PR unblocks the redo.

The same issue-body shape exists on other foundation tickets (#66, #70, #75), so the parser fix is global, not just #22.

## Test plan
- [x] `poetry run pytest tests/agentic/test_issue_parser.py -v` → 18 passed (15 existing + 3 new R10)
- [x] `poetry run pytest tests/agentic/ tests/test_public_api_contract.py -q` → 134 passed
- [x] `poetry run python scripts/smoke_import.py` → passes
- [x] Manually traced the regex against the failing #22 file list and the existing edge cases (sentinel tokens, mixed annotations, multi-path bullets)

Refs #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)