### PR TITLE
fix(logging): filter taskName from log output (issue #2)

### DIFF
--- a/src/almaapitk/alma_logging/formatters.py
+++ b/src/almaapitk/alma_logging/formatters.py
@@ -80,12 +80,13 @@ class JSONFormatter(logging.Formatter):
         if hasattr(record, 'environment'):
             log_data['environment'] = record.environment
 
-        # Extract all custom attributes (anything not in standard LogRecord)
+        # Extract all custom attributes (anything not in standard LogRecord).
+        # `taskName` was added in Python 3.12 — must be filtered (issue #2).
         standard_attrs = {
             'name', 'msg', 'args', 'created', 'filename', 'funcName', 'levelname',
             'levelno', 'lineno', 'module', 'msecs', 'message', 'pathname', 'process',
-            'processName', 'relativeCreated', 'thread', 'threadName', 'exc_info',
-            'exc_text', 'stack_info', 'getMessage', 'domain', 'environment'
+            'processName', 'relativeCreated', 'thread', 'threadName', 'taskName',
+            'exc_info', 'exc_text', 'stack_info', 'getMessage', 'domain', 'environment'
         }
 
         custom_fields = {}
@@ -166,12 +167,13 @@ class TextFormatter(logging.Formatter):
         # Add message
         parts.append(record.getMessage())
 
-        # Extract custom fields for display
+        # Extract custom fields for display.
+        # `taskName` was added in Python 3.12 — must be filtered (issue #2).
         standard_attrs = {
             'name', 'msg', 'args', 'created', 'filename', 'funcName', 'levelname',
             'levelno', 'lineno', 'module', 'msecs', 'message', 'pathname', 'process',
-            'processName', 'relativeCreated', 'thread', 'threadName', 'exc_info',
-            'exc_text', 'stack_info', 'getMessage', 'domain', 'environment'
+            'processName', 'relativeCreated', 'thread', 'threadName', 'taskName',
+            'exc_info', 'exc_text', 'stack_info', 'getMessage', 'domain', 'environment'
         }
 
         custom_fields = []

--- a/tests/unit/test_formatters.py
+++ b/tests/unit/test_formatters.py
@@ -1,0 +1,76 @@
+"""Unit tests for almaapitk.alma_logging.formatters.
+
+Regression coverage for issue #2: stray `(taskName=None)` on every log line
+under Python 3.12+. Python 3.12 added `taskName` as a built-in LogRecord
+attribute; both formatters must treat it as standard so it does not bleed
+into custom-context output.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from almaapitk.alma_logging.formatters import JSONFormatter, TextFormatter
+
+
+def _make_record(extra: dict | None = None) -> logging.LogRecord:
+    record = logging.LogRecord(
+        name="almaapitk.test",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello",
+        args=None,
+        exc_info=None,
+    )
+    record.taskName = None  # what Python 3.12+ injects for sync code
+    if extra:
+        for key, value in extra.items():
+            setattr(record, key, value)
+    return record
+
+
+class TestTaskNameNotLeaked:
+    """Issue #2: `taskName` from Python 3.12+ must not appear in formatted output."""
+
+    def test_text_formatter_omits_taskname(self) -> None:
+        record = _make_record()
+        formatted = TextFormatter(use_colors=False).format(record)
+        assert "taskName" not in formatted
+
+    def test_text_formatter_keeps_real_custom_fields(self) -> None:
+        record = _make_record(extra={"invoice_id": "INV-1"})
+        formatted = TextFormatter(use_colors=False).format(record)
+        assert "invoice_id=INV-1" in formatted
+        assert "taskName" not in formatted
+
+    def test_json_formatter_omits_taskname(self) -> None:
+        record = _make_record()
+        payload = json.loads(JSONFormatter().format(record))
+        assert "taskName" not in payload.get("context", {})
+        assert "taskName" not in payload
+
+    def test_json_formatter_keeps_real_custom_fields(self) -> None:
+        record = _make_record(extra={"invoice_id": "INV-1"})
+        payload = json.loads(JSONFormatter().format(record))
+        assert payload["context"] == {"invoice_id": "INV-1"}
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "taskName",  # added in Python 3.12 (issue #2)
+    ],
+)
+def test_python_312_logrecord_attrs_are_treated_as_standard(attr: str) -> None:
+    """Guard against future drift: any attribute Python's logging module sets
+    automatically on LogRecord must not appear in the custom-context tail.
+    """
+    record = _make_record(extra={attr: None})
+    text_out = TextFormatter(use_colors=False).format(record)
+    json_out = json.loads(JSONFormatter().format(record))
+    assert attr not in text_out
+    assert attr not in json_out.get("context", {})


### PR DESCRIPTION
## Summary

- Adds `taskName` to the `standard_attrs` filter set in both `JSONFormatter` and `TextFormatter`. Python 3.12 introduced `taskName` as a built-in `LogRecord` attribute (the name of the active `asyncio.Task`, `None` for sync code), and the formatters were written before 3.12 so the new attribute leaked into the custom-context tail of every log line — `(taskName=None)` everywhere.
- Adds a pytest regression test under `tests/unit/test_formatters.py` per R10. Covers both formatters, both with and without real custom fields, and parametrises on attribute name so the next Python-stdlib `LogRecord` addition is a one-line update.

Off-pipeline (no chunk scaffolding) — single literal change. Run-log entry to follow.

Fixes #2.

## Test plan

- [x] `poetry run pytest tests/unit/test_formatters.py` — 5 passed (failed on `main` before the formatter edit; passes after)
- [x] `poetry run pytest tests/test_public_api_contract.py` — 29 passed
- [x] `poetry run python scripts/smoke_import.py` — passes
- [x] `scripts/agentic/chunks regression-smoke` — 4 passed, 2 skipped (fixture-gated), 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)