### PR TITLE
chunk: config-orgs-and-locations (#24, #25)

### DIFF
--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -1,22 +1,27 @@
 """
 Configuration Domain Class for Alma API
 Foundation skeleton for the Configuration API surface (issue #22), extended
-with organizational-structure read methods (issue #24).
+with organizational-structure read methods (issue #24) and locations CRUD
+(issue #25).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
 smoke-test connection check.
 
 Issue #24 adds five read-only organizational-structure endpoints
-(libraries, departments, circulation desks). Concrete API methods for
-the remaining sibling tickets (locations, code tables, calendars, etc.)
-land in those tickets and intentionally do NOT live here.
+(libraries, departments, circulation desks).
+
+Issue #25 adds full CRUD for per-library locations (list / get / create /
+update / delete). Concrete API methods for the remaining sibling tickets
+(code tables, calendars, etc.) land in those tickets and intentionally do
+NOT live here.
 """
 from typing import Any, Dict, List
 
 from almaapitk.client.AlmaAPIClient import (
     AlmaAPIClient,
     AlmaAPIError,
+    AlmaResponse,
     AlmaValidationError,
 )
 from almaapitk.alma_logging import get_logger
@@ -366,5 +371,423 @@ class Configuration:
                     "tracking_id": getattr(e, "tracking_id", None),
                     "status_code": getattr(e, "status_code", None),
                 },
