### PR TITLE
chore(distribution): add CHANGELOG.md (issue #17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to `almaapitk` are documented in this file.
+
+The format is based on [Keep a Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- `AlmaAPIClient` now uses a persistent `requests.Session` for all HTTP calls
+  (issue #3) and routes every verb through a single `_request()` method
+  (issue #4), giving every later feature one chokepoint for retry, timeout,
+  and rate-limit policy.
+- HTTP retry with exponential backoff for transient failures
+  (`429`, `500`, `502`, `503`, `504`) (issue #5).
+- Configurable per-call timeout and a region map covering the published
+  Alma endpoints (NA, EU, APAC, China) (issues #6, #7).
+- Mapped Alma error codes to `AlmaAPIError` subclasses
+  (`AlmaAuthenticationError`, `AlmaRateLimitError`, `AlmaValidationError`)
+  and surfaced `trackingId` / `errorCode` on raised exceptions (issues #9, #10).
+- `client.iter_paged(endpoint, ...)` generator that walks paged Alma
+  endpoints with on-demand fetching, `max_records` cap, and centralized
+  `limit` / `offset` / `total_record_count` bookkeeping (issue #11).
+  `Acquisitions.list_invoices` and `Acquisitions.search_invoices` migrated
+  as proof points.
+- `AlmaAPIClient` is now a context manager (`with AlmaAPIClient(...) as c:`)
+  and exposes an explicit `close()` (issue #13).
+- `AlmaResponse.data` caches its parsed payload across repeated access
+  (issue #16).
+- `Configuration` domain foundation skeleton added under
+  `almaapitk.domains.configuration` (issue #22). Concrete methods land
+  in sibling tickets #24–#35.
+
+### Changed
+
+- Replaced direct `print()` calls in domain code with the project logger
+  (issue #14). All operational events now flow through
+  `almaapitk.alma_logging`.
+- Tightened `try / except` blocks across the client to catch only the
+  exceptions actually raised, not bare `Exception` (issue #16).
+
+### Fixed
+
+- Filtered `taskName` from custom-context log output. Python 3.12 added
+  `taskName` as a built-in `LogRecord` attribute, which both formatters
+  were leaking into every log line as `(taskName=None)` (issue #2).
+
+### Removed
+
+- Dropped 7 unused dependencies, including the transitive
+  CVE-2023-36464 source. Runtime dependency surface is now `requests`
+  only (issue #83).
+
+## [0.3.1] — 2026-04-27
+
+First publish of `almaapitk` to PyPI. (0.3.0 was uploaded to TestPyPI
+during pre-publish verification but never released; README content
+corrections caught during the TestPyPI gate required a version bump
+to 0.3.1.)
+
+### Added
+
+- `Analytics` domain class with `get_report_headers()` and
+  `fetch_report_rows()`, including built-in pagination. Alma Analytics
+  is backed by a single shared database accessible only via PRODUCTION
+  credentials; SANDBOX has no analytics endpoint.
+- `progress_callback` hook on `Analytics.fetch_report_rows()`, invoked
+  after each page so callers can display progress for long-running
+  fetches.
+- Generous `timeout=300` on every `requests` call in `AlmaAPIClient` to
+  prevent indefinite hangs.
+
+### Changed
+
+- Documented `process_users_batch.max_workers` as a no-op pending a
+  future concurrency feature, instead of implying parallelism.
+- Moved internal `alma_logging` documentation out of the package source
+  tree to `docs/alma_logging/` so the published wheel contains zero
+  non-Python content.
+
+[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.3.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,12 +40,14 @@ Homepage = "https://github.com/hagaybar/AlmaAPITK"
 Repository = "https://github.com/hagaybar/AlmaAPITK"
 Documentation = "https://github.com/hagaybar/AlmaAPITK#readme"
 Issues = "https://github.com/hagaybar/AlmaAPITK/issues"
+Changelog = "https://github.com/hagaybar/AlmaAPITK/blob/main/CHANGELOG.md"
 
 [tool.poetry]
 packages = [{ include = "almaapitk", from = "src" }]
 include = [
     { path = "README.md", format = "sdist" },
     { path = "LICENSE", format = "sdist" },
+    { path = "CHANGELOG.md", format = "sdist" },
     { path = "docs/releases/0.3.1.md", format = "sdist" },
 ]
 exclude = [


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` at repo root in [Keep-a-Changelog 1.1.0](https://keepachangelog.com/en/1.1.0/) format. `[Unreleased]` covers everything merged since 0.3.1 (issues #2, #3-#7, #9-#11, #13, #14, #16, #22, #83). 0.3.1 entry backfilled from `docs/releases/0.3.1.md`.
- Adds `Changelog` to `[project.urls]` and `CHANGELOG.md` to the sdist inclusion list, so the file ships with the next published wheel and is linked from the PyPI sidebar.

Off-pipeline (no chunk scaffolding) — the LICENSE / classifiers / badge requirements from #17 are already satisfied; this commit is just the missing changelog discipline.

**Issue #1 (OIDC release workflow) is intentionally out of scope.** It was closed 2026-05-04 as overhead for a single-maintainer cadence. Revisit if/when the maintainer count or release frequency changes.

Closes #17.

## Test plan

- [x] `poetry build` produces clean wheel + sdist
- [x] `poetry run twine check dist/*` — both PASSED
- [x] `tar tzf dist/almaapitk-0.3.1.tar.gz | grep CHANGELOG` — file is in the sdist
- [x] `pyproject.toml` `[project.urls]` now exposes Changelog link

🤖 Generated with [Claude Code](https://claude.com/claude-code)