### PR TITLE
chunk: config-tables (#26, #27)

### DIFF
--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -2,7 +2,8 @@
 Configuration Domain Class for Alma API
 Foundation skeleton for the Configuration API surface (issue #22), extended
 with organizational-structure read methods (issue #24), locations CRUD
-(issue #25), and code-tables list/get/replace (issue #26).
+(issue #25), code-tables list/get/replace (issue #26), and mapping-tables
+list/get/replace (issue #27).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
@@ -16,8 +17,14 @@ update / delete).
 
 Issue #26 adds code-tables coverage: list institution-wide code tables,
 fetch a single table (with rows), and replace an entire table via PUT.
-Concrete API methods for the remaining sibling tickets (calendars, etc.)
-land in those tickets and intentionally do NOT live here.
+
+Issue #27 adds mapping-tables coverage: list institution-wide mapping
+tables, fetch a single table (with rows), and replace an entire table
+via PUT. Mapping tables are structurally identical to code tables at the
+API surface — they differ only in semantic intent (mapping tables map a
+key to a value, code tables enumerate codes). Concrete API methods for
+the remaining sibling tickets (calendars, etc.) land in those tickets
+and intentionally do NOT live here.
 """
 from typing import Any, Dict, List
 
@@ -980,6 +987,195 @@ class Configuration:
             self.logger.error(
                 f"✗ Failed to update code table {name}",
                 code_table_name=name,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    # =========================================================================
+    # Mapping tables (issue #27)
+    #
+    # Identical shape to the code-tables block above (issue #26) — the Alma
+    # API surface is structurally the same; mapping tables and code tables
+    # differ only in semantic intent (mapping tables map a key to a value,
+    # code tables enumerate codes). The collection endpoint takes NO ``scope``
+    # parameter; same audit guidance as #26 applies — do not add one.
+    # =========================================================================
+
+    def list_mapping_tables(self) -> List[Dict[str, Any]]:
+        """List all mapping tables configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/mapping-tables`` and unwraps the Alma
+        response envelope
+        (``{"mapping_table": [...], "total_record_count": N}``) into a
+        flat list. The endpoint takes no ``scope`` filter — mirroring
+        :meth:`list_code_tables`, this method intentionally exposes no
+        filter parameters.
+
+        Returns:
+            List of mapping-table summary dicts (typically containing
+            ``name``, ``description``, ``sub_system``, etc.). Returns an
+            empty list when the institution has no mapping tables (or
+            when the response envelope is missing the ``mapping_table``
+            key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_code_tables (issue #26, above).
+        self.logger.info(
+            f"Listing mapping tables ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/mapping-tables",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            mapping_tables = payload.get("mapping_table") or []
+            if isinstance(mapping_tables, dict):
+                # Single-record responses can come back as a dict; normalise.
+                mapping_tables = [mapping_tables]
+            self.logger.info(
+                f"✓ Retrieved {len(mapping_tables)} mapping tables"
+            )
+            return mapping_tables
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list mapping tables",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_mapping_table(self, mapping_table_name: str) -> Dict[str, Any]:
+        """Get a single mapping table including all of its rows.
+
+        Calls ``GET /almaws/v1/conf/mapping-tables/{mappingTableName}``.
+        The full mapping-table object is returned unwrapped — including
+        the ``row`` collection that holds the table's individual entries
+        — so callers can mutate rows in place and pass the dict back to
+        :meth:`update_mapping_table`.
+
+        Args:
+            mapping_table_name: The Alma mapping-table name.
+
+        Returns:
+            The full mapping-table object as returned by Alma. Includes
+            metadata (``name``, ``description``, ``sub_system``, etc.)
+            and the ``row`` array of entries.
+
+        Raises:
+            AlmaValidationError: If ``mapping_table_name`` is empty or
+                not a string.
+            AlmaAPIError: If the API request fails (including 400 with
+                Alma error code ``90101`` "Table does not exist." for
+                an unknown table name).
+        """
+        # Pattern source: Configuration.get_code_table (issue #26, above).
+        name = self._validate_code(mapping_table_name, "mapping_table_name")
+        self.logger.info(
+            f"Getting mapping table: {name} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/mapping-tables/{name}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved mapping table {name}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get mapping table {name}",
+                extra={
+                    "mapping_table_name": name,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def update_mapping_table(
+        self,
+        mapping_table_name: str,
+        mapping_table_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Replace an entire mapping table.
+
+        Wraps ``PUT /almaws/v1/conf/mapping-tables/{mappingTableName}``.
+        **The PUT replaces the entire table — it is NOT a partial
+        update.** Alma requires the complete mapping-table object on the
+        wire, including every row that should remain in the table.
+        Mapping tables can be large; callers typically read the table
+        with :meth:`get_mapping_table`, mutate the dict (add / remove /
+        edit ``row`` entries), then pass the whole thing back here. Rows
+        omitted from the request body are dropped from the table.
+
+        Args:
+            mapping_table_name: The Alma mapping-table name.
+            mapping_table_data: Full mapping-table object payload. Must
+                be a non-empty dict.
+
+        Returns:
+            AlmaResponse wrapping the updated mapping-table object.
+
+        Raises:
+            AlmaValidationError: If ``mapping_table_name`` is empty / not
+                a string, or ``mapping_table_data`` is empty / not a
+                dict.
+            AlmaAPIError: On API failure. Notable Alma error codes for
+                this endpoint include ``90101`` ("Table does not
+                exist."), ``90102`` ("Requested table is hidden."),
+                ``90121`` / ``90127`` ("Requested table scope is not
+                legal."), ``90123`` ("Requested table is not
+                customizable"), and ``90126`` ("Mapping table name is
+                empty.").
+
+        Example:
+            >>> table = config.get_mapping_table("RecallDueDate")
+            >>> # Mutate rows in place — e.g. flip a row's enabled flag.
+            >>> for row in table.get("row", []):
+            ...     if row.get("column0") == "STAFF":
+            ...         row["enabled"] = {"value": "false"}
+            >>> response = config.update_mapping_table(
+            ...     "RecallDueDate", table
+            ... )
+        """
+        # Pattern source: Configuration.update_code_table (issue #26, above).
+        name = self._validate_code(mapping_table_name, "mapping_table_name")
+        if not isinstance(mapping_table_data, dict) or not mapping_table_data:
+            raise AlmaValidationError(
+                "mapping_table_data must be a non-empty dict"
+            )
+
+        self.logger.info(
+            f"Updating mapping table: {name}",
+            mapping_table_name=name,
+        )
+
+        try:
+            response = self.client.put(
+                f"almaws/v1/conf/mapping-tables/{name}",
+                data=mapping_table_data,
+            )
+            self.logger.info(
+                f"✓ Updated mapping table: {name}",
+                mapping_table_name=name,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to update mapping table {name}",
+                mapping_table_name=name,
                 error_code=e.status_code,
                 alma_code=getattr(e, "alma_code", ""),
                 tracking_id=getattr(e, "tracking_id", None),

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -1,8 +1,8 @@
 """
 Configuration Domain Class for Alma API
 Foundation skeleton for the Configuration API surface (issue #22), extended
-with organizational-structure read methods (issue #24) and locations CRUD
-(issue #25).
+with organizational-structure read methods (issue #24), locations CRUD
+(issue #25), and code-tables list/get/replace (issue #26).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
@@ -12,9 +12,12 @@ Issue #24 adds five read-only organizational-structure endpoints
 (libraries, departments, circulation desks).
 
 Issue #25 adds full CRUD for per-library locations (list / get / create /
-update / delete). Concrete API methods for the remaining sibling tickets
-(code tables, calendars, etc.) land in those tickets and intentionally do
-NOT live here.
+update / delete).
+
+Issue #26 adds code-tables coverage: list institution-wide code tables,
+fetch a single table (with rows), and replace an entire table via PUT.
+Concrete API methods for the remaining sibling tickets (calendars, etc.)
+land in those tickets and intentionally do NOT live here.
 """
 from typing import Any, Dict, List
 
@@ -785,6 +788,198 @@ class Configuration:
                 f"{lib_code}",
                 library_code=lib_code,
                 location_code=loc_code,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    # =========================================================================
+    # Code tables (issue #26)
+    #
+    # Read methods mirror ``Configuration.list_libraries`` /
+    # ``Configuration.get_library`` (issue #24): single GET, unwrap the Alma
+    # envelope (``{"code_table": [...], "total_record_count": N}`` for the
+    # collection endpoint), normalise dict→list, propagate AlmaAPIError with
+    # full context. The PUT mirrors ``Configuration.update_location``
+    # (issue #25): validate-up-top, log entry, ``self.client.put``, log
+    # success-with-name / error-with-context, return ``AlmaResponse`` or
+    # re-raise. The collection endpoint takes NO ``scope`` parameter — the
+    # Alma docs do not advertise one and an audit flagged it as
+    # undocumented; do not add it here.
+    # =========================================================================
+
+    def list_code_tables(self) -> List[Dict[str, Any]]:
+        """List all code tables configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/code-tables`` and unwraps the Alma
+        response envelope (``{"code_table": [...], "total_record_count": N}``)
+        into a flat list. The endpoint takes no ``scope`` filter — the
+        Alma documentation does not advertise one and an audit flagged
+        it as undocumented, so this method intentionally exposes no
+        filter parameters.
+
+        Returns:
+            List of code-table summary dicts (typically containing
+            ``name``, ``description``, ``sub_system``, etc.). Returns an
+            empty list when the institution has no code tables (or when
+            the response envelope is missing the ``code_table`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above).
+        self.logger.info(
+            f"Listing code tables ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/code-tables",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            code_tables = payload.get("code_table") or []
+            if isinstance(code_tables, dict):
+                # Single-record responses can come back as a dict; normalise.
+                code_tables = [code_tables]
+            self.logger.info(
+                f"✓ Retrieved {len(code_tables)} code tables"
+            )
+            return code_tables
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list code tables",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_code_table(self, code_table_name: str) -> Dict[str, Any]:
+        """Get a single code table including all of its rows.
+
+        Calls ``GET /almaws/v1/conf/code-tables/{codeTableName}``. The
+        full code-table object is returned unwrapped — including the
+        ``row`` collection that holds the table's individual entries —
+        so callers can mutate rows in place and pass the dict back to
+        :meth:`update_code_table`.
+
+        Args:
+            code_table_name: The Alma code-table name (e.g.
+                ``"AcqInvoiceLineType"``).
+
+        Returns:
+            The full code-table object as returned by Alma. Includes
+            metadata (``name``, ``description``, ``sub_system``, etc.)
+            and the ``row`` array of entries.
+
+        Raises:
+            AlmaValidationError: If ``code_table_name`` is empty or not
+                a string.
+            AlmaAPIError: If the API request fails (including 400 with
+                Alma error code ``90101`` "Table does not exist." for
+                an unknown table name).
+        """
+        # Pattern source: Configuration.get_library (issue #24, above).
+        name = self._validate_code(code_table_name, "code_table_name")
+        self.logger.info(
+            f"Getting code table: {name} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/code-tables/{name}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved code table {name}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get code table {name}",
+                extra={
+                    "code_table_name": name,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def update_code_table(
+        self, code_table_name: str, code_table_data: Dict[str, Any]
+    ) -> AlmaResponse:
+        """Replace an entire code table.
+
+        Wraps ``PUT /almaws/v1/conf/code-tables/{codeTableName}``. **The
+        PUT replaces the entire table — it is NOT a partial update.**
+        Alma requires the complete code-table object on the wire,
+        including every row that should remain in the table. Callers
+        typically read the table with :meth:`get_code_table`, mutate
+        the dict (add / remove / edit ``row`` entries), then pass the
+        whole thing back here. Rows omitted from the request body are
+        dropped from the table.
+
+        Args:
+            code_table_name: The Alma code-table name (e.g.
+                ``"AcqInvoiceLineType"``).
+            code_table_data: Full code-table object payload. Must be a
+                non-empty dict.
+
+        Returns:
+            AlmaResponse wrapping the updated code-table object.
+
+        Raises:
+            AlmaValidationError: If ``code_table_name`` is empty / not a
+                string, or ``code_table_data`` is empty / not a dict.
+            AlmaAPIError: On API failure. Notable Alma error codes for
+                this endpoint include ``90100`` ("Code table name is
+                empty."), ``90101`` ("Table does not exist."),
+                ``90102`` ("Requested table is hidden."), ``90121``
+                ("Requested table scope is not legal."), ``90122``
+                ("Multiple default codes."), and ``90123`` ("Requested
+                table is not customizable").
+
+        Example:
+            >>> table = config.get_code_table("AcqInvoiceLineType")
+            >>> # Mutate rows in place — e.g. flip a row's enabled flag.
+            >>> for row in table.get("row", []):
+            ...     if row.get("code") == "REGULAR":
+            ...         row["enabled"] = {"value": "false"}
+            >>> response = config.update_code_table(
+            ...     "AcqInvoiceLineType", table
+            ... )
+        """
+        # Pattern source: Configuration.update_location (issue #25, above).
+        name = self._validate_code(code_table_name, "code_table_name")
+        if not isinstance(code_table_data, dict) or not code_table_data:
+            raise AlmaValidationError(
+                "code_table_data must be a non-empty dict"
+            )
+
+        self.logger.info(
+            f"Updating code table: {name}",
+            code_table_name=name,
+        )
+
+        try:
+            response = self.client.put(
+                f"almaws/v1/conf/code-tables/{name}",
+                data=code_table_data,
+            )
+            self.logger.info(
+                f"✓ Updated code table: {name}",
+                code_table_name=name,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to update code table {name}",
+                code_table_name=name,
                 error_code=e.status_code,
                 alma_code=getattr(e, "alma_code", ""),
                 tracking_id=getattr(e, "tracking_id", None),

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -881,7 +881,13 @@ class Configuration:
         Returns:
             The full code-table object as returned by Alma. Includes
             metadata (``name``, ``description``, ``sub_system``, etc.)
-            and the ``row`` array of entries.
+            and a top-level ``row`` array of entries.
+
+            **Response-shape note:** the entries live at the top-level
+            ``row`` key (singular), NOT wrapped in ``rows.row``. Access
+            via ``table["row"]``. This differs from some other Alma
+            list endpoints (where the wrapper is ``{"rows": {"row":
+            [...]}}``) — verified live against SANDBOX 2026-05-07.
 
         Raises:
             AlmaValidationError: If ``code_table_name`` is empty or not
@@ -1068,7 +1074,13 @@ class Configuration:
         Returns:
             The full mapping-table object as returned by Alma. Includes
             metadata (``name``, ``description``, ``sub_system``, etc.)
-            and the ``row`` array of entries.
+            and a top-level ``row`` array of entries.
+
+            **Response-shape note:** the entries live at the top-level
+            ``row`` key (singular), NOT wrapped in ``rows.row``. Access
+            via ``table["row"]``. This mirrors :meth:`get_code_table`
+            and differs from some other Alma list endpoints whose
+            wrapper is ``{"rows": {"row": [...]}}``.
 
         Raises:
             AlmaValidationError: If ``mapping_table_name`` is empty or

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the Configuration domain class (issues #22, #24, #25, #26).
+Unit tests for the Configuration domain class (issues #22, #24, #25, #26, #27).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
@@ -11,6 +11,8 @@ Tests cover:
 - list_locations() / get_location() / create_location() /
   update_location() / delete_location() (issue #25)
 - list_code_tables() / get_code_table() / update_code_table() (issue #26)
+- list_mapping_tables() / get_mapping_table() / update_mapping_table()
+  (issue #27)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
@@ -1669,4 +1671,421 @@ class TestUpdateCodeTable:
         with pytest.raises(AlmaAPIError):
             config.update_code_table(
                 "AcqInvoiceLineType", self._valid_payload()
+            )
+
+
+# ---------------------------------------------------------------------------
+# Issue #27: Mapping tables (list / get / update)
+# ---------------------------------------------------------------------------
+
+
+class TestListMappingTables:
+    """Tests for ``Configuration.list_mapping_tables`` (issue #27)."""
+
+    def test_list_mapping_tables_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "mapping_table": [
+                    {
+                        "name": "RecallDueDate",
+                        "description": "Recall due-date overrides",
+                    },
+                    {
+                        "name": "FineFeeTransactionType",
+                        "description": "Fine/fee transaction types",
+                    },
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_mapping_tables()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/mapping-tables"
+        # Single round-trip with generous page size; no scope filter.
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["name"] == "RecallDueDate"
+
+    def test_list_mapping_tables_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``mapping_table`` key → empty list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_mapping_tables() == []
+
+    def test_list_mapping_tables_handles_single_dict_response(self):
+        """A single mapping-table returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "mapping_table": {
+                    "name": "OnlyTable",
+                    "description": "The only mapping table",
+                },
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_mapping_tables()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "OnlyTable"
+
+    def test_list_mapping_tables_does_not_send_scope_param(self):
+        """Audit-flagged: the endpoint takes NO ``scope`` parameter.
+
+        Mirrors the equivalent guard on ``list_code_tables`` (#26). The
+        AC explicitly forbids exposing a scope filter.
+        """
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"mapping_table": []}
+        )
+        config = Configuration(mock_client)
+
+        config.list_mapping_tables()
+
+        params = mock_client.calls["get"][0]["params"] or {}
+        assert "scope" not in params
+
+    def test_list_mapping_tables_signature_takes_no_args(self):
+        """list_mapping_tables takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_mapping_tables)
+        # Only ``self`` is allowed; no scope, no filter, no kwargs.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_mapping_tables_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_mapping_tables()
+
+
+class TestGetMappingTable:
+    """Tests for ``Configuration.get_mapping_table`` (issue #27)."""
+
+    def test_get_mapping_table_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "name": "RecallDueDate",
+                "description": "Recall due-date overrides",
+                "row": [
+                    {
+                        "column0": "STAFF",
+                        "column1": "7",
+                        "enabled": {"value": "true"},
+                    },
+                    {
+                        "column0": "STUDENT",
+                        "column1": "14",
+                        "enabled": {"value": "true"},
+                    },
+                ],
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_mapping_table("RecallDueDate")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/mapping-tables/RecallDueDate"
+        )
+        assert isinstance(result, dict)
+        assert result["name"] == "RecallDueDate"
+        # Full mapping-table object returned unwrapped, including rows.
+        assert isinstance(result["row"], list)
+        assert len(result["row"]) == 2
+        assert result["row"][0]["column0"] == "STAFF"
+
+    def test_get_mapping_table_returns_unwrapped_dict_with_rows(self):
+        """``get_mapping_table`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "name": "FineFeeTransactionType",
+                "row": [{"column0": "PAYMENT", "column1": "Payment"}],
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_mapping_table("FineFeeTransactionType")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "mapping_table" not in result
+        assert "total_record_count" not in result
+        # Direct access to the row collection works.
+        assert result["row"][0]["column0"] == "PAYMENT"
+
+    def test_get_mapping_table_strips_whitespace(self):
+        """Validator trims whitespace from the name before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"name": "RecallDueDate"}
+        )
+        config = Configuration(mock_client)
+
+        config.get_mapping_table("  RecallDueDate  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/mapping-tables/RecallDueDate"
+        )
+
+    def test_get_mapping_table_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_mapping_table("")
+
+    def test_get_mapping_table_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_mapping_table("   ")
+
+    def test_get_mapping_table_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_mapping_table(123)  # type: ignore[arg-type]
+
+    def test_get_mapping_table_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_mapping_table(None)  # type: ignore[arg-type]
+
+    def test_get_mapping_table_propagates_api_error(self):
+        """Alma 90101 (table does not exist) propagates as AlmaAPIError."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Table does not exist.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_mapping_table("NoSuchTable")
+
+
+class TestUpdateMappingTable:
+    """Tests for ``Configuration.update_mapping_table`` (issue #27)."""
+
+    @staticmethod
+    def _valid_payload() -> Dict[str, Any]:
+        # PUT replaces the entire table — payload mirrors what
+        # ``get_mapping_table`` returns, including the full ``row`` list.
+        return {
+            "name": "RecallDueDate",
+            "description": "Recall due-date overrides",
+            "row": [
+                {
+                    "column0": "STAFF",
+                    "column1": "7",
+                    "enabled": {"value": "true"},
+                },
+                {
+                    "column0": "STUDENT",
+                    "column1": "14",
+                    "enabled": {"value": "false"},
+                },
+            ],
+        }
+
+    def test_update_mapping_table_calls_correct_endpoint_and_returns_response(
+        self,
+    ):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={
+                "name": "RecallDueDate",
+                "description": "Recall due-date overrides",
+                "row": [
+                    {"column0": "STAFF", "enabled": {"value": "true"}},
+                    {"column0": "STUDENT", "enabled": {"value": "false"}},
+                ],
+            }
+        )
+        config = Configuration(mock_client)
+
+        response = config.update_mapping_table(
+            "RecallDueDate", self._valid_payload()
+        )
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/mapping-tables/RecallDueDate"
+        )
+        # Body forwarded verbatim — full table object on the wire.
+        assert call["data"] == self._valid_payload()
+        assert response is mock_client.put_response
+        assert response.data["name"] == "RecallDueDate"
+
+    def test_update_mapping_table_strips_whitespace_in_name(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"name": "RecallDueDate"}
+        )
+        config = Configuration(mock_client)
+
+        config.update_mapping_table(
+            "  RecallDueDate  ", self._valid_payload()
+        )
+
+        assert (
+            mock_client.calls["put"][0]["endpoint"]
+            == "almaws/v1/conf/mapping-tables/RecallDueDate"
+        )
+
+    def test_update_mapping_table_rejects_empty_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table("", self._valid_payload())
+
+    def test_update_mapping_table_rejects_whitespace_only_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table("   ", self._valid_payload())
+
+    def test_update_mapping_table_rejects_non_string_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table(
+                123, self._valid_payload()  # type: ignore[arg-type]
+            )
+
+    def test_update_mapping_table_rejects_empty_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table("RecallDueDate", {})
+
+    def test_update_mapping_table_rejects_non_dict_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table(
+                "RecallDueDate",
+                "not a dict",  # type: ignore[arg-type]
+            )
+
+    def test_update_mapping_table_rejects_none_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_mapping_table(
+                "RecallDueDate", None  # type: ignore[arg-type]
+            )
+
+    def test_update_mapping_table_propagates_api_error(self):
+        """Alma 90123 (table not customizable) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Requested table is not customizable", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.update_mapping_table(
+                "RecallDueDate", self._valid_payload()
+            )
+
+        assert "not customizable" in str(exc_info.value)
+
+    def test_update_mapping_table_propagates_generic_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.update_mapping_table(
+                "RecallDueDate", self._valid_payload()
             )

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the Configuration domain class (issues #22, #24, #25).
+Unit tests for the Configuration domain class (issues #22, #24, #25, #26).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
@@ -10,6 +10,7 @@ Tests cover:
 - list_circ_desks() / get_circ_desk() (issue #24)
 - list_locations() / get_location() / create_location() /
   update_location() / delete_location() (issue #25)
+- list_code_tables() / get_code_table() / update_code_table() (issue #26)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
@@ -1254,3 +1255,418 @@ class TestDeleteLocation:
 
         with pytest.raises(AlmaAPIError):
             config.delete_location("MAIN", "STACKS")
+
+
+# ---------------------------------------------------------------------------
+# Issue #26: Code tables (list / get / update)
+# ---------------------------------------------------------------------------
+
+
+class TestListCodeTables:
+    """Tests for ``Configuration.list_code_tables`` (issue #26)."""
+
+    def test_list_code_tables_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "code_table": [
+                    {
+                        "name": "AcqInvoiceLineType",
+                        "description": "Invoice line types",
+                    },
+                    {
+                        "name": "VendorReferenceNumberType",
+                        "description": "Vendor reference number types",
+                    },
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_code_tables()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/code-tables"
+        # Single round-trip with generous page size; no scope filter.
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["name"] == "AcqInvoiceLineType"
+
+    def test_list_code_tables_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``code_table`` key → empty list, not None."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_code_tables() == []
+
+    def test_list_code_tables_handles_single_dict_response(self):
+        """A single code-table returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "code_table": {
+                    "name": "OnlyTable",
+                    "description": "The only table",
+                },
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_code_tables()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["name"] == "OnlyTable"
+
+    def test_list_code_tables_does_not_send_scope_param(self):
+        """Audit-flagged: the endpoint takes NO ``scope`` parameter.
+
+        The AC explicitly forbids exposing a scope filter. This test
+        guards against a future regression where someone re-adds it.
+        """
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"code_table": []})
+        config = Configuration(mock_client)
+
+        config.list_code_tables()
+
+        params = mock_client.calls["get"][0]["params"] or {}
+        assert "scope" not in params
+
+    def test_list_code_tables_signature_takes_no_args(self):
+        """list_code_tables takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_code_tables)
+        # Only ``self`` is allowed; no scope, no filter, no kwargs.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_code_tables_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_code_tables()
+
+
+class TestGetCodeTable:
+    """Tests for ``Configuration.get_code_table`` (issue #26)."""
+
+    def test_get_code_table_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "name": "AcqInvoiceLineType",
+                "description": "Invoice line types",
+                "row": [
+                    {
+                        "code": "REGULAR",
+                        "description": "Regular line",
+                        "enabled": {"value": "true"},
+                    },
+                    {
+                        "code": "ADJUSTMENT",
+                        "description": "Adjustment line",
+                        "enabled": {"value": "true"},
+                    },
+                ],
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_code_table("AcqInvoiceLineType")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/code-tables/AcqInvoiceLineType"
+        )
+        assert isinstance(result, dict)
+        assert result["name"] == "AcqInvoiceLineType"
+        # The full code-table object is returned unwrapped, including rows.
+        assert isinstance(result["row"], list)
+        assert len(result["row"]) == 2
+        assert result["row"][0]["code"] == "REGULAR"
+
+    def test_get_code_table_returns_unwrapped_dict_with_rows(self):
+        """``get_code_table`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "name": "VendorReferenceNumberType",
+                "row": [{"code": "VRN", "description": "VRN"}],
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_code_table("VendorReferenceNumberType")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "code_table" not in result
+        assert "total_record_count" not in result
+        # Direct access to the row collection works.
+        assert result["row"][0]["code"] == "VRN"
+
+    def test_get_code_table_strips_whitespace(self):
+        """Validator trims whitespace from the name before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"name": "AcqInvoiceLineType"}
+        )
+        config = Configuration(mock_client)
+
+        config.get_code_table("  AcqInvoiceLineType  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/code-tables/AcqInvoiceLineType"
+        )
+
+    def test_get_code_table_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_code_table("")
+
+    def test_get_code_table_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_code_table("   ")
+
+    def test_get_code_table_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_code_table(123)  # type: ignore[arg-type]
+
+    def test_get_code_table_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_code_table(None)  # type: ignore[arg-type]
+
+    def test_get_code_table_propagates_api_error(self):
+        """Alma 90101 (table does not exist) propagates as AlmaAPIError."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Table does not exist.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_code_table("NoSuchTable")
+
+
+class TestUpdateCodeTable:
+    """Tests for ``Configuration.update_code_table`` (issue #26)."""
+
+    @staticmethod
+    def _valid_payload() -> Dict[str, Any]:
+        # PUT replaces the entire table — payload mirrors what
+        # ``get_code_table`` returns, including the full ``row`` list.
+        return {
+            "name": "AcqInvoiceLineType",
+            "description": "Invoice line types",
+            "row": [
+                {
+                    "code": "REGULAR",
+                    "description": "Regular line",
+                    "enabled": {"value": "true"},
+                },
+                {
+                    "code": "ADJUSTMENT",
+                    "description": "Adjustment line",
+                    "enabled": {"value": "false"},
+                },
+            ],
+        }
+
+    def test_update_code_table_calls_correct_endpoint_and_returns_response(
+        self,
+    ):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={
+                "name": "AcqInvoiceLineType",
+                "description": "Invoice line types",
+                "row": [
+                    {"code": "REGULAR", "enabled": {"value": "true"}},
+                    {"code": "ADJUSTMENT", "enabled": {"value": "false"}},
+                ],
+            }
+        )
+        config = Configuration(mock_client)
+
+        response = config.update_code_table(
+            "AcqInvoiceLineType", self._valid_payload()
+        )
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/code-tables/AcqInvoiceLineType"
+        )
+        # Body forwarded verbatim — full table object on the wire.
+        assert call["data"] == self._valid_payload()
+        assert response is mock_client.put_response
+        assert response.data["name"] == "AcqInvoiceLineType"
+
+    def test_update_code_table_strips_whitespace_in_name(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"name": "AcqInvoiceLineType"}
+        )
+        config = Configuration(mock_client)
+
+        config.update_code_table(
+            "  AcqInvoiceLineType  ", self._valid_payload()
+        )
+
+        assert (
+            mock_client.calls["put"][0]["endpoint"]
+            == "almaws/v1/conf/code-tables/AcqInvoiceLineType"
+        )
+
+    def test_update_code_table_rejects_empty_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table("", self._valid_payload())
+
+    def test_update_code_table_rejects_whitespace_only_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table("   ", self._valid_payload())
+
+    def test_update_code_table_rejects_non_string_name(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table(
+                123, self._valid_payload()  # type: ignore[arg-type]
+            )
+
+    def test_update_code_table_rejects_empty_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table("AcqInvoiceLineType", {})
+
+    def test_update_code_table_rejects_non_dict_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table(
+                "AcqInvoiceLineType",
+                "not a dict",  # type: ignore[arg-type]
+            )
+
+    def test_update_code_table_rejects_none_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_code_table(
+                "AcqInvoiceLineType", None  # type: ignore[arg-type]
+            )
+
+    def test_update_code_table_propagates_api_error(self):
+        """Alma 90123 (table not customizable) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Requested table is not customizable", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.update_code_table(
+                "AcqInvoiceLineType", self._valid_payload()
+            )
+
+        assert "not customizable" in str(exc_info.value)
+
+    def test_update_code_table_propagates_generic_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.update_code_table(
+                "AcqInvoiceLineType", self._valid_payload()
+            )


### PR DESCRIPTION
## Chunk: `config-tables`

Closes #26
Closes #27

## Implementation summary

Configuration class extended with list/get/update for code-tables (#26) and mapping-tables (#27). All validate input via AlmaValidationError, log entry/success/error, propagate AlmaAPIError. Plus a docstring clarification on get_code_table / get_mapping_table noting the response shape uses top-level row (singular) NOT rows.row.

## SANDBOX test summary

All 4 SANDBOX tests passed. #26 read smokes + validation guards on the supplied test code-table. #27 read smokes + validation guards on the supplied test mapping-table. PUT round-trips deliberately skipped (institution-wide config). Both issues labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/config-tables/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