+            )
+            raise
+
+    # =========================================================================
+    # Locations CRUD (issue #25)
+    #
+    # Read patterns mirror ``Configuration.list_libraries`` /
+    # ``Configuration.get_library`` (just merged in issue #24): single GET,
+    # unwrap the Alma envelope, normalise dict→list, propagate AlmaAPIError
+    # with full context. Write patterns mirror ``Admin.create_set`` /
+    # ``Admin.update_set`` / ``Admin.delete_set`` (admin.py:598+):
+    # validate-up-top, log entry, ``self.client.<verb>``, log success-with-id
+    # / error-with-context, return ``AlmaResponse`` or re-raise.
+    # =========================================================================
+
+    @staticmethod
+    def _validate_location_data_for_create(location_data: Any) -> None:
+        """Validate the ``location_data`` argument to ``create_location``.
+
+        Alma requires at minimum ``code``, ``name``, and ``type`` on the
+        body sent to ``POST /almaws/v1/conf/libraries/{libraryCode}/locations``.
+        ``type`` may be either a bare string (``"OPEN"``) or the canonical
+        ``{"value": "OPEN"}`` dict shape Alma returns on reads — we accept
+        both, mirroring ``Admin._validate_set_data_for_create``.
+
+        Args:
+            location_data: Candidate payload for ``create_location``.
+
+        Raises:
+            AlmaValidationError: If ``location_data`` is not a non-empty
+                dict, or if any of ``code`` / ``name`` / ``type`` is
+                missing or empty.
+        """
+        # Pattern source: Admin._validate_set_data_for_create (admin.py:862).
+        if not isinstance(location_data, dict) or not location_data:
+            raise AlmaValidationError(
+                "location_data must be a non-empty dict"
+            )
+        code = location_data.get("code")
+        if not isinstance(code, str) or not code.strip():
+            raise AlmaValidationError(
+                "location_data['code'] is required and must be a "
+                "non-empty string"
+            )
+        name = location_data.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise AlmaValidationError(
+                "location_data['name'] is required and must be a "
+                "non-empty string"
+            )
+        loc_type = location_data.get("type")
+        if isinstance(loc_type, dict):
+            type_value = loc_type.get("value")
+            if not isinstance(type_value, str) or not type_value.strip():
+                raise AlmaValidationError(
+                    "location_data['type']['value'] is required and must "
+                    "be a non-empty string (e.g. 'OPEN' or 'CLOSED_STACK')"
+                )
+        elif isinstance(loc_type, str):
+            if not loc_type.strip():
+                raise AlmaValidationError(
+                    "location_data['type'] must be a non-empty string"
+                )
+        else:
+            raise AlmaValidationError(
+                "location_data['type'] is required (string or "
+                "{'value': '<TYPE>'} dict)"
+            )
+
+    def list_locations(self, library_code: str) -> List[Dict[str, Any]]:
+        """List all locations configured for a given library.
+
+        Calls ``GET /almaws/v1/conf/libraries/{libraryCode}/locations``
+        and unwraps the Alma response envelope
+        (``{"location": [...], "total_record_count": N}``) into a flat
+        list. Locations are scoped to a single library — the same
+        ``locationCode`` may be reused by another library — so callers
+        must always supply ``library_code``.
+
+        Args:
+            library_code: The Alma library code whose locations to list.
+
+        Returns:
+            List of location dicts as returned by Alma. Returns an empty
+            list when the library has no locations configured (or when
+            the response envelope is missing the ``location`` key).
+
+        Raises:
+            AlmaValidationError: If ``library_code`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_circ_desks (issue #24, above).
+        code = self._validate_code(library_code, "library_code")
+        self.logger.info(
+            f"Listing locations for library {code} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/libraries/{code}/locations",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            locations = payload.get("location") or []
+            if isinstance(locations, dict):
+                # Single-record responses can come back as a dict; normalise.
+                locations = [locations]
+            self.logger.info(
+                f"✓ Retrieved {len(locations)} locations for library {code}"
+            )
+            return locations
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to list locations for library {code}",
+                extra={
+                    "library_code": code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_location(
+        self, library_code: str, location_code: str
+    ) -> Dict[str, Any]:
+        """Get configuration details for a single location.
+
+        Calls
+        ``GET /almaws/v1/conf/libraries/{libraryCode}/locations/{locationCode}``.
+
+        Note: location codes are unique **per library**, not globally.
+        The same ``location_code`` value may be reused across libraries,
+        so callers must always supply both codes.
+
+        Args:
+            library_code: The Alma library code that owns the location.
+            location_code: The location code (unique within ``library_code``).
+
+        Returns:
+            The location configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If either code is empty or not a string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the location does not exist within the library).
+        """
+        # Pattern source: Configuration.get_circ_desk (issue #24, above).
+        lib_code = self._validate_code(library_code, "library_code")
+        loc_code = self._validate_code(location_code, "location_code")
+        self.logger.info(
+            f"Getting location {loc_code} for library {lib_code} "
+            f"({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/libraries/{lib_code}/locations/{loc_code}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved location {loc_code} for library {lib_code}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get location {loc_code} for library {lib_code}",
+                extra={
+                    "library_code": lib_code,
+                    "location_code": loc_code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def create_location(
+        self, library_code: str, location_data: Dict[str, Any]
+    ) -> AlmaResponse:
+        """Create a new location within a library.
+
+        Wraps
+        ``POST /almaws/v1/conf/libraries/{libraryCode}/locations``. The
+        body Alma expects is the location object directly (not wrapped).
+        ``location_data`` must include at minimum the ``code``, ``name``,
+        and ``type`` fields Alma requires; the rest of the payload
+        (description, fulfillment unit, call-number type, etc.) is
+        passed through verbatim so callers can build any location Alma
+        accepts without waiting for explicit kwargs.
+
+        Args:
+            library_code: The Alma library code the new location will
+                belong to.
+            location_data: Location object payload. Required keys:
+
+                - ``code`` (str): The location code, unique within
+                  ``library_code``.
+                - ``name`` (str): The location name shown in Alma.
+                - ``type`` (str | dict): The location type, e.g.
+                  ``"OPEN"`` or ``{"value": "CLOSED_STACK"}``.
+
+        Returns:
+            AlmaResponse wrapping the create response. The created
+            location body lives on ``response.data``.
+
+        Raises:
+            AlmaValidationError: If ``library_code`` is empty / not a
+                string, or if ``location_data`` is empty / not a dict /
+                missing any required field.
+            AlmaAPIError: On API failure (typed subclass when the Alma
+                error code or HTTP status maps to one — see
+                ``AlmaAPIClient._classify_error``).
+
+        Example:
+            >>> response = config.create_location(
+            ...     "MAIN",
+            ...     {
+            ...         "code": "STACKS",
+            ...         "name": "Main Stacks",
+            ...         "type": {"value": "OPEN"},
+            ...     },
+            ... )
+            >>> created_code = response.data.get("code")
+        """
+        # Pattern source: Admin.create_set (admin.py:598).
+        lib_code = self._validate_code(library_code, "library_code")
+        self._validate_location_data_for_create(location_data)
+        location_code = location_data.get("code")
+        location_name = location_data.get("name")
+
+        # ``type`` may be either a bare string or the canonical
+        # ``{"value": "..."}`` dict shape -- normalise here for the log
+        # record only; the body sent to Alma is forwarded verbatim.
+        raw_type = location_data.get("type")
+        type_value = (
+            raw_type.get("value") if isinstance(raw_type, dict) else raw_type
+        )
+
+        self.logger.info(
+            f"Creating location: {location_code} in library {lib_code}",
+            library_code=lib_code,
+            location_code=location_code,
+            location_name=location_name,
+            location_type=type_value,
+        )
+
+        try:
+            response = self.client.post(
+                f"almaws/v1/conf/libraries/{lib_code}/locations",
+                data=location_data,
+            )
+            created_code = None
+            try:
+                created_code = response.data.get("code")
+            except (ValueError, AttributeError):
+                # Body may not be JSON / dict; the response itself is
+                # still a valid AlmaResponse and we should hand it back.
+                created_code = None
+
+            if created_code:
+                self.logger.info(
+                    f"✓ Created location: {created_code} in library {lib_code}",
+                    library_code=lib_code,
+                    location_code=created_code,
+                )
+            else:
+                self.logger.info(
+                    f"✓ Created location in library {lib_code}",
+                    library_code=lib_code,
+                )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to create location {location_code} in library "
+                f"{lib_code}",
+                library_code=lib_code,
+                location_code=location_code,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def update_location(
+        self,
+        library_code: str,
+        location_code: str,
+        location_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Update an existing location's metadata.
+
+        Wraps
+        ``PUT /almaws/v1/conf/libraries/{libraryCode}/locations/{locationCode}``.
+        Alma expects a complete location object (see ``get_location`` for
+        the shape Alma returns); callers typically read the current
+        location, mutate the fields they want to change, and pass the
+        whole dict here.
+
+        Args:
+            library_code: The Alma library code that owns the location.
+            location_code: The location code to update.
+            location_data: Full location object payload. Must be a
+                non-empty dict.
+
+        Returns:
+            AlmaResponse wrapping the updated location object.
+
+        Raises:
+            AlmaValidationError: If either code is empty / not a string,
+                or ``location_data`` is empty / not a dict.
+            AlmaAPIError: On API failure.
+
+        Example:
+            >>> info = config.get_location("MAIN", "STACKS")
+            >>> info["name"] = "Main Stacks (renamed)"
+            >>> response = config.update_location("MAIN", "STACKS", info)
+        """
+        # Pattern source: Admin.update_set (admin.py:697).
+        lib_code = self._validate_code(library_code, "library_code")
+        loc_code = self._validate_code(location_code, "location_code")
+        if not isinstance(location_data, dict) or not location_data:
+            raise AlmaValidationError(
+                "location_data must be a non-empty dict"
+            )
+
+        self.logger.info(
+            f"Updating location: {loc_code} in library {lib_code}",
+            library_code=lib_code,
+            location_code=loc_code,
+            location_name=location_data.get("name"),
+        )
+
+        try:
+            response = self.client.put(
+                f"almaws/v1/conf/libraries/{lib_code}/locations/{loc_code}",
+                data=location_data,
+            )
+            self.logger.info(
+                f"✓ Updated location: {loc_code} in library {lib_code}",
+                library_code=lib_code,
+                location_code=loc_code,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to update location {loc_code} in library "
+                f"{lib_code}",
+                library_code=lib_code,
+                location_code=loc_code,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def delete_location(
+        self, library_code: str, location_code: str
+    ) -> AlmaResponse:
+        """Delete a location.
+
+        Wraps
+        ``DELETE /almaws/v1/conf/libraries/{libraryCode}/locations/{locationCode}``.
+
+        Failure mode: Alma rejects the delete with a typed 4xx error
+        when the location still has linked items (or holdings). This
+        method does NOT swallow that error — the underlying
+        ``AlmaAPIError`` propagates verbatim with its ``alma_code``,
+        ``tracking_id``, and message intact so callers can surface
+        Alma's own diagnostic to the operator.
+
+        Args:
+            library_code: The Alma library code that owns the location.
+            location_code: The location code to delete.
+
+        Returns:
+            AlmaResponse wrapping the delete response. Alma typically
+            returns an empty body on a successful delete.
+
+        Raises:
+            AlmaValidationError: If either code is empty / not a string.
+            AlmaAPIError: On API failure (e.g. when the location has
+                linked items the API surface refuses to orphan).
+        """
+        # Pattern source: Admin.delete_set (admin.py:756).
+        lib_code = self._validate_code(library_code, "library_code")
+        loc_code = self._validate_code(location_code, "location_code")
+
+        self.logger.info(
+            f"Deleting location: {loc_code} in library {lib_code}",
+            library_code=lib_code,
+            location_code=loc_code,
+        )
+
+        try:
+            response = self.client.delete(
+                f"almaws/v1/conf/libraries/{lib_code}/locations/{loc_code}"
+            )
+            self.logger.info(
+                f"✓ Deleted location: {loc_code} in library {lib_code}",
+                library_code=lib_code,
+                location_code=loc_code,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to delete location {loc_code} in library "
+                f"{lib_code}",
+                library_code=lib_code,
+                location_code=loc_code,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
             )
             raise

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -1,18 +1,24 @@
 """
 Configuration Domain Class for Alma API
-Foundation skeleton for the Configuration API surface (issue #22).
+Foundation skeleton for the Configuration API surface (issue #22), extended
+with organizational-structure read methods (issue #24).
 
-This module establishes the Configuration domain class with the minimal
-plumbing required by sibling tickets (issues 24-35) — environment
-introspection and a smoke-test connection check. Concrete API methods
-(libraries, locations, code tables, calendars, etc.) land in those
-sibling tickets and intentionally do NOT live here.
+Issue #22 established the Configuration domain class with the minimal
+plumbing required by sibling tickets — environment introspection and a
+smoke-test connection check.
 
-Pattern source: mirrors ``src/almaapitk/domains/admin.py`` and
-``src/almaapitk/domains/acquisition.py`` for ``__init__`` /
-``get_environment`` / ``test_connection`` shape.
+Issue #24 adds five read-only organizational-structure endpoints
+(libraries, departments, circulation desks). Concrete API methods for
+the remaining sibling tickets (locations, code tables, calendars, etc.)
+land in those tickets and intentionally do NOT live here.
 """
-from almaapitk.client.AlmaAPIClient import AlmaAPIClient
+from typing import Any, Dict, List
+
+from almaapitk.client.AlmaAPIClient import (
+    AlmaAPIClient,
+    AlmaAPIError,
+    AlmaValidationError,
+)
 from almaapitk.alma_logging import get_logger
 
 
@@ -20,10 +26,10 @@ class Configuration:
     """
     Domain class for handling Alma Configuration API operations.
 
-    This class is a foundation skeleton (issue #22). It establishes the
-    public-API entry point for configuration endpoints — concrete methods
-    (libraries, locations, code tables, calendars, etc.) ship in sibling
-    tickets (issues 24-35).
+    Foundation skeleton (issue #22) plus organizational-structure read
+    methods (issue #24). Sibling tickets (issues 25-35) layer additional
+    Configuration endpoints (locations, code tables, calendars, etc.) on
+    top of this class.
 
     This class uses the AlmaAPIClient as its foundation for all HTTP
     operations.
@@ -88,3 +94,277 @@ class Configuration:
             )
 
         return success
+
+    # =========================================================================
+    # Organizational structure (issue #24)
+    # =========================================================================
+
+    @staticmethod
+    def _validate_code(value: Any, field_name: str) -> str:
+        """Validate a code-style identifier.
+
+        Used by the per-library / per-circ-desk endpoints. The Alma API
+        treats library and circ-desk codes as opaque non-empty strings —
+        we only enforce that here and let the API surface domain-specific
+        errors (404, "Parameter value missing or invalid", etc.).
+
+        Args:
+            value: The candidate value passed by the caller.
+            field_name: The argument name to surface in the error message.
+
+        Returns:
+            The trimmed string when validation passes.
+
+        Raises:
+            AlmaValidationError: When the value is not a non-empty string.
+        """
+        if not isinstance(value, str):
+            raise AlmaValidationError(
+                f"{field_name} is required and must be a string"
+            )
+        trimmed = value.strip()
+        if not trimmed:
+            raise AlmaValidationError(f"{field_name} is required")
+        return trimmed
+
+    def list_libraries(self) -> List[Dict[str, Any]]:
+        """
+        List all libraries configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/libraries`` and unwraps the Alma
+        response envelope (``{"library": [...], "total_record_count": N}``)
+        into a flat list. The organizational-structure tables are small —
+        institutions typically have at most a few dozen libraries — so a
+        single call with a generous page size is sufficient.
+
+        Returns:
+            List of library dicts as returned by Alma. Returns an empty
+            list when the institution has no libraries configured (or
+            when the response envelope is missing the ``library`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Admin.list_sets shape (admin.py line 439) for the
+        # "single GET, return list" idiom — the org tables are tiny so we
+        # do not need iter_paged here.
+        self.logger.info(
+            f"Listing libraries ({self.environment})"
+        )
+        try:
+            # Use a generous page size so a single request covers any
+            # plausible institution. Alma caps at 100; libraries rarely
+            # exceed that.
+            response = self.client.get(
+                "almaws/v1/conf/libraries",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            libraries = payload.get("library") or []
+            if isinstance(libraries, dict):
+                # Single-record responses can come back as a dict; normalise.
+                libraries = [libraries]
+            self.logger.info(
+                f"✓ Retrieved {len(libraries)} libraries"
+            )
+            return libraries
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list libraries",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_library(self, library_code: str) -> Dict[str, Any]:
+        """
+        Get configuration details for a single library.
+
+        Calls ``GET /almaws/v1/conf/libraries/{libraryCode}``.
+
+        Args:
+            library_code: The Alma library code (e.g., ``"MAIN"``).
+
+        Returns:
+            The library configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``library_code`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the library code does not exist).
+        """
+        # Pattern source: Admin.get_set_info shape (admin.py line 313) —
+        # validate, log entry, GET, log success, propagate API errors.
+        code = self._validate_code(library_code, "library_code")
+        self.logger.info(
+            f"Getting library: {code} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/libraries/{code}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved library {code}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get library {code}",
+                extra={
+                    "library_code": code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def list_departments(self) -> List[Dict[str, Any]]:
+        """
+        List all departments configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/departments`` and unwraps the Alma
+        response envelope (``{"department": [...], "total_record_count": N}``)
+        into a flat list.
+
+        Returns:
+            List of department dicts. Returns an empty list when the
+            institution has no departments configured.
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Admin.list_sets shape (admin.py line 439).
+        self.logger.info(
+            f"Listing departments ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/departments",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            departments = payload.get("department") or []
+            if isinstance(departments, dict):
+                departments = [departments]
+            self.logger.info(
+                f"✓ Retrieved {len(departments)} departments"
+            )
+            return departments
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list departments",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def list_circ_desks(self, library_code: str) -> List[Dict[str, Any]]:
+        """
+        List circulation desks configured for a given library.
+
+        Calls ``GET /almaws/v1/conf/libraries/{libraryCode}/circ-desks``
+        and unwraps the Alma envelope
+        (``{"circ_desk": [...], "total_record_count": N}``) into a flat
+        list.
+
+        Args:
+            library_code: The Alma library code whose circ desks to list.
+
+        Returns:
+            List of circ-desk dicts. Returns an empty list when the
+            library has no circ desks configured.
+
+        Raises:
+            AlmaValidationError: If ``library_code`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Admin.list_sets shape (admin.py line 439) +
+        # Admin.get_set_info input validation (admin.py line 313).
+        code = self._validate_code(library_code, "library_code")
+        self.logger.info(
+            f"Listing circ desks for library {code} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/libraries/{code}/circ-desks",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            circ_desks = payload.get("circ_desk") or []
+            if isinstance(circ_desks, dict):
+                circ_desks = [circ_desks]
+            self.logger.info(
+                f"✓ Retrieved {len(circ_desks)} circ desks for library {code}"
+            )
+            return circ_desks
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to list circ desks for library {code}",
+                extra={
+                    "library_code": code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_circ_desk(
+        self, library_code: str, circ_desk_code: str
+    ) -> Dict[str, Any]:
+        """
+        Get configuration details for a single circulation desk.
+
+        Calls
+        ``GET /almaws/v1/conf/libraries/{libraryCode}/circ-desks/{circDeskCode}``.
+
+        Args:
+            library_code: The Alma library code that owns the circ desk.
+            circ_desk_code: The circulation-desk code.
+
+        Returns:
+            The circ-desk configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If either code is empty or not a string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the circ desk does not exist).
+        """
+        # Pattern source: Admin.get_set_info shape (admin.py line 313).
+        lib_code = self._validate_code(library_code, "library_code")
+        desk_code = self._validate_code(circ_desk_code, "circ_desk_code")
+        self.logger.info(
+            f"Getting circ desk {desk_code} for library {lib_code} "
+            f"({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/libraries/{lib_code}/circ-desks/{desk_code}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved circ desk {desk_code} for library {lib_code}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get circ desk {desk_code} for library {lib_code}",
+                extra={
+                    "library_code": lib_code,
+                    "circ_desk_code": desk_code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,34 +1,77 @@
 """
-Unit tests for the Configuration domain class (issue #22).
+Unit tests for the Configuration domain class (issues #22, #24).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
 - get_environment() - returns the environment from the underlying client
 - test_connection() - delegates to client.test_connection()
+- list_libraries() / get_library() (issue #24)
+- list_departments() (issue #24)
+- list_circ_desks() / get_circ_desk() (issue #24)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
-``tests/unit/domains/test_analytics.py``.
+``tests/unit/domains/test_admin.py`` for the get-shaped tests and
+``tests/unit/domains/test_analytics.py`` for the foundation skeleton.
 """
 
+from typing import Any, Dict, Optional
 from unittest.mock import MagicMock
 
 import pytest
 
 
+class MockAlmaResponse:
+    """Lightweight stand-in for ``almaapitk.AlmaResponse``.
+
+    Just enough surface area for the Configuration GET methods under
+    test: ``status_code``, ``success``, and ``.data`` / ``.json()`` both
+    backed by a single dict.
+    """
+
+    def __init__(
+        self,
+        body: Optional[Dict[str, Any]] = None,
+        status_code: int = 200,
+        success: bool = True,
+    ):
+        self._body = body if body is not None else {}
+        self.status_code = status_code
+        self.success = success
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+    @property
+    def data(self) -> Dict[str, Any]:
+        return self._body
+
+
 class MockAlmaAPIClient:
     """Mock AlmaAPIClient for testing the Configuration domain.
 
-    Mirrors the shape of ``MockAlmaAPIClient`` in
-    ``tests/unit/domains/test_analytics.py``.
+    The foundation tests (issue #22) only need ``get_environment`` and
+    ``test_connection``. The org-structure tests (issue #24) additionally
+    record GET calls so they can assert on URL / query params, and let
+    each test set the response (or a one-shot exception) per call.
     """
 
-    def __init__(self, environment: str = 'SANDBOX',
-                 connection_result: bool = True):
+    def __init__(
+        self,
+        environment: str = 'SANDBOX',
+        connection_result: bool = True,
+    ):
         self.environment = environment
         self.logger = MagicMock()
         self._connection_result = connection_result
         self.test_connection_call_count = 0
+
+        # Per-verb response register and call log for the issue-#24
+        # methods. Tests set ``get_response`` or ``next_exception`` before
+        # invoking the Configuration method under test.
+        self.get_response: MockAlmaResponse = MockAlmaResponse()
+        self.next_exception: Optional[Exception] = None
+        self.calls = {"get": []}
 
     def get_environment(self) -> str:
         return self.environment
@@ -36,6 +79,20 @@ class MockAlmaAPIClient:
     def test_connection(self) -> bool:
         self.test_connection_call_count += 1
         return self._connection_result
+
+    def get(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["get"].append(
+            {"endpoint": endpoint, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.get_response
 
 
 class TestConfigurationInit:
@@ -155,26 +212,421 @@ class TestConfigurationTestConnection:
         assert mock_client.test_connection_call_count == 1
 
 
-class TestConfigurationDoesNotCallHTTP:
-    """Foundation-only guard: no API methods should be wired up yet."""
+# ---------------------------------------------------------------------------
+# Issue #24: organizational structure read methods
+# ---------------------------------------------------------------------------
 
-    def test_no_api_endpoint_methods_yet(self):
-        """Foundation skeleton: only the trivial methods should exist.
 
-        Sibling tickets (issues 24-35) add concrete endpoint methods.
-        """
+class TestListLibraries:
+    """Tests for ``Configuration.list_libraries`` (issue #24)."""
+
+    def test_list_libraries_calls_correct_endpoint(self):
         from almaapitk.domains.configuration import Configuration
 
-        # Public methods that are NOT inherited from object — just the
-        # foundation skeleton.
-        public_methods = {
-            name for name in dir(Configuration)
-            if not name.startswith('_')
-        }
-        # Exactly the two foundation methods plus nothing else added by
-        # this PR. If a sibling ticket extends this set the assertion
-        # protects against accidental scope-creep in this PR specifically.
-        assert public_methods == {'get_environment', 'test_connection'}, (
-            f"Foundation skeleton must only expose get_environment and "
-            f"test_connection; found {public_methods}"
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "library": [
+                    {"code": "MAIN", "name": "Main Library"},
+                    {"code": "SCI", "name": "Science Library"},
+                ],
+                "total_record_count": 2,
+            }
         )
+        config = Configuration(mock_client)
+
+        result = config.list_libraries()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/libraries"
+        # We pass limit/offset to keep a single round-trip predictable.
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"] == "MAIN"
+
+    def test_list_libraries_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``library`` key → empty list, not None."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_libraries()
+
+        assert result == []
+
+    def test_list_libraries_handles_single_dict_response(self):
+        """A single library returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "library": {"code": "ONLY", "name": "Only Library"},
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_libraries()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["code"] == "ONLY"
+
+    def test_list_libraries_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_libraries()
+
+    def test_list_libraries_logs_success_count(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"library": [{"code": "A"}, {"code": "B"}]}
+        )
+        config = Configuration(mock_client)
+
+        config.list_libraries()
+
+        # logger.info was called at least once with a success summary.
+        # (Configuration uses alma_logging's get_logger, not the mock
+        # client's logger, so we just assert no errors fired.)
+        assert mock_client.next_exception is None
+
+
+class TestGetLibrary:
+    """Tests for ``Configuration.get_library`` (issue #24)."""
+
+    def test_get_library_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"code": "MAIN", "name": "Main Library", "type": {"value": "BRANCH"}}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_library("MAIN")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert mock_client.calls["get"][0]["endpoint"] == "almaws/v1/conf/libraries/MAIN"
+        assert isinstance(result, dict)
+        assert result["code"] == "MAIN"
+        assert result["name"] == "Main Library"
+
+    def test_get_library_strips_whitespace(self):
+        """Validator trims whitespace from the code before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"code": "MAIN"})
+        config = Configuration(mock_client)
+
+        config.get_library("  MAIN  ")
+
+        # The endpoint must contain the trimmed code.
+        assert mock_client.calls["get"][0]["endpoint"] == "almaws/v1/conf/libraries/MAIN"
+
+    def test_get_library_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_library("")
+
+    def test_get_library_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_library("   ")
+
+    def test_get_library_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_library(123)  # type: ignore[arg-type]
+
+    def test_get_library_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_library(None)  # type: ignore[arg-type]
+
+    def test_get_library_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "not found", status_code=404
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_library("NOPE")
+
+
+class TestListDepartments:
+    """Tests for ``Configuration.list_departments`` (issue #24)."""
+
+    def test_list_departments_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "department": [
+                    {"code": "ACQ", "name": "Acquisitions"},
+                    {"code": "CAT", "name": "Cataloging"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_departments()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/departments"
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"] == "ACQ"
+
+    def test_list_departments_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_departments() == []
+
+    def test_list_departments_handles_single_dict_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"department": {"code": "ACQ", "name": "Acquisitions"}}
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_departments()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["code"] == "ACQ"
+
+    def test_list_departments_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_departments()
+
+
+class TestListCircDesks:
+    """Tests for ``Configuration.list_circ_desks`` (issue #24)."""
+
+    def test_list_circ_desks_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "circ_desk": [
+                    {"code": "DESK1", "name": "Front Desk"},
+                    {"code": "DESK2", "name": "Reserve Desk"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_circ_desks("MAIN")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/libraries/MAIN/circ-desks"
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"] == "DESK1"
+
+    def test_list_circ_desks_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_circ_desks("MAIN") == []
+
+    def test_list_circ_desks_handles_single_dict_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"circ_desk": {"code": "DESK1", "name": "Front Desk"}}
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_circ_desks("MAIN")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["code"] == "DESK1"
+
+    def test_list_circ_desks_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.list_circ_desks("")
+
+    def test_list_circ_desks_rejects_non_string_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.list_circ_desks(42)  # type: ignore[arg-type]
+
+    def test_list_circ_desks_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_circ_desks("MAIN")
+
+
+class TestGetCircDesk:
+    """Tests for ``Configuration.get_circ_desk`` (issue #24)."""
+
+    def test_get_circ_desk_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"code": "DESK1", "name": "Front Desk"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_circ_desk("MAIN", "DESK1")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/circ-desks/DESK1"
+        )
+        assert isinstance(result, dict)
+        assert result["code"] == "DESK1"
+
+    def test_get_circ_desk_strips_whitespace(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"code": "DESK1"})
+        config = Configuration(mock_client)
+
+        config.get_circ_desk("  MAIN  ", "  DESK1  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/circ-desks/DESK1"
+        )
+
+    def test_get_circ_desk_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_circ_desk("", "DESK1")
+
+    def test_get_circ_desk_rejects_empty_desk_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_circ_desk("MAIN", "")
+
+    def test_get_circ_desk_rejects_whitespace_only_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_circ_desk("MAIN", "   ")
+
+    def test_get_circ_desk_rejects_non_string_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_circ_desk("MAIN", None)  # type: ignore[arg-type]
+
+    def test_get_circ_desk_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "not found", status_code=404
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_circ_desk("MAIN", "NOPE")

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the Configuration domain class (issues #22, #24).
+Unit tests for the Configuration domain class (issues #22, #24, #25).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
@@ -8,11 +8,14 @@ Tests cover:
 - list_libraries() / get_library() (issue #24)
 - list_departments() (issue #24)
 - list_circ_desks() / get_circ_desk() (issue #24)
+- list_locations() / get_location() / create_location() /
+  update_location() / delete_location() (issue #25)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
-``tests/unit/domains/test_admin.py`` for the get-shaped tests and
-``tests/unit/domains/test_analytics.py`` for the foundation skeleton.
+``tests/unit/domains/test_admin.py`` for the get-shaped and
+state-changing tests and ``tests/unit/domains/test_analytics.py`` for
+the foundation skeleton.
 """
 
 from typing import Any, Dict, Optional
@@ -66,12 +69,16 @@ class MockAlmaAPIClient:
         self._connection_result = connection_result
         self.test_connection_call_count = 0
 
-        # Per-verb response register and call log for the issue-#24
-        # methods. Tests set ``get_response`` or ``next_exception`` before
-        # invoking the Configuration method under test.
+        # Per-verb response register and call log for the issue-#24/#25
+        # methods. Tests set ``get_response`` / ``post_response`` /
+        # ``put_response`` / ``delete_response`` or ``next_exception``
+        # before invoking the Configuration method under test.
         self.get_response: MockAlmaResponse = MockAlmaResponse()
+        self.post_response: MockAlmaResponse = MockAlmaResponse()
+        self.put_response: MockAlmaResponse = MockAlmaResponse()
+        self.delete_response: MockAlmaResponse = MockAlmaResponse()
         self.next_exception: Optional[Exception] = None
-        self.calls = {"get": []}
+        self.calls = {"get": [], "post": [], "put": [], "delete": []}
 
     def get_environment(self) -> str:
         return self.environment
@@ -93,6 +100,50 @@ class MockAlmaAPIClient:
             exc, self.next_exception = self.next_exception, None
             raise exc
         return self.get_response
+
+    def post(
+        self,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["post"].append(
+            {"endpoint": endpoint, "data": data, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.post_response
+
+    def put(
+        self,
+        endpoint: str,
+        data: Optional[Dict[str, Any]] = None,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["put"].append(
+            {"endpoint": endpoint, "data": data, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.put_response
+
+    def delete(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["delete"].append(
+            {"endpoint": endpoint, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.delete_response
 
 
 class TestConfigurationInit:
@@ -630,3 +681,576 @@ class TestGetCircDesk:
 
         with pytest.raises(AlmaAPIError):
             config.get_circ_desk("MAIN", "NOPE")
+
+
+# ---------------------------------------------------------------------------
+# Issue #25: Locations CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestListLocations:
+    """Tests for ``Configuration.list_locations`` (issue #25)."""
+
+    def test_list_locations_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "location": [
+                    {"code": "STACKS", "name": "Main Stacks"},
+                    {"code": "REF", "name": "Reference"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_locations("MAIN")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/libraries/MAIN/locations"
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"] == "STACKS"
+
+    def test_list_locations_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_locations("MAIN") == []
+
+    def test_list_locations_handles_single_dict_response(self):
+        """A single location returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"location": {"code": "ONLY", "name": "Only Location"}}
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_locations("MAIN")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["code"] == "ONLY"
+
+    def test_list_locations_strips_whitespace_in_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"location": []})
+        config = Configuration(mock_client)
+
+        config.list_locations("  MAIN  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations"
+        )
+
+    def test_list_locations_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.list_locations("")
+
+    def test_list_locations_rejects_non_string_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.list_locations(42)  # type: ignore[arg-type]
+
+    def test_list_locations_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_locations("MAIN")
+
+
+class TestGetLocation:
+    """Tests for ``Configuration.get_location`` (issue #25)."""
+
+    def test_get_location_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "code": "STACKS",
+                "name": "Main Stacks",
+                "type": {"value": "OPEN"},
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_location("MAIN", "STACKS")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+        assert isinstance(result, dict)
+        assert result["code"] == "STACKS"
+        assert result["name"] == "Main Stacks"
+
+    def test_get_location_strips_whitespace(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"code": "STACKS"})
+        config = Configuration(mock_client)
+
+        config.get_location("  MAIN  ", "  STACKS  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+
+    def test_get_location_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_location("", "STACKS")
+
+    def test_get_location_rejects_empty_location_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_location("MAIN", "")
+
+    def test_get_location_rejects_whitespace_only_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_location("MAIN", "   ")
+
+    def test_get_location_rejects_non_string_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_location("MAIN", None)  # type: ignore[arg-type]
+
+    def test_get_location_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "not found", status_code=404
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_location("MAIN", "NOPE")
+
+
+class TestCreateLocation:
+    """Tests for ``Configuration.create_location`` (issue #25)."""
+
+    @staticmethod
+    def _valid_payload() -> Dict[str, Any]:
+        return {
+            "code": "STACKS",
+            "name": "Main Stacks",
+            "type": {"value": "OPEN"},
+        }
+
+    def test_create_location_calls_correct_endpoint_and_returns_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={
+                "code": "STACKS",
+                "name": "Main Stacks",
+                "type": {"value": "OPEN"},
+            }
+        )
+        config = Configuration(mock_client)
+
+        response = config.create_location("MAIN", self._valid_payload())
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/conf/libraries/MAIN/locations"
+        # Body is the location object directly (not wrapped).
+        assert call["data"] == self._valid_payload()
+        # AC: returns AlmaResponse-shaped object exposing .data.
+        assert response is mock_client.post_response
+        assert response.data["code"] == "STACKS"
+
+    def test_create_location_accepts_string_type(self):
+        """``type`` may be a bare string per the AC (mirrors create_set)."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"code": "STACKS"})
+        config = Configuration(mock_client)
+
+        payload = {"code": "STACKS", "name": "Main Stacks", "type": "OPEN"}
+        config.create_location("MAIN", payload)
+
+        # Body forwarded verbatim — string ``type`` is preserved.
+        assert mock_client.calls["post"][0]["data"]["type"] == "OPEN"
+
+    def test_create_location_strips_whitespace_in_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"code": "STACKS"})
+        config = Configuration(mock_client)
+
+        config.create_location("  MAIN  ", self._valid_payload())
+
+        assert (
+            mock_client.calls["post"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations"
+        )
+
+    def test_create_location_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location("", self._valid_payload())
+
+    def test_create_location_rejects_empty_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location("MAIN", {})
+
+    def test_create_location_rejects_non_dict_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location("MAIN", "not a dict")  # type: ignore[arg-type]
+
+    def test_create_location_rejects_missing_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location(
+                "MAIN",
+                {"name": "Main Stacks", "type": {"value": "OPEN"}},
+            )
+
+    def test_create_location_rejects_missing_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location(
+                "MAIN",
+                {"code": "STACKS", "type": {"value": "OPEN"}},
+            )
+
+    def test_create_location_rejects_missing_type(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location(
+                "MAIN", {"code": "STACKS", "name": "Main Stacks"}
+            )
+
+    def test_create_location_rejects_empty_string_type(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location(
+                "MAIN",
+                {"code": "STACKS", "name": "Main Stacks", "type": "   "},
+            )
+
+    def test_create_location_rejects_empty_dict_type_value(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.create_location(
+                "MAIN",
+                {
+                    "code": "STACKS",
+                    "name": "Main Stacks",
+                    "type": {"value": ""},
+                },
+            )
+
+    def test_create_location_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.create_location("MAIN", self._valid_payload())
+
+
+class TestUpdateLocation:
+    """Tests for ``Configuration.update_location`` (issue #25)."""
+
+    @staticmethod
+    def _valid_payload() -> Dict[str, Any]:
+        return {
+            "code": "STACKS",
+            "name": "Main Stacks (renamed)",
+            "type": {"value": "OPEN"},
+        }
+
+    def test_update_location_calls_correct_endpoint_and_returns_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"code": "STACKS", "name": "Main Stacks (renamed)"}
+        )
+        config = Configuration(mock_client)
+
+        response = config.update_location(
+            "MAIN", "STACKS", self._valid_payload()
+        )
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+        assert call["data"] == self._valid_payload()
+        assert response is mock_client.put_response
+        assert response.data["name"] == "Main Stacks (renamed)"
+
+    def test_update_location_strips_whitespace(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(body={"code": "STACKS"})
+        config = Configuration(mock_client)
+
+        config.update_location(
+            "  MAIN  ", "  STACKS  ", self._valid_payload()
+        )
+
+        assert (
+            mock_client.calls["put"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+
+    def test_update_location_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_location("", "STACKS", self._valid_payload())
+
+    def test_update_location_rejects_empty_location_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_location("MAIN", "", self._valid_payload())
+
+    def test_update_location_rejects_non_string_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_location(
+                "MAIN", 123, self._valid_payload()  # type: ignore[arg-type]
+            )
+
+    def test_update_location_rejects_empty_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_location("MAIN", "STACKS", {})
+
+    def test_update_location_rejects_non_dict_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_location(
+                "MAIN", "STACKS", "not a dict"  # type: ignore[arg-type]
+            )
+
+    def test_update_location_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.update_location("MAIN", "STACKS", self._valid_payload())
+
+
+class TestDeleteLocation:
+    """Tests for ``Configuration.delete_location`` (issue #25)."""
+
+    def test_delete_location_calls_correct_endpoint_and_returns_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        config = Configuration(mock_client)
+
+        response = config.delete_location("MAIN", "STACKS")
+
+        assert len(mock_client.calls["delete"]) == 1
+        assert (
+            mock_client.calls["delete"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+        assert response is mock_client.delete_response
+
+    def test_delete_location_strips_whitespace(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        config = Configuration(mock_client)
+
+        config.delete_location("  MAIN  ", "  STACKS  ")
+
+        assert (
+            mock_client.calls["delete"][0]["endpoint"]
+            == "almaws/v1/conf/libraries/MAIN/locations/STACKS"
+        )
+
+    def test_delete_location_rejects_empty_library_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.delete_location("", "STACKS")
+
+    def test_delete_location_rejects_empty_location_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.delete_location("MAIN", "")
+
+    def test_delete_location_rejects_non_string_codes(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.delete_location(None, "STACKS")  # type: ignore[arg-type]
+
+    def test_delete_location_propagates_linked_items_error_verbatim(self):
+        """Linked-items deletion failures must surface Alma's error
+        verbatim — we do NOT swallow them. The AC requires preserving
+        ``alma_code`` and ``tracking_id`` on the propagated exception so
+        callers can surface Alma's diagnostic to operators.
+        """
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Location has linked items",
+            status_code=400,
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.delete_location("MAIN", "STACKS")
+
+        # The original error message must be preserved verbatim.
+        assert "Location has linked items" in str(exc_info.value)
+
+    def test_delete_location_propagates_generic_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.delete_location("MAIN", "STACKS")


### PR DESCRIPTION
## Chunk: `config-orgs-and-locations`

Closes #24
Closes #25

## Implementation summary

Configuration class extended with read-only org-unit methods (#24: list_libraries, get_library, list_departments, list_circ_desks, get_circ_desk) and locations CRUD (#25: list_locations, create_location, get_location, update_location, delete_location). All validate input via AlmaValidationError, log entry/success/error through alma_logging, and propagate AlmaAPIError. create_location validates code/name/type before sending. Smoke + public-API contract green throughout.

## SANDBOX test summary

All 4 SANDBOX tests passed. #24 read smokes (t-24-1 list_libraries / get_library, list_circ_desks / get_circ_desk against supplied test fixtures; t-24-2 validation guards). #25 round-trip (t-25-1 create -> get -> list -> update -> delete on a UUID-suffixed location in the target library, with try/finally cleanup; t-25-2 validation guards). Both issues labelled tested:passing-needs-review per R4 (each has unmappable ACs).

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/config-orgs-and-locations/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
