### PR TITLE
chunk: config-sets (#23)

### DIFF
--- a/src/almaapitk/domains/admin.py
+++ b/src/almaapitk/domains/admin.py
@@ -562,7 +562,7 @@ class Admin:
     def test_connection(self) -> bool:
         """
         Test if the admin/configuration endpoints are accessible.
-        
+
         Returns:
             True if connection successful, False otherwise
         """
@@ -570,17 +570,416 @@ class Admin:
             # Try to list a small number of sets as a connection test
             response = self.client.get("almaws/v1/conf/sets", params={"limit": "1"})
             success = response.status_code == 200
-            
+
             if success:
                 self.logger.info(f"✓ Admin API connection successful ({self.environment})")
             else:
                 self.logger.error(f"✗ Admin API connection failed: {response.status_code}")
-            
+
             return success
-            
+
         except Exception as e:
             self.logger.error(f"✗ Admin API connection error: {e}")
             return False
+
+    # =========================================================================
+    # Set CRUD + member-management methods (issue #23)
+    #
+    # Pattern source: read pattern mirrors ``Admin.list_sets`` (line 439);
+    # write pattern mirrors ``Acquisitions.create_invoice_simple`` -- input
+    # validation up top, ``self.client.<verb>`` for HTTP, structured
+    # logging at entry / success / error, AlmaAPIError surfaced verbatim
+    # with full context. The member-management endpoint matches the Alma
+    # developer-network spec: ``POST /almaws/v1/conf/sets/{set_id}`` with
+    # an ``op`` query parameter (``add_members`` / ``delete_members``)
+    # and a body shaped as ``{"members": {"member": [{"id": ...}, ...]}}``.
+    # =========================================================================
+
+    def create_set(self, set_data: Dict[str, Any]) -> AlmaResponse:
+        """Create a new itemized or logical set.
+
+        Wraps ``POST /almaws/v1/conf/sets``. ``set_data`` must include at
+        minimum the ``name`` and ``type`` fields Alma requires; the rest
+        of the payload (description, content type, status, query, etc.)
+        is passed through verbatim so callers can build any set Alma
+        accepts without having to wait for explicit kwargs.
+
+        Args:
+            set_data: Set object payload. Required keys:
+
+                - ``name`` (str): The set name shown in Alma.
+                - ``type`` (dict): The set type, e.g.
+                  ``{"value": "ITEMIZED"}`` or ``{"value": "LOGICAL"}``.
+
+                Almost every real call also wants ``content`` (the
+                content type, e.g. ``{"value": "BIB_MMS"}`` or
+                ``{"value": "USER"}``) — but Alma's own validation owns
+                that, so it is documented but not enforced here.
+
+        Returns:
+            AlmaResponse wrapping the create response. The created set's
+            ``id`` lives at ``response.data["id"]``.
+
+        Raises:
+            AlmaValidationError: If ``set_data`` is empty / not a dict,
+                or if ``name`` / ``type`` are missing.
+            AlmaAPIError: On API failure (typed subclass when the Alma
+                error code or HTTP status maps to one — see
+                ``AlmaAPIClient._classify_error``).
+
+        Example:
+            >>> response = admin.create_set({
+            ...     "name": "My BIB set",
+            ...     "type": {"value": "ITEMIZED"},
+            ...     "content": {"value": "BIB_MMS"},
+            ... })
+            >>> set_id = response.data["id"]
+        """
+        self._validate_set_data_for_create(set_data)
+        set_name = set_data.get("name")
+
+        # ``type`` and ``content`` may be either a bare string or the
+        # canonical ``{"value": "..."}`` dict shape -- normalise here
+        # for the log record only; the body sent to Alma is forwarded
+        # verbatim.
+        raw_type = set_data.get("type")
+        type_value = (
+            raw_type.get("value") if isinstance(raw_type, dict) else raw_type
+        )
+        raw_content = set_data.get("content")
+        content_value = (
+            raw_content.get("value")
+            if isinstance(raw_content, dict)
+            else raw_content
+        )
+
+        self.logger.info(
+            f"Creating set: {set_name}",
+            set_name=set_name,
+            set_type=type_value,
+            content_type=content_value,
+        )
+
+        try:
+            response = self.client.post("almaws/v1/conf/sets", data=set_data)
+            created_id = None
+            try:
+                created_id = response.data.get("id")
+            except (ValueError, AttributeError):
+                # Body may not be JSON / dict; the response itself is
+                # still a valid AlmaResponse and we should hand it back.
+                created_id = None
+
+            if created_id:
+                self.logger.info(
+                    f"✓ Created set: {set_name} (id={created_id})",
+                    set_id=created_id,
+                    set_name=set_name,
+                )
+            else:
+                self.logger.info(
+                    f"✓ Created set: {set_name}",
+                    set_name=set_name,
+                )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to create set: {set_name}",
+                set_name=set_name,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def update_set(self, set_id: str, set_data: Dict[str, Any]) -> AlmaResponse:
+        """Update an existing set's metadata.
+
+        Wraps ``PUT /almaws/v1/conf/sets/{set_id}``. Alma expects a
+        complete set object (see ``get_set_info`` for the shape Alma
+        returns); callers typically read the current set, mutate the
+        fields they want to change, and pass the whole dict here.
+
+        Args:
+            set_id: The Alma set identifier to update.
+            set_data: Full set object payload. Must be a non-empty dict.
+
+        Returns:
+            AlmaResponse wrapping the updated set object.
+
+        Raises:
+            AlmaValidationError: If ``set_id`` is empty or ``set_data``
+                is empty / not a dict.
+            AlmaAPIError: On API failure.
+
+        Example:
+            >>> info = admin.get_set_info(set_id)
+            >>> info["description"] = "Updated description"
+            >>> response = admin.update_set(set_id, info)
+        """
+        if not set_id:
+            raise AlmaValidationError("Set ID is required")
+        if not isinstance(set_data, dict) or not set_data:
+            raise AlmaValidationError(
+                "set_data must be a non-empty dict"
+            )
+
+        self.logger.info(
+            f"Updating set: {set_id}",
+            set_id=set_id,
+            set_name=set_data.get("name"),
+        )
+
+        try:
+            response = self.client.put(
+                f"almaws/v1/conf/sets/{set_id}", data=set_data
+            )
+            self.logger.info(
+                f"✓ Updated set: {set_id}",
+                set_id=set_id,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to update set: {set_id}",
+                set_id=set_id,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def delete_set(self, set_id: str) -> AlmaResponse:
+        """Delete a set.
+
+        Wraps ``DELETE /almaws/v1/conf/sets/{set_id}``. Removes the set
+        record from Alma; the underlying member records (bibs, users,
+        etc.) are untouched.
+
+        Args:
+            set_id: The Alma set identifier to delete.
+
+        Returns:
+            AlmaResponse wrapping the delete response. Alma typically
+            returns an empty body on a successful delete.
+
+        Raises:
+            AlmaValidationError: If ``set_id`` is empty.
+            AlmaAPIError: On API failure.
+        """
+        if not set_id:
+            raise AlmaValidationError("Set ID is required")
+
+        self.logger.info(
+            f"Deleting set: {set_id}",
+            set_id=set_id,
+        )
+
+        try:
+            response = self.client.delete(f"almaws/v1/conf/sets/{set_id}")
+            self.logger.info(
+                f"✓ Deleted set: {set_id}",
+                set_id=set_id,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to delete set: {set_id}",
+                set_id=set_id,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def add_members_to_set(
+        self, set_id: str, member_ids: List[str]
+    ) -> AlmaResponse:
+        """Add members to an existing set.
+
+        Wraps ``POST /almaws/v1/conf/sets/{set_id}?op=add_members``. The
+        body shape Alma expects is ``{"members": {"member": [{"id":
+        "<member_id>"}, ...]}}``.
+
+        Member-content validation: a ``BIB_MMS`` set takes MMS IDs and
+        a ``USER`` set takes user primary IDs. Caller-side ID-shape
+        validation is intentionally NOT performed here — Alma owns that
+        rule and will reject mismatched IDs server-side with a typed
+        error code (``60116`` / ``60120``).
+
+        Args:
+            set_id: The Alma set identifier to extend.
+            member_ids: Non-empty list of member IDs to add. Each entry
+                must be a non-empty string.
+
+        Returns:
+            AlmaResponse wrapping the updated set object.
+
+        Raises:
+            AlmaValidationError: If ``set_id`` is empty, ``member_ids``
+                is empty / not a list, or any entry is empty / not a
+                string.
+            AlmaAPIError: On API failure.
+        """
+        return self._manage_set_members(set_id, member_ids, op="add_members")
+
+    def remove_members_from_set(
+        self, set_id: str, member_ids: List[str]
+    ) -> AlmaResponse:
+        """Remove members from an existing set.
+
+        Wraps ``POST /almaws/v1/conf/sets/{set_id}?op=delete_members``.
+        Body shape matches ``add_members_to_set``: ``{"members":
+        {"member": [{"id": "<member_id>"}, ...]}}``.
+
+        Args:
+            set_id: The Alma set identifier to shrink.
+            member_ids: Non-empty list of member IDs to remove. Each
+                entry must be a non-empty string.
+
+        Returns:
+            AlmaResponse wrapping the updated set object.
+
+        Raises:
+            AlmaValidationError: If ``set_id`` is empty, ``member_ids``
+                is empty / not a list, or any entry is empty / not a
+                string.
+            AlmaAPIError: On API failure.
+        """
+        return self._manage_set_members(
+            set_id, member_ids, op="delete_members"
+        )
+
+    # ----- internal helpers for the set CRUD methods (issue #23) -------------
+
+    @staticmethod
+    def _validate_set_data_for_create(set_data: Any) -> None:
+        """Validate the ``set_data`` argument to ``create_set``.
+
+        Args:
+            set_data: Candidate payload for ``create_set``.
+
+        Raises:
+            AlmaValidationError: If ``set_data`` is not a non-empty
+                dict, or if the required ``name``/``type`` keys are
+                missing.
+        """
+        if not isinstance(set_data, dict) or not set_data:
+            raise AlmaValidationError(
+                "set_data must be a non-empty dict"
+            )
+        name = set_data.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise AlmaValidationError(
+                "set_data['name'] is required and must be a non-empty string"
+            )
+        # ``type`` may be either the bare string code or the canonical
+        # ``{"value": "ITEMIZED"}`` shape Alma returns on reads. Accept
+        # both -- callers using the shape returned by ``get_set_info``
+        # should not have to reshape it before sending it back.
+        set_type = set_data.get("type")
+        if isinstance(set_type, dict):
+            type_value = set_type.get("value")
+            if not isinstance(type_value, str) or not type_value.strip():
+                raise AlmaValidationError(
+                    "set_data['type']['value'] is required and must be a "
+                    "non-empty string (e.g. 'ITEMIZED' or 'LOGICAL')"
+                )
+        elif isinstance(set_type, str):
+            if not set_type.strip():
+                raise AlmaValidationError(
+                    "set_data['type'] must be a non-empty string"
+                )
+        else:
+            raise AlmaValidationError(
+                "set_data['type'] is required (string or "
+                "{'value': '<TYPE>'} dict)"
+            )
+
+    def _manage_set_members(
+        self, set_id: str, member_ids: List[str], op: str
+    ) -> AlmaResponse:
+        """Shared add/remove-members implementation.
+
+        Centralises validation, body construction, logging, and error
+        handling for ``add_members_to_set`` / ``remove_members_from_set``
+        so the two public wrappers differ only by the ``op`` value sent
+        on the query string.
+
+        Args:
+            set_id: Target set identifier.
+            member_ids: Members to add/remove (non-empty list of
+                non-empty strings).
+            op: Either ``"add_members"`` or ``"delete_members"`` — the
+                value Alma's ``op`` query parameter expects.
+
+        Returns:
+            AlmaResponse wrapping the API response.
+
+        Raises:
+            AlmaValidationError: For any input violation.
+            AlmaAPIError: On API failure.
+        """
+        if not set_id:
+            raise AlmaValidationError("Set ID is required")
+        if not isinstance(member_ids, list) or not member_ids:
+            raise AlmaValidationError(
+                "member_ids must be a non-empty list of strings"
+            )
+        for index, mid in enumerate(member_ids):
+            if not isinstance(mid, str) or not mid.strip():
+                raise AlmaValidationError(
+                    f"member_ids[{index}] must be a non-empty string"
+                )
+
+        # Body shape per Alma developer-network sets API:
+        # {"members": {"member": [{"id": "<id>"}, ...]}}
+        body = {
+            "members": {
+                "member": [{"id": mid} for mid in member_ids]
+            }
+        }
+
+        action = "Adding" if op == "add_members" else "Removing"
+        self.logger.info(
+            f"{action} {len(member_ids)} member(s) {('to' if op == 'add_members' else 'from')} set {set_id}",
+            set_id=set_id,
+            op=op,
+            member_count=len(member_ids),
+        )
+
+        try:
+            response = self.client.post(
+                f"almaws/v1/conf/sets/{set_id}",
+                data=body,
+                params={"op": op},
+            )
+            self.logger.info(
+                f"✓ {action} {len(member_ids)} member(s): set {set_id}",
+                set_id=set_id,
+                op=op,
+                member_count=len(member_ids),
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to {op.replace('_', ' ')} on set {set_id}",
+                set_id=set_id,
+                op=op,
+                member_count=len(member_ids),
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
 
 
 # Usage examples and integration for the email update project

--- a/tests/integration/test_admin_sets.py
+++ b/tests/integration/test_admin_sets.py
@@ -1,0 +1,217 @@
+"""Integration tests for ``Admin`` set CRUD + member management (issue #23).
+
+Exercises the live SANDBOX API for the new methods landed by issue #23:
+
+- ``Admin.create_set``
+- ``Admin.update_set``
+- ``Admin.delete_set``
+- ``Admin.add_members_to_set``
+- ``Admin.remove_members_from_set``
+
+These tests stay opt-in. They are skipped cleanly when:
+
+- The ``ALMA_SB_API_KEY`` environment variable is unset (no fixture
+  available in this shell).
+- The ``ALMA_SETS_INTEGRATION`` environment variable is not set to a
+  truthy value (operator opt-in gate; round-trip tests create + delete
+  real Alma objects, so we don't run them silently on every ``pytest``
+  invocation).
+
+Pattern source: skip-on-missing-fixture mirrors
+``tests/integration/domains/test_bibs_collections.py``; round-trip
+shape mirrors the issue #23 acceptance criterion.
+
+Run with::
+
+    ALMA_SETS_INTEGRATION=1 ALMA_SB_API_KEY=<key> \\
+      pytest tests/integration/test_admin_sets.py -v -m integration
+
+The optional ``ALMA_SETS_INTEGRATION_MEMBER_ID`` environment variable
+controls the member ID used for the add/remove portion of the
+round-trip (default fixture lives in the SANDBOX). When the supplied
+ID is not valid in the caller's tenant, the add-step is allowed to
+fall back to a skip.
+"""
+
+import os
+import uuid
+
+import pytest
+
+
+def _integration_enabled() -> bool:
+    """Return True when the operator has opted into the live round-trip."""
+    flag = os.getenv("ALMA_SETS_INTEGRATION", "").strip().lower()
+    return flag in {"1", "true", "yes", "on"}
+
+
+@pytest.fixture(scope="module")
+def alma_client():
+    """Build a SANDBOX ``AlmaAPIClient`` if the environment supports it.
+
+    Skips the entire module when no SANDBOX key is available so the
+    suite never hard-fails on a workstation without credentials.
+    """
+    if not _integration_enabled():
+        pytest.skip(
+            "ALMA_SETS_INTEGRATION not set; skipping live sets round-trip"
+        )
+    api_key = os.getenv("ALMA_SB_API_KEY")
+    if not api_key:
+        pytest.skip("ALMA_SB_API_KEY not set; cannot run integration test")
+
+    from almaapitk import AlmaAPIClient
+
+    return AlmaAPIClient("SANDBOX")
+
+
+@pytest.fixture(scope="module")
+def admin(alma_client):
+    from almaapitk import Admin
+
+    return Admin(alma_client)
+
+
+@pytest.fixture
+def unique_set_name() -> str:
+    """A short, collision-resistant set name.
+
+    Per R9, no real operator IDs in committed content -- we use a UUID
+    suffix here so the integration run cannot accidentally clobber a
+    pre-existing tenant set. ``almaapitk-#23-`` makes the source
+    obvious in the Alma UI when an operator inspects the SANDBOX.
+    """
+    return f"almaapitk-#23-{uuid.uuid4().hex[:8]}"
+
+
+@pytest.mark.integration
+class TestAdminSetsRoundTrip:
+    """Full create → update → add → remove → delete round-trip."""
+
+    def test_round_trip(self, admin, unique_set_name):
+        from almaapitk import AlmaAPIError, AlmaValidationError
+
+        # The default member ID is a placeholder; operators with a real
+        # SANDBOX fixture should set ALMA_SETS_INTEGRATION_MEMBER_ID
+        # to a valid ID for their tenant.
+        member_id = os.getenv(
+            "ALMA_SETS_INTEGRATION_MEMBER_ID", ""
+        ).strip()
+
+        created_set_id = None
+        try:
+            # ----- create ----------------------------------------------
+            create_payload = {
+                "name": unique_set_name,
+                "description": "Created by AlmaAPITK issue #23 integration test",
+                "type": {"value": "ITEMIZED"},
+                "content": {"value": "BIB_MMS"},
+                "private": {"value": "false"},
+                "status": {"value": "ACTIVE"},
+            }
+
+            try:
+                create_response = admin.create_set(create_payload)
+            except AlmaAPIError as e:
+                pytest.skip(
+                    f"create_set failed in SANDBOX (tenant config?): {e}"
+                )
+
+            assert create_response is not None
+            assert create_response.success
+            created = create_response.data
+            created_set_id = created.get("id")
+            assert created_set_id, "Alma did not return an id for the new set"
+
+            # ----- update ----------------------------------------------
+            updated_payload = dict(created)
+            updated_payload["description"] = (
+                "Updated by AlmaAPITK issue #23 integration test"
+            )
+            update_response = admin.update_set(created_set_id, updated_payload)
+            assert update_response is not None
+            assert update_response.success
+
+            # ----- add members -----------------------------------------
+            if member_id:
+                try:
+                    add_response = admin.add_members_to_set(
+                        created_set_id, [member_id]
+                    )
+                    assert add_response is not None
+                    assert add_response.success
+
+                    # ----- remove members ------------------------------
+                    remove_response = admin.remove_members_from_set(
+                        created_set_id, [member_id]
+                    )
+                    assert remove_response is not None
+                    assert remove_response.success
+                except AlmaAPIError as e:
+                    # Member-management failed (likely the supplied
+                    # member ID isn't valid in this tenant); the rest
+                    # of the round-trip is still useful, so don't fail
+                    # the whole test on the member step.
+                    pytest.skip(
+                        f"member-management step skipped in SANDBOX: {e}"
+                    )
+            else:
+                pytest.skip(
+                    "ALMA_SETS_INTEGRATION_MEMBER_ID not set; "
+                    "skipping the add/remove portion of the round-trip"
+                )
+
+        finally:
+            # ----- delete ---------------------------------------------
+            # Always clean up the set we created, even if a mid-step
+            # assertion blew up. Swallow delete failures here so the
+            # original test failure is what gets reported.
+            if created_set_id:
+                try:
+                    admin.delete_set(created_set_id)
+                except AlmaAPIError:
+                    pass
+
+
+@pytest.mark.integration
+class TestAdminSetsValidation:
+    """Validation paths -- no live API call required, but kept here so the
+    integration-marker filter still exercises them."""
+
+    def test_create_set_validates_input(self, admin):
+        from almaapitk import AlmaValidationError
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set({})
+
+    def test_update_set_validates_set_id(self, admin):
+        from almaapitk import AlmaValidationError
+
+        with pytest.raises(AlmaValidationError):
+            admin.update_set("", {"name": "x", "type": "ITEMIZED"})
+
+    def test_delete_set_validates_set_id(self, admin):
+        from almaapitk import AlmaValidationError
+
+        with pytest.raises(AlmaValidationError):
+            admin.delete_set("")
+
+    def test_add_members_validates_inputs(self, admin):
+        from almaapitk import AlmaValidationError
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("", ["m1"])
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("set-1", [])
+
+    def test_remove_members_validates_inputs(self, admin):
+        from almaapitk import AlmaValidationError
+
+        with pytest.raises(AlmaValidationError):
+            admin.remove_members_from_set("", ["m1"])
+        with pytest.raises(AlmaValidationError):
+            admin.remove_members_from_set("set-1", [])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-m", "integration"])

--- a/tests/unit/domains/test_admin.py
+++ b/tests/unit/domains/test_admin.py
@@ -1,10 +1,610 @@
-from almaapitk import AlmaAPIClient
-from almaapitk import Admin
+"""Unit tests for the Admin domain class — set CRUD + member management (issue #23).
 
-# Initialize
-client = AlmaAPIClient('SANDBOX')  # or 'PRODUCTION'
-admin = Admin(client)
+Tests cover the five new methods:
 
-# Get all MMS IDs from a set
-mms_ids = admin.get_set_members('34143075950004146')
-print(f"Retrieved {len(mms_ids)} MMS IDs")
+- ``Admin.create_set``
+- ``Admin.update_set``
+- ``Admin.delete_set``
+- ``Admin.add_members_to_set``
+- ``Admin.remove_members_from_set``
+
+Pattern source: mirrors ``tests/unit/domains/test_configuration.py`` /
+``tests/unit/domains/test_analytics.py`` for the mock-client style
+(plain ``MockAlmaAPIClient`` + ``MockAlmaResponse``, no real HTTP).
+"""
+
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class MockAlmaResponse:
+    """Lightweight stand-in for ``almaapitk.AlmaResponse``.
+
+    Just enough surface area for the Admin methods under test:
+    ``status_code``, ``success``, and a ``.data`` / ``.json()`` pair
+    backed by a single dict.
+    """
+
+    def __init__(
+        self,
+        body: Optional[Dict[str, Any]] = None,
+        status_code: int = 200,
+        success: bool = True,
+    ):
+        self._body = body if body is not None else {}
+        self.status_code = status_code
+        self.success = success
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+    @property
+    def data(self) -> Dict[str, Any]:
+        return self._body
+
+
+class MockAlmaAPIClient:
+    """Mock AlmaAPIClient wired so each verb records the call it received.
+
+    Records the last ``(endpoint, params, data)`` triple per verb so
+    tests can assert on URL / query-param / body shape without standing
+    up an HTTP layer.
+    """
+
+    def __init__(self, environment: str = 'SANDBOX'):
+        self.environment = environment
+        # The Admin constructor copies ``client.logger`` onto ``self``;
+        # MagicMock gives us call-recording for free without asking the
+        # alma_logging stack to spin up.
+        self.logger = MagicMock()
+
+        # Per-verb response registers; tests set these before they call
+        # the Admin method under test.
+        self.post_response: MockAlmaResponse = MockAlmaResponse()
+        self.put_response: MockAlmaResponse = MockAlmaResponse()
+        self.delete_response: MockAlmaResponse = MockAlmaResponse()
+        # Optional override: when set to an exception, the next call
+        # raises it instead of returning ``*_response``.
+        self.next_exception: Optional[Exception] = None
+
+        self.calls: Dict[str, list] = {
+            "post": [],
+            "put": [],
+            "delete": [],
+            "get": [],
+        }
+
+    def get_environment(self) -> str:
+        return self.environment
+
+    def post(
+        self,
+        endpoint: str,
+        data: Any = None,
+        params: Optional[Dict[str, Any]] = None,
+        content_type: Optional[str] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["post"].append(
+            {"endpoint": endpoint, "data": data, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.post_response
+
+    def put(
+        self,
+        endpoint: str,
+        data: Any = None,
+        params: Optional[Dict[str, Any]] = None,
+        content_type: Optional[str] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["put"].append(
+            {"endpoint": endpoint, "data": data, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.put_response
+
+    def delete(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["delete"].append(
+            {"endpoint": endpoint, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.delete_response
+
+    def get(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        # Not exercised by the tests below, but several Admin methods
+        # call ``client.get`` indirectly through other paths -- keep the
+        # surface complete to avoid AttributeError in any future test.
+        self.calls["get"].append({"endpoint": endpoint, "params": params})
+        return MockAlmaResponse()
+
+
+# ---------------------------------------------------------------------------
+# create_set
+# ---------------------------------------------------------------------------
+
+
+class TestCreateSet:
+    """Tests for ``Admin.create_set``."""
+
+    def _valid_payload(self) -> Dict[str, Any]:
+        return {
+            "name": "My Test Set",
+            "type": {"value": "ITEMIZED"},
+            "content": {"value": "BIB_MMS"},
+            "description": "A test set",
+        }
+
+    def test_create_set_posts_to_correct_endpoint(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "1234567890", "name": "My Test Set"}
+        )
+        admin = Admin(mock_client)
+
+        response = admin.create_set(self._valid_payload())
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/conf/sets"
+        # No ``op`` query param on create.
+        assert call["params"] is None
+        # Body is forwarded verbatim.
+        assert call["data"]["name"] == "My Test Set"
+        assert call["data"]["type"] == {"value": "ITEMIZED"}
+        # Returned response is the mock.
+        assert response is mock_client.post_response
+        assert response.data["id"] == "1234567890"
+
+    def test_create_set_accepts_string_type(self):
+        """Alma accepts ``type`` as a bare string in create payloads."""
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        payload = {"name": "S", "type": "ITEMIZED"}
+        admin.create_set(payload)
+
+        call = mock_client.calls["post"][0]
+        assert call["data"]["type"] == "ITEMIZED"
+
+    def test_create_set_logs_success_with_id(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "9999"})
+        admin = Admin(mock_client)
+
+        admin.create_set(self._valid_payload())
+
+        assert mock_client.logger.info.called
+
+    def test_create_set_rejects_empty_dict(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set({})
+
+    def test_create_set_rejects_non_dict(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set("not a dict")  # type: ignore[arg-type]
+
+    def test_create_set_rejects_missing_name(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set({"type": {"value": "ITEMIZED"}})
+
+    def test_create_set_rejects_blank_name(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set(
+                {"name": "   ", "type": {"value": "ITEMIZED"}}
+            )
+
+    def test_create_set_rejects_missing_type(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set({"name": "S"})
+
+    def test_create_set_rejects_type_dict_without_value(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.create_set({"name": "S", "type": {}})
+
+    def test_create_set_propagates_api_error_with_logging(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "The set name already exists.", status_code=400, alma_code="402263"
+        )
+        admin = Admin(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            admin.create_set(self._valid_payload())
+
+        assert mock_client.logger.error.called
+
+
+# ---------------------------------------------------------------------------
+# update_set
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateSet:
+    """Tests for ``Admin.update_set``."""
+
+    def _valid_payload(self) -> Dict[str, Any]:
+        return {
+            "id": "1234567890",
+            "name": "Updated Set Name",
+            "description": "Updated description",
+            "type": {"value": "ITEMIZED"},
+        }
+
+    def test_update_set_puts_to_correct_endpoint(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(body=self._valid_payload())
+        admin = Admin(mock_client)
+
+        response = admin.update_set("1234567890", self._valid_payload())
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert call["endpoint"] == "almaws/v1/conf/sets/1234567890"
+        assert call["data"]["name"] == "Updated Set Name"
+        assert response is mock_client.put_response
+
+    def test_update_set_rejects_empty_set_id(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.update_set("", self._valid_payload())
+
+    def test_update_set_rejects_empty_payload(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.update_set("1234567890", {})
+
+    def test_update_set_rejects_non_dict_payload(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.update_set("1234567890", "not a dict")  # type: ignore[arg-type]
+
+    def test_update_set_propagates_api_error(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Failed updating set.", status_code=400, alma_code="40166408"
+        )
+        admin = Admin(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            admin.update_set("1234567890", self._valid_payload())
+
+        assert mock_client.logger.error.called
+
+
+# ---------------------------------------------------------------------------
+# delete_set
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteSet:
+    """Tests for ``Admin.delete_set``."""
+
+    def test_delete_set_calls_correct_endpoint(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(
+            body={}, status_code=204
+        )
+        admin = Admin(mock_client)
+
+        response = admin.delete_set("1234567890")
+
+        assert len(mock_client.calls["delete"]) == 1
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == "almaws/v1/conf/sets/1234567890"
+        assert response is mock_client.delete_response
+
+    def test_delete_set_rejects_empty_set_id(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.delete_set("")
+
+    def test_delete_set_propagates_api_error(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Delete of Set Failed.", status_code=400, alma_code="402282"
+        )
+        admin = Admin(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            admin.delete_set("1234567890")
+
+        assert mock_client.logger.error.called
+
+
+# ---------------------------------------------------------------------------
+# add_members_to_set
+# ---------------------------------------------------------------------------
+
+
+class TestAddMembersToSet:
+    """Tests for ``Admin.add_members_to_set``."""
+
+    def test_add_members_uses_op_add_members_query(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        admin.add_members_to_set("1234567890", ["m1", "m2", "m3"])
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/conf/sets/1234567890"
+        assert call["params"] == {"op": "add_members"}
+
+    def test_add_members_body_shape(self):
+        """Body must wrap the IDs as members.member[*].id (per Alma spec)."""
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        admin.add_members_to_set("set-1", ["m1", "m2"])
+
+        body = mock_client.calls["post"][0]["data"]
+        assert body == {
+            "members": {"member": [{"id": "m1"}, {"id": "m2"}]}
+        }
+
+    def test_add_members_returns_response(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "set-1", "number_of_members": {"value": 5}}
+        )
+        admin = Admin(mock_client)
+
+        response = admin.add_members_to_set("set-1", ["m1"])
+
+        assert response is mock_client.post_response
+
+    def test_add_members_rejects_empty_set_id(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("", ["m1"])
+
+    def test_add_members_rejects_empty_list(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("set-1", [])
+
+    def test_add_members_rejects_non_list(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("set-1", "not a list")  # type: ignore[arg-type]
+
+    def test_add_members_rejects_non_string_entry(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("set-1", ["m1", 12345])  # type: ignore[list-item]
+
+    def test_add_members_rejects_blank_entry(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.add_members_to_set("set-1", ["m1", "   "])
+
+    def test_add_members_propagates_api_error(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "A member ID is already in the set.",
+            status_code=400,
+            alma_code="60115",
+        )
+        admin = Admin(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            admin.add_members_to_set("set-1", ["m1"])
+
+        assert mock_client.logger.error.called
+
+
+# ---------------------------------------------------------------------------
+# remove_members_from_set
+# ---------------------------------------------------------------------------
+
+
+class TestRemoveMembersFromSet:
+    """Tests for ``Admin.remove_members_from_set``."""
+
+    def test_remove_members_uses_op_delete_members_query(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        admin.remove_members_from_set("1234567890", ["m1"])
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/conf/sets/1234567890"
+        assert call["params"] == {"op": "delete_members"}
+
+    def test_remove_members_body_shape(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        admin.remove_members_from_set("set-1", ["m1", "m2"])
+
+        body = mock_client.calls["post"][0]["data"]
+        assert body == {
+            "members": {"member": [{"id": "m1"}, {"id": "m2"}]}
+        }
+
+    def test_remove_members_rejects_empty_set_id(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.remove_members_from_set("", ["m1"])
+
+    def test_remove_members_rejects_empty_list(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.remove_members_from_set("set-1", [])
+
+    def test_remove_members_rejects_non_string_entry(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaValidationError
+
+        admin = Admin(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            admin.remove_members_from_set("set-1", [None])  # type: ignore[list-item]
+
+    def test_remove_members_propagates_api_error(self):
+        from almaapitk.domains.admin import Admin
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Input set member ID is not in set.",
+            status_code=400,
+            alma_code="60117",
+        )
+        admin = Admin(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            admin.remove_members_from_set("set-1", ["m1"])
+
+        assert mock_client.logger.error.called
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: the two member-management methods must differ ONLY by op
+# ---------------------------------------------------------------------------
+
+
+class TestMemberManagementOpDispatch:
+    """Add and remove must hit the same endpoint with different ``op`` values."""
+
+    def test_add_and_remove_differ_only_in_op(self):
+        from almaapitk.domains.admin import Admin
+
+        mock_client = MockAlmaAPIClient()
+        admin = Admin(mock_client)
+
+        admin.add_members_to_set("set-1", ["m1"])
+        admin.remove_members_from_set("set-1", ["m1"])
+
+        add_call, remove_call = mock_client.calls["post"]
+        assert add_call["endpoint"] == remove_call["endpoint"]
+        assert add_call["data"] == remove_call["data"]
+        assert add_call["params"] == {"op": "add_members"}
+        assert remove_call["params"] == {"op": "delete_members"}


### PR DESCRIPTION
## Chunk: `config-sets`

Closes #23

## Implementation summary

Issue #23 extended the existing Admin domain class with create_set / update_set / delete_set / add_members_to_set / remove_members_from_set. Each method validates required inputs (AlmaValidationError on bad input), routes via the AlmaAPIClient verbs, and logs through alma_logging. Member-management uses the correct op=add_members / op=delete_members query parameter on POST /almaws/v1/conf/sets/{set_id}.

## SANDBOX test summary

Both SANDBOX tests passed. t-23-1 drove the full round-trip (create -> update -> add member -> remove member -> delete) against live SANDBOX with the supplied test bib MMS; t-23-2 exercised the new validation guards. autoCloseEligible is false (six static-source / unit-test ACs not SANDBOX-observable); issue labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/config-sets/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
