### PR TITLE
chunk: config-grab-bag-1 (#30, #33, #35)

### DIFF
--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -2,8 +2,9 @@
 Configuration Domain Class for Alma API
 Foundation skeleton for the Configuration API surface (issue #22), extended
 with organizational-structure read methods (issue #24), locations CRUD
-(issue #25), code-tables list/get/replace (issue #26), and mapping-tables
-list/get/replace (issue #27).
+(issue #25), code-tables list/get/replace (issue #26), mapping-tables
+list/get/replace (issue #27), and deposit / metadata-import profile read
+methods (issue #30).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
@@ -22,9 +23,13 @@ Issue #27 adds mapping-tables coverage: list institution-wide mapping
 tables, fetch a single table (with rows), and replace an entire table
 via PUT. Mapping tables are structurally identical to code tables at the
 API surface — they differ only in semantic intent (mapping tables map a
-key to a value, code tables enumerate codes). Concrete API methods for
-the remaining sibling tickets (calendars, etc.) land in those tickets
-and intentionally do NOT live here.
+key to a value, code tables enumerate codes).
+
+Issue #30 adds read-only coverage for deposit profiles and metadata
+import (md-import) profiles: list / get on each. All four endpoints are
+plain GETs and mirror the libraries read shape from issue #24. Concrete
+API methods for the remaining sibling tickets (calendars, etc.) land in
+those tickets and intentionally do NOT live here.
 """
 from typing import Any, Dict, List
 
@@ -1192,5 +1197,202 @@ class Configuration:
                 alma_code=getattr(e, "alma_code", ""),
                 tracking_id=getattr(e, "tracking_id", None),
                 error_message=str(e),
+            )
+            raise
+
+    # =========================================================================
+    # Deposit profiles + metadata-import profiles (issue #30)
+    #
+    # All four endpoints are plain GETs. The list shapes mirror
+    # ``Configuration.list_libraries`` (issue #24): single GET, unwrap the
+    # Alma envelope, normalise dict→list, propagate AlmaAPIError with full
+    # context. The get shapes mirror ``Configuration.get_library``
+    # (issue #24): validate the id, GET, return the unwrapped dict, propagate
+    # AlmaAPIError. Issue #30 is read-only — no mutators belong here.
+    # =========================================================================
+
+    def list_deposit_profiles(self) -> List[Dict[str, Any]]:
+        """List all deposit profiles configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/deposit-profiles`` and unwraps the
+        Alma response envelope
+        (``{"deposit_profile": [...], "total_record_count": N}``) into a
+        flat list. Deposit profiles are typically few — a single call
+        with a generous page size is sufficient.
+
+        Returns:
+            List of deposit-profile dicts as returned by Alma. Returns an
+            empty list when the institution has no deposit profiles
+            configured (or when the response envelope is missing the
+            ``deposit_profile`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above).
+        self.logger.info(
+            f"Listing deposit profiles ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/deposit-profiles",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            deposit_profiles = payload.get("deposit_profile") or []
+            if isinstance(deposit_profiles, dict):
+                # Single-record responses can come back as a dict; normalise.
+                deposit_profiles = [deposit_profiles]
+            self.logger.info(
+                f"✓ Retrieved {len(deposit_profiles)} deposit profiles"
+            )
+            return deposit_profiles
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list deposit profiles",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_deposit_profile(
+        self, deposit_profile_id: str
+    ) -> Dict[str, Any]:
+        """Get configuration details for a single deposit profile.
+
+        Calls ``GET /almaws/v1/conf/deposit-profiles/{deposit_profile_id}``.
+
+        Args:
+            deposit_profile_id: The Alma deposit-profile identifier.
+
+        Returns:
+            The deposit-profile configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``deposit_profile_id`` is empty or
+                not a string.
+            AlmaAPIError: If the API request fails (including 4xx when
+                the profile id does not exist).
+        """
+        # Pattern source: Configuration.get_library (issue #24, above).
+        profile_id = self._validate_code(
+            deposit_profile_id, "deposit_profile_id"
+        )
+        self.logger.info(
+            f"Getting deposit profile: {profile_id} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/deposit-profiles/{profile_id}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved deposit profile {profile_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get deposit profile {profile_id}",
+                extra={
+                    "deposit_profile_id": profile_id,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def list_import_profiles(self) -> List[Dict[str, Any]]:
+        """List all metadata-import profiles configured in the institution.
+
+        Calls ``GET /almaws/v1/conf/md-import-profiles`` and unwraps the
+        Alma response envelope
+        (``{"import_profile": [...], "total_record_count": N}``) into a
+        flat list. The Alma developer-network docs use ``import_profile``
+        as the singular envelope key for this endpoint; the older
+        ``md_import_profile`` form has not been observed on the wire.
+
+        Returns:
+            List of import-profile dicts as returned by Alma. Returns an
+            empty list when the institution has no import profiles
+            configured (or when the response envelope is missing the
+            ``import_profile`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above).
+        self.logger.info(
+            f"Listing import profiles ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/md-import-profiles",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            import_profiles = payload.get("import_profile") or []
+            if isinstance(import_profiles, dict):
+                # Single-record responses can come back as a dict; normalise.
+                import_profiles = [import_profiles]
+            self.logger.info(
+                f"✓ Retrieved {len(import_profiles)} import profiles"
+            )
+            return import_profiles
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list import profiles",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_import_profile(self, profile_id: str) -> Dict[str, Any]:
+        """Get configuration details for a single metadata-import profile.
+
+        Calls ``GET /almaws/v1/conf/md-import-profiles/{profile_id}``.
+
+        Args:
+            profile_id: The Alma metadata-import-profile identifier.
+
+        Returns:
+            The import-profile configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``profile_id`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails. Notable Alma error
+                code for this endpoint: ``401871`` ("Failed to find the
+                Profile ID.") for an unknown profile id.
+        """
+        # Pattern source: Configuration.get_library (issue #24, above).
+        pid = self._validate_code(profile_id, "profile_id")
+        self.logger.info(
+            f"Getting import profile: {pid} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/md-import-profiles/{pid}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved import profile {pid}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get import profile {pid}",
+                extra={
+                    "profile_id": pid,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
             )
             raise

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -3,8 +3,9 @@ Configuration Domain Class for Alma API
 Foundation skeleton for the Configuration API surface (issue #22), extended
 with organizational-structure read methods (issue #24), locations CRUD
 (issue #25), code-tables list/get/replace (issue #26), mapping-tables
-list/get/replace (issue #27), and deposit / metadata-import profile read
-methods (issue #30).
+list/get/replace (issue #27), deposit / metadata-import profile read
+methods (issue #30), and letters + printers read coverage plus letter
+update (issue #33).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
@@ -27,9 +28,13 @@ key to a value, code tables enumerate codes).
 
 Issue #30 adds read-only coverage for deposit profiles and metadata
 import (md-import) profiles: list / get on each. All four endpoints are
-plain GETs and mirror the libraries read shape from issue #24. Concrete
-API methods for the remaining sibling tickets (calendars, etc.) land in
-those tickets and intentionally do NOT live here.
+plain GETs and mirror the libraries read shape from issue #24.
+
+Issue #33 adds letters list/get/update plus printers list/get. The PUT
+on /almaws/v1/conf/letters/{letterCode} replaces the entire letter
+template (subject + XSL body) — Alma does not support partial updates.
+Concrete API methods for the remaining sibling tickets (calendars, etc.)
+land in those tickets and intentionally do NOT live here.
 """
 from typing import Any, Dict, List
 
@@ -1390,6 +1395,291 @@ class Configuration:
                 f"✗ Failed to get import profile {pid}",
                 extra={
                     "profile_id": pid,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    # =========================================================================
+    # Letters + printers (issue #33)
+    #
+    # Read shapes mirror ``Configuration.list_libraries`` /
+    # ``Configuration.get_library`` (issue #24): single GET, unwrap the Alma
+    # envelope, normalise dict→list for collections, propagate AlmaAPIError
+    # with full context. The PUT on letters mirrors
+    # ``Configuration.update_code_table`` / ``Configuration.update_mapping_table``
+    # (issues #26 / #27): validate-up-top, log entry, ``self.client.put``,
+    # log success-with-name / error-with-context, return ``AlmaResponse`` or
+    # re-raise. The Alma PUT on /letters/{letterCode} replaces the entire
+    # letter template (subject + XSL body) — partial updates are not
+    # supported by the API surface (60343 "The update failed.",
+    # 40166411 "Letter code or other parameter is not valid.").
+    # =========================================================================
+
+    def list_letters(self) -> List[Dict[str, Any]]:
+        """List all letters configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/letters`` and unwraps the Alma
+        response envelope (``{"letter": [...], "total_record_count": N}``)
+        into a flat list. Letters define the templates Alma uses to
+        render notifications (overdue, hold-pickup, fulfillment, etc.) —
+        the catalogue is small (a few hundred at most) so a single call
+        with a generous page size is sufficient.
+
+        Returns:
+            List of letter dicts as returned by Alma. Returns an empty
+            list when the institution has no letters configured (or when
+            the response envelope is missing the ``letter`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails. Notable Alma error
+                code for this endpoint: ``60344`` ("Problem retrieving
+                letter data.").
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above).
+        self.logger.info(
+            f"Listing letters ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/letters",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            letters = payload.get("letter") or []
+            if isinstance(letters, dict):
+                # Single-record responses can come back as a dict; normalise.
+                letters = [letters]
+            self.logger.info(
+                f"✓ Retrieved {len(letters)} letters"
+            )
+            return letters
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list letters",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_letter(self, letter_code: str) -> Dict[str, Any]:
+        """Get a single letter's full configuration including its template.
+
+        Calls ``GET /almaws/v1/conf/letters/{letterCode}``. The full
+        letter object is returned unwrapped — including ``subject``,
+        ``body``, ``description``, ``enabled``, ``letter_name``, and the
+        ``letter_template_xsl`` payload that holds the XSL template.
+        Callers typically read the letter, mutate the dict (edit
+        subject / template), and pass the whole thing back to
+        :meth:`update_letter`.
+
+        Args:
+            letter_code: The Alma letter code (e.g. ``"OverdueAndLostLoanLetter"``).
+
+        Returns:
+            The full letter object as returned by Alma. The response is
+            the raw Alma payload — sub-objects like ``subject``,
+            ``body``, ``description``, ``enabled``, ``letter_name``, and
+            ``letter_template_xsl`` are surfaced verbatim.
+
+        Raises:
+            AlmaValidationError: If ``letter_code`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails. Notable Alma error
+                codes for this endpoint: ``60344`` ("Problem retrieving
+                letter data.") and ``40166411`` ("Letter code is not
+                valid.") for an unknown letter code.
+        """
+        # Pattern source: Configuration.get_library (issue #24, above).
+        code = self._validate_code(letter_code, "letter_code")
+        self.logger.info(
+            f"Getting letter: {code} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/letters/{code}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved letter {code}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get letter {code}",
+                extra={
+                    "letter_code": code,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def update_letter(
+        self, letter_code: str, letter_data: Dict[str, Any]
+    ) -> AlmaResponse:
+        """Replace an entire letter template.
+
+        Wraps ``PUT /almaws/v1/conf/letters/{letterCode}``. **The PUT
+        replaces the entire letter — it is NOT a partial update.** Alma
+        requires the complete letter object on the wire (subject, body,
+        XSL template, enabled flag, etc.). Callers typically read the
+        letter with :meth:`get_letter`, mutate the dict (edit the
+        subject text or the ``letter_template_xsl`` body), then pass
+        the whole thing back here. Fields omitted from the request body
+        are dropped from the letter.
+
+        Args:
+            letter_code: The Alma letter code (e.g.
+                ``"OverdueAndLostLoanLetter"``).
+            letter_data: Full letter object payload. Must be a non-empty
+                dict.
+
+        Returns:
+            AlmaResponse wrapping the updated letter object.
+
+        Raises:
+            AlmaValidationError: If ``letter_code`` is empty / not a
+                string, or ``letter_data`` is empty / not a dict.
+            AlmaAPIError: On API failure. Notable Alma error codes for
+                this endpoint include ``60105`` ("JSON is not supported
+                for this API." — letters require XML), ``60343`` ("The
+                update failed."), ``60344`` ("Problem retrieving letter
+                data."), and ``40166411`` ("Letter code or other
+                parameter is not valid.").
+
+        Example:
+            >>> letter = config.get_letter("OverdueAndLostLoanLetter")
+            >>> letter["subject"] = "Overdue notice — please return"
+            >>> response = config.update_letter(
+            ...     "OverdueAndLostLoanLetter", letter
+            ... )
+        """
+        # Pattern source: Configuration.update_code_table (issue #26, above).
+        code = self._validate_code(letter_code, "letter_code")
+        if not isinstance(letter_data, dict) or not letter_data:
+            raise AlmaValidationError(
+                "letter_data must be a non-empty dict"
+            )
+
+        self.logger.info(
+            f"Updating letter: {code}",
+            letter_code=code,
+        )
+
+        try:
+            response = self.client.put(
+                f"almaws/v1/conf/letters/{code}",
+                data=letter_data,
+            )
+            self.logger.info(
+                f"✓ Updated letter: {code}",
+                letter_code=code,
+            )
+            return response
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to update letter {code}",
+                letter_code=code,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def list_printers(self) -> List[Dict[str, Any]]:
+        """List all printers configured in the Alma institution.
+
+        Calls ``GET /almaws/v1/conf/printers`` and unwraps the Alma
+        response envelope (``{"printer": [...], "total_record_count": N}``)
+        into a flat list. The printer catalogue is institution-wide and
+        typically small — a single call with a generous page size is
+        sufficient.
+
+        Returns:
+            List of printer dicts as returned by Alma. Returns an empty
+            list when the institution has no printers configured (or
+            when the response envelope is missing the ``printer`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails. Notable Alma error
+                codes for this endpoint: ``402469`` ("The library code
+                is not valid.") and ``40166410`` ("Invalid parameter.").
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above).
+        self.logger.info(
+            f"Listing printers ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/printers",
+                params={"limit": "100", "offset": "0"},
+            )
+            payload = response.json() or {}
+            printers = payload.get("printer") or []
+            if isinstance(printers, dict):
+                # Single-record responses can come back as a dict; normalise.
+                printers = [printers]
+            self.logger.info(
+                f"✓ Retrieved {len(printers)} printers"
+            )
+            return printers
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to list printers",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_printer(self, printer_id: str) -> Dict[str, Any]:
+        """Get configuration details for a single printer.
+
+        Calls ``GET /almaws/v1/conf/printers/{printer_id}``.
+
+        Args:
+            printer_id: The Alma printer identifier.
+
+        Returns:
+            The printer configuration dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``printer_id`` is empty or not a
+                string.
+            AlmaAPIError: If the API request fails. Notable Alma error
+                code for this endpoint: ``402899`` ("Invalid Printer
+                ID.") for an unknown printer id.
+        """
+        # Pattern source: Configuration.get_library (issue #24, above).
+        pid = self._validate_code(printer_id, "printer_id")
+        self.logger.info(
+            f"Getting printer: {pid} ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                f"almaws/v1/conf/printers/{pid}"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Retrieved printer {pid}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to get printer {pid}",
+                extra={
+                    "printer_id": pid,
                     "alma_code": getattr(e, "alma_code", ""),
                     "tracking_id": getattr(e, "tracking_id", None),
                     "status_code": getattr(e, "status_code", None),

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -4,8 +4,9 @@ Foundation skeleton for the Configuration API surface (issue #22), extended
 with organizational-structure read methods (issue #24), locations CRUD
 (issue #25), code-tables list/get/replace (issue #26), mapping-tables
 list/get/replace (issue #27), deposit / metadata-import profile read
-methods (issue #30), and letters + printers read coverage plus letter
-update (issue #33).
+methods (issue #30), letters + printers read coverage plus letter
+update (issue #33), and the workflow-runner / fee-transactions /
+general-configuration utility endpoints (issue #35).
 
 Issue #22 established the Configuration domain class with the minimal
 plumbing required by sibling tickets — environment introspection and a
@@ -33,10 +34,17 @@ plain GETs and mirror the libraries read shape from issue #24.
 Issue #33 adds letters list/get/update plus printers list/get. The PUT
 on /almaws/v1/conf/letters/{letterCode} replaces the entire letter
 template (subject + XSL body) — Alma does not support partial updates.
+
+Issue #35 adds the workflow runner (POST /conf/workflows/{workflow_id})
+and two utility GETs: fee-transactions report
+(/conf/utilities/fee-transactions) and general institutional
+configuration (/conf/general). The workflow runner has real side
+effects — callers must restrict it to known-safe workflow ids.
+
 Concrete API methods for the remaining sibling tickets (calendars, etc.)
 land in those tickets and intentionally do NOT live here.
 """
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from almaapitk.client.AlmaAPIClient import (
     AlmaAPIClient,
@@ -1680,6 +1688,225 @@ class Configuration:
                 f"✗ Failed to get printer {pid}",
                 extra={
                     "printer_id": pid,
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    # =========================================================================
+    # Workflows runner + utilities (issue #35)
+    #
+    # Three small endpoints round out the Configuration grab-bag:
+    #
+    #   POST /almaws/v1/conf/workflows/{workflow_id}
+    #     -- triggers a configured workflow. Side effects depend entirely
+    #        on the workflow's configuration; callers must restrict
+    #        themselves to known-safe workflow ids.
+    #
+    #   GET  /almaws/v1/conf/utilities/fee-transactions
+    #     -- fee-transactions report. Filter set is operator-supplied
+    #        (status, library, from_date, to_date, ...). Envelope key is
+    #        ``fee_transaction``.
+    #
+    #   GET  /almaws/v1/conf/general
+    #     -- general institutional configuration. Returned unwrapped.
+    #
+    # Pattern sources called out per-method below.
+    # =========================================================================
+
+    def run_workflow(
+        self,
+        workflow_id: str,
+        parameters: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Execute a configured Alma workflow.
+
+        Wraps ``POST /almaws/v1/conf/workflows/{workflow_id}``.
+
+        **WARNING:** This method actually triggers an Alma workflow.
+        Side effects depend entirely on the workflow's configuration —
+        a workflow can mutate records, send notifications, kick off
+        long-running jobs, etc. Test against a known-safe ``workflow_id``
+        only; never bind this method to untrusted input.
+
+        Args:
+            workflow_id: The Alma workflow identifier to execute.
+            parameters: Optional workflow-specific parameter payload.
+                When provided, sent as the JSON request body. When
+                ``None``, no body is sent — Alma accepts a parameterless
+                workflow trigger.
+
+        Returns:
+            The parsed response dict from Alma. Alma typically returns a
+            workflow-instance object containing at least an instance id
+            and a status code; the exact shape varies per workflow.
+
+        Raises:
+            AlmaValidationError: If ``workflow_id`` is empty or not a
+                string.
+            AlmaAPIError: On API failure. Notable Alma error codes for
+                this endpoint include ``450001`` ("Workflow not
+                found."), ``450002`` ("Workflow inactive."), ``450003``
+                ("Workflow missing trigger node."), and ``450004``
+                ("Workflow missing trigger configuration.").
+
+        Example:
+            >>> result = config.run_workflow(
+            ...     "MY_SAFE_TEST_WORKFLOW",
+            ...     {"input_param": "value"},
+            ... )
+            >>> instance_id = result.get("id")
+        """
+        # Pattern source: Configuration.update_letter (issue #33, above) for
+        # the validate -> log entry -> client.<verb> -> log success -> on
+        # AlmaAPIError, log + re-raise shape; Configuration.get_library
+        # (issue #24) for unwrapping the response body via response.json().
+        wf_id = self._validate_code(workflow_id, "workflow_id")
+
+        self.logger.info(
+            f"Running workflow: {wf_id} ({self.environment})",
+            workflow_id=wf_id,
+            has_parameters=parameters is not None,
+        )
+
+        try:
+            response = self.client.post(
+                f"almaws/v1/conf/workflows/{wf_id}",
+                data=parameters,
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"✓ Ran workflow: {wf_id}",
+                workflow_id=wf_id,
+            )
+            return data
+
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"✗ Failed to run workflow {wf_id}",
+                workflow_id=wf_id,
+                error_code=e.status_code,
+                alma_code=getattr(e, "alma_code", ""),
+                tracking_id=getattr(e, "tracking_id", None),
+                error_message=str(e),
+            )
+            raise
+
+    def get_fee_transactions_report(
+        self, **filters: Any
+    ) -> List[Dict[str, Any]]:
+        """Fetch the Alma fee-transactions report.
+
+        Wraps ``GET /almaws/v1/conf/utilities/fee-transactions`` and
+        unwraps the Alma response envelope
+        (``{"fee_transaction": [...], "total_record_count": N}``) into a
+        flat list. The endpoint accepts a flexible set of filters
+        (``status``, ``library``, ``from_date``, ``to_date``,
+        ``transaction_type``, etc.); rather than enumerate them in the
+        signature this method forwards arbitrary keyword args verbatim
+        as query parameters so callers can drive any filter Alma
+        accepts.
+
+        Args:
+            **filters: Arbitrary query-parameter filters forwarded to
+                Alma. Common filters per the Alma docs:
+
+                - ``status`` (str): transaction status filter.
+                - ``library`` (str): library code to scope the report.
+                - ``from_date`` (str): inclusive lower bound (YYYY-MM-DD).
+                - ``to_date`` (str): inclusive upper bound (YYYY-MM-DD).
+                - ``transaction_type`` (str): transaction-type filter.
+
+        Returns:
+            List of fee-transaction dicts as returned by Alma. Returns
+            an empty list when no matching transactions are found (or
+            when the response envelope is missing the
+            ``fee_transaction`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails. Notable Alma error
+                codes for this endpoint include ``401652`` ("An error
+                has occurred in setting circ library or circ desk."),
+                ``40166410`` ("An error has occurred in setting from
+                and/or to dates."), and ``40166413`` ("An error has
+                occurred in setting transaction type.").
+
+        Example:
+            >>> txs = config.get_fee_transactions_report(
+            ...     library="MAIN",
+            ...     from_date="2026-01-01",
+            ...     to_date="2026-01-31",
+            ... )
+        """
+        # Pattern source: Configuration.list_libraries (issue #24, above) for
+        # the GET-then-unwrap-envelope-into-list shape; the **filters
+        # forwarding mirrors Acquisitions.search_invoices kwargs handling.
+        self.logger.info(
+            f"Fetching fee-transactions report ({self.environment})",
+            filters=dict(filters) if filters else None,
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/utilities/fee-transactions",
+                params=dict(filters) if filters else None,
+            )
+            payload = response.json() or {}
+            transactions = payload.get("fee_transaction") or []
+            if isinstance(transactions, dict):
+                # Single-record responses can come back as a dict; normalise.
+                transactions = [transactions]
+            self.logger.info(
+                f"✓ Retrieved {len(transactions)} fee transactions"
+            )
+            return transactions
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to fetch fee-transactions report",
+                extra={
+                    "alma_code": getattr(e, "alma_code", ""),
+                    "tracking_id": getattr(e, "tracking_id", None),
+                    "status_code": getattr(e, "status_code", None),
+                },
+            )
+            raise
+
+    def get_general_configuration(self) -> Dict[str, Any]:
+        """Get the institution's general configuration.
+
+        Calls ``GET /almaws/v1/conf/general`` and returns the unwrapped
+        institutional-configuration dict (Alma surfaces fields like
+        ``institution``, ``default_language``, ``default_currency``,
+        ``timezone``, etc. directly at the top level of the response —
+        there is no envelope wrapper).
+
+        Returns:
+            The general-configuration dict as returned by Alma. Returns
+            an empty dict if Alma returns an empty body.
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.get_library (issue #24, above) — but
+        # without the path-param validation, since this endpoint takes no
+        # arguments.
+        self.logger.info(
+            f"Getting general configuration ({self.environment})"
+        )
+        try:
+            response = self.client.get(
+                "almaws/v1/conf/general"
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                "✓ Retrieved general configuration"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                "✗ Failed to get general configuration",
+                extra={
                     "alma_code": getattr(e, "alma_code", ""),
                     "tracking_id": getattr(e, "tracking_id", None),
                     "status_code": getattr(e, "status_code", None),

--- a/src/almaapitk/domains/configuration.py
+++ b/src/almaapitk/domains/configuration.py
@@ -1534,6 +1534,18 @@ class Configuration:
     ) -> AlmaResponse:
         """Replace an entire letter template.
 
+        .. warning::
+            **Known limitation as of 2026-05-07:** the live Alma
+            letters PUT endpoint requires an XML request body and
+            rejects JSON with HTTP 400 + Alma error code ``60105``
+            ("JSON is not supported for this API."). This method
+            sends JSON like the rest of the toolkit, so calls against
+            live Alma will fail. The implementation is correct for a
+            JSON-accepting endpoint and is exercised by the unit-test
+            suite (mocked HTTP); XML body support is tracked as a
+            follow-up issue. Until that ships, treat this method as
+            non-functional against live Alma.
+
         Wraps ``PUT /almaws/v1/conf/letters/{letterCode}``. **The PUT
         replaces the entire letter — it is NOT a partial update.** Alma
         requires the complete letter object on the wire (subject, body,

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -3074,3 +3074,380 @@ class TestGetPrinter:
             config.get_printer("NOPE")
 
         assert "Printer ID" in str(exc_info.value)
+
+
+class TestRunWorkflow:
+    """Tests for ``Configuration.run_workflow`` (issue #35)."""
+
+    def test_run_workflow_with_parameters_sends_body(self):
+        """Parameters dict is forwarded as the JSON request body."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "INSTANCE_42", "status": "RUNNING"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.run_workflow(
+            "MY_SAFE_TEST_WORKFLOW", {"input_param": "value"}
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/workflows/MY_SAFE_TEST_WORKFLOW"
+        )
+        # Parameters forwarded verbatim as the request body.
+        assert call["data"] == {"input_param": "value"}
+        assert isinstance(result, dict)
+        assert result["id"] == "INSTANCE_42"
+        assert result["status"] == "RUNNING"
+
+    def test_run_workflow_without_parameters_sends_no_body(self):
+        """parameters=None means data=None on the wire (no body)."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "INSTANCE_43", "status": "QUEUED"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.run_workflow("MY_SAFE_TEST_WORKFLOW")
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/workflows/MY_SAFE_TEST_WORKFLOW"
+        )
+        # No body forwarded when parameters is None.
+        assert call["data"] is None
+        assert result["id"] == "INSTANCE_43"
+
+    def test_run_workflow_returns_unwrapped_dict(self):
+        """``run_workflow`` returns the parsed body dict (no envelope)."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "INSTANCE_99", "status": "COMPLETED"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.run_workflow("WF")
+
+        assert isinstance(result, dict)
+        assert result == {"id": "INSTANCE_99", "status": "COMPLETED"}
+
+    def test_run_workflow_handles_empty_body(self):
+        """Empty/None response body normalises to an empty dict."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        config = Configuration(mock_client)
+
+        result = config.run_workflow("WF")
+
+        assert result == {}
+
+    def test_run_workflow_strips_whitespace_in_id(self):
+        """Validator trims whitespace from the workflow id."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "X"})
+        config = Configuration(mock_client)
+
+        config.run_workflow("  MY_WF  ")
+
+        assert (
+            mock_client.calls["post"][0]["endpoint"]
+            == "almaws/v1/conf/workflows/MY_WF"
+        )
+
+    def test_run_workflow_rejects_empty_id(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.run_workflow("")
+
+    def test_run_workflow_rejects_whitespace_only_id(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.run_workflow("   ")
+
+    def test_run_workflow_rejects_non_string_id(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.run_workflow(1234)  # type: ignore[arg-type]
+
+    def test_run_workflow_rejects_none_id(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.run_workflow(None)  # type: ignore[arg-type]
+
+    def test_run_workflow_propagates_workflow_not_found(self):
+        """Alma 450001 (Workflow not found) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Workflow not found.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.run_workflow("DOES_NOT_EXIST")
+
+        assert "Workflow not found" in str(exc_info.value)
+
+    def test_run_workflow_propagates_generic_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.run_workflow("WF")
+
+
+class TestGetFeeTransactionsReport:
+    """Tests for ``Configuration.get_fee_transactions_report`` (issue #35)."""
+
+    def test_get_fee_transactions_report_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "fee_transaction": [
+                    {"id": "T1", "amount": 5.00, "status": "ACTIVE"},
+                    {"id": "T2", "amount": 10.00, "status": "CLOSED"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_fee_transactions_report()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/utilities/fee-transactions"
+        # No filters means no params.
+        assert call["params"] is None
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "T1"
+        assert result[1]["status"] == "CLOSED"
+
+    def test_get_fee_transactions_report_forwards_filters_as_params(self):
+        """Arbitrary **filters kwargs flow through to the query string."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "fee_transaction": [
+                    {"id": "T1", "library": "MAIN"},
+                ],
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_fee_transactions_report(
+            status="ACTIVE",
+            library="MAIN",
+            from_date="2026-01-01",
+            to_date="2026-01-31",
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "status": "ACTIVE",
+            "library": "MAIN",
+            "from_date": "2026-01-01",
+            "to_date": "2026-01-31",
+        }
+        assert len(result) == 1
+        assert result[0]["library"] == "MAIN"
+
+    def test_get_fee_transactions_report_returns_empty_on_missing_key(self):
+        """Envelope without ``fee_transaction`` key → empty list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.get_fee_transactions_report() == []
+
+    def test_get_fee_transactions_report_handles_single_dict_response(self):
+        """A single transaction returned as a dict is normalised to a list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "fee_transaction": {"id": "T1", "amount": 5.00},
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_fee_transactions_report()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "T1"
+
+    def test_get_fee_transactions_report_unwraps_envelope(self):
+        """Top-level envelope keys must not appear in the unwrapped list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "fee_transaction": [{"id": "T1"}],
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_fee_transactions_report()
+
+        assert isinstance(result, list)
+        # No envelope keys appear inside the unwrapped list items.
+        assert "total_record_count" not in result[0]
+        assert "fee_transaction" not in result[0]
+
+    def test_get_fee_transactions_report_propagates_api_error(self):
+        """Alma 401652 (circ library/desk error) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "An error has occurred in setting circ library or circ desk.",
+            status_code=400,
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.get_fee_transactions_report(library="BAD")
+
+        assert "circ library" in str(exc_info.value)
+
+
+class TestGetGeneralConfiguration:
+    """Tests for ``Configuration.get_general_configuration`` (issue #35)."""
+
+    def test_get_general_configuration_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "institution": {
+                    "value": "01TAU_INST",
+                    "desc": "Tel Aviv University",
+                },
+                "default_language": {"value": "en"},
+                "default_currency": {"value": "USD"},
+                "timezone": "Asia/Jerusalem",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_general_configuration()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/general"
+        # Endpoint takes no path params and no query filters.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["institution"]["value"] == "01TAU_INST"
+        assert result["timezone"] == "Asia/Jerusalem"
+
+    def test_get_general_configuration_returns_unwrapped_dict(self):
+        """No top-level envelope wrapper — body is returned verbatim."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"timezone": "Asia/Jerusalem"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_general_configuration()
+
+        assert isinstance(result, dict)
+        assert result == {"timezone": "Asia/Jerusalem"}
+
+    def test_get_general_configuration_handles_empty_body(self):
+        """An empty Alma body normalises to an empty dict (not None)."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        config = Configuration(mock_client)
+
+        result = config.get_general_configuration()
+
+        assert isinstance(result, dict)
+        assert result == {}
+
+    def test_get_general_configuration_signature_takes_no_args(self):
+        """get_general_configuration takes no positional / keyword args."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.get_general_configuration)
+        # Only ``self`` is allowed.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_get_general_configuration_propagates_api_error(self):
+        """Alma 400 ("General Error - ...") propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "General Error - An error has occurred while processing the "
+            "request.",
+            status_code=400,
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.get_general_configuration()
+
+        assert "General Error" in str(exc_info.value)

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the Configuration domain class (issues #22, #24, #25, #26, #27).
+Unit tests for the Configuration domain class
+(issues #22, #24, #25, #26, #27, #30).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
@@ -13,6 +14,8 @@ Tests cover:
 - list_code_tables() / get_code_table() / update_code_table() (issue #26)
 - list_mapping_tables() / get_mapping_table() / update_mapping_table()
   (issue #27)
+- list_deposit_profiles() / get_deposit_profile() /
+  list_import_profiles() / get_import_profile() (issue #30)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
@@ -2089,3 +2092,395 @@ class TestUpdateMappingTable:
             config.update_mapping_table(
                 "RecallDueDate", self._valid_payload()
             )
+
+
+# ---------------------------------------------------------------------------
+# Issue #30: Deposit profiles + metadata-import profiles (read-only)
+# ---------------------------------------------------------------------------
+
+
+class TestListDepositProfiles:
+    """Tests for ``Configuration.list_deposit_profiles`` (issue #30)."""
+
+    def test_list_deposit_profiles_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "deposit_profile": [
+                    {"id": "1234", "name": "Default Deposit"},
+                    {"id": "5678", "name": "Thesis Deposit"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_deposit_profiles()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/deposit-profiles"
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "1234"
+        assert result[1]["name"] == "Thesis Deposit"
+
+    def test_list_deposit_profiles_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``deposit_profile`` key → empty list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_deposit_profiles() == []
+
+    def test_list_deposit_profiles_handles_single_dict_response(self):
+        """A single deposit profile returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "deposit_profile": {"id": "ONLY", "name": "Only Profile"},
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_deposit_profiles()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "ONLY"
+
+    def test_list_deposit_profiles_signature_takes_no_args(self):
+        """list_deposit_profiles takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_deposit_profiles)
+        # Only ``self`` is allowed.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_deposit_profiles_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_deposit_profiles()
+
+
+class TestGetDepositProfile:
+    """Tests for ``Configuration.get_deposit_profile`` (issue #30)."""
+
+    def test_get_deposit_profile_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "1234",
+                "name": "Default Deposit",
+                "description": "Default deposit profile",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_deposit_profile("1234")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/deposit-profiles/1234"
+        )
+        assert isinstance(result, dict)
+        assert result["id"] == "1234"
+        assert result["name"] == "Default Deposit"
+
+    def test_get_deposit_profile_returns_unwrapped_dict(self):
+        """``get_deposit_profile`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"id": "1234", "name": "Default Deposit"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_deposit_profile("1234")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "deposit_profile" not in result
+        assert "total_record_count" not in result
+
+    def test_get_deposit_profile_strips_whitespace(self):
+        """Validator trims whitespace from the id before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "1234"})
+        config = Configuration(mock_client)
+
+        config.get_deposit_profile("  1234  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/deposit-profiles/1234"
+        )
+
+    def test_get_deposit_profile_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_deposit_profile("")
+
+    def test_get_deposit_profile_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_deposit_profile("   ")
+
+    def test_get_deposit_profile_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_deposit_profile(1234)  # type: ignore[arg-type]
+
+    def test_get_deposit_profile_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_deposit_profile(None)  # type: ignore[arg-type]
+
+    def test_get_deposit_profile_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "not found", status_code=404
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.get_deposit_profile("NOPE")
+
+
+class TestListImportProfiles:
+    """Tests for ``Configuration.list_import_profiles`` (issue #30)."""
+
+    def test_list_import_profiles_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "import_profile": [
+                    {"id": "100", "name": "MARC Import"},
+                    {"id": "200", "name": "Dublin Core Import"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_import_profiles()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/md-import-profiles"
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "100"
+        assert result[1]["name"] == "Dublin Core Import"
+
+    def test_list_import_profiles_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``import_profile`` key → empty list."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_import_profiles() == []
+
+    def test_list_import_profiles_handles_single_dict_response(self):
+        """A single import profile returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "import_profile": {"id": "100", "name": "Only Profile"},
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_import_profiles()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "100"
+
+    def test_list_import_profiles_signature_takes_no_args(self):
+        """list_import_profiles takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_import_profiles)
+        # Only ``self`` is allowed.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_import_profiles_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_import_profiles()
+
+
+class TestGetImportProfile:
+    """Tests for ``Configuration.get_import_profile`` (issue #30)."""
+
+    def test_get_import_profile_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "100",
+                "name": "MARC Import",
+                "description": "Standard MARC import",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_import_profile("100")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/md-import-profiles/100"
+        )
+        assert isinstance(result, dict)
+        assert result["id"] == "100"
+        assert result["name"] == "MARC Import"
+
+    def test_get_import_profile_returns_unwrapped_dict(self):
+        """``get_import_profile`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"id": "100", "name": "MARC Import"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_import_profile("100")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "import_profile" not in result
+        assert "total_record_count" not in result
+
+    def test_get_import_profile_strips_whitespace(self):
+        """Validator trims whitespace from the id before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "100"})
+        config = Configuration(mock_client)
+
+        config.get_import_profile("  100  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/md-import-profiles/100"
+        )
+
+    def test_get_import_profile_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_import_profile("")
+
+    def test_get_import_profile_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_import_profile("   ")
+
+    def test_get_import_profile_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_import_profile(100)  # type: ignore[arg-type]
+
+    def test_get_import_profile_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_import_profile(None)  # type: ignore[arg-type]
+
+    def test_get_import_profile_propagates_api_error(self):
+        """Alma 401871 (Failed to find Profile ID) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Failed to find the Profile ID.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.get_import_profile("999999")
+
+        assert "Profile ID" in str(exc_info.value)

--- a/tests/unit/domains/test_configuration.py
+++ b/tests/unit/domains/test_configuration.py
@@ -1,6 +1,6 @@
 """
 Unit tests for the Configuration domain class
-(issues #22, #24, #25, #26, #27, #30).
+(issues #22, #24, #25, #26, #27, #30, #33).
 
 Tests cover:
 - Initialization (client, environment, logger setup)
@@ -16,6 +16,8 @@ Tests cover:
   (issue #27)
 - list_deposit_profiles() / get_deposit_profile() /
   list_import_profiles() / get_import_profile() (issue #30)
+- list_letters() / get_letter() / update_letter() /
+  list_printers() / get_printer() (issue #33)
 
 These tests use mocked AlmaAPIClient instances to test the Configuration
 domain in isolation. Pattern source mirrors
@@ -2484,3 +2486,591 @@ class TestGetImportProfile:
             config.get_import_profile("999999")
 
         assert "Profile ID" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# Issue #33: Letters (list / get / update) + Printers (list / get)
+# ---------------------------------------------------------------------------
+
+
+class TestListLetters:
+    """Tests for ``Configuration.list_letters`` (issue #33)."""
+
+    def test_list_letters_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "letter": [
+                    {
+                        "code": "OverdueAndLostLoanLetter",
+                        "letter_name": "Overdue and Lost Loan Letter",
+                        "enabled": {"value": "true"},
+                    },
+                    {
+                        "code": "FulHoldShelfLetter",
+                        "letter_name": "Hold Shelf Letter",
+                        "enabled": {"value": "true"},
+                    },
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_letters()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/letters"
+        # Single round-trip with generous page size.
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["code"] == "OverdueAndLostLoanLetter"
+        assert result[1]["code"] == "FulHoldShelfLetter"
+
+    def test_list_letters_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``letter`` key → empty list, not None."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_letters() == []
+
+    def test_list_letters_handles_single_dict_response(self):
+        """A single letter returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "letter": {
+                    "code": "OnlyLetter",
+                    "letter_name": "Only Letter",
+                },
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_letters()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["code"] == "OnlyLetter"
+
+    def test_list_letters_signature_takes_no_args(self):
+        """list_letters takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_letters)
+        # Only ``self`` is allowed.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_letters_propagates_api_error(self):
+        """Alma 60344 (Problem retrieving letter data) propagates."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Problem retrieving letter data.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_letters()
+
+
+class TestGetLetter:
+    """Tests for ``Configuration.get_letter`` (issue #33)."""
+
+    def test_get_letter_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "code": "OverdueAndLostLoanLetter",
+                "letter_name": "Overdue and Lost Loan Letter",
+                "description": "Sent on overdue / lost loans.",
+                "enabled": {"value": "true"},
+                "subject": "Your loan is overdue",
+                "body": "<xsl:stylesheet>...</xsl:stylesheet>",
+                "letter_template_xsl": "<xsl:stylesheet>...</xsl:stylesheet>",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_letter("OverdueAndLostLoanLetter")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/letters/OverdueAndLostLoanLetter"
+        )
+        assert isinstance(result, dict)
+        assert result["code"] == "OverdueAndLostLoanLetter"
+        # Sub-objects surfaced verbatim.
+        assert result["subject"] == "Your loan is overdue"
+        assert "letter_template_xsl" in result
+
+    def test_get_letter_returns_unwrapped_dict(self):
+        """``get_letter`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "code": "FulHoldShelfLetter",
+                "letter_name": "Hold Shelf Letter",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_letter("FulHoldShelfLetter")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "letter" not in result
+        assert "total_record_count" not in result
+
+    def test_get_letter_strips_whitespace(self):
+        """Validator trims whitespace from the code before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"code": "OverdueAndLostLoanLetter"}
+        )
+        config = Configuration(mock_client)
+
+        config.get_letter("  OverdueAndLostLoanLetter  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/letters/OverdueAndLostLoanLetter"
+        )
+
+    def test_get_letter_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_letter("")
+
+    def test_get_letter_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_letter("   ")
+
+    def test_get_letter_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_letter(123)  # type: ignore[arg-type]
+
+    def test_get_letter_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_letter(None)  # type: ignore[arg-type]
+
+    def test_get_letter_propagates_api_error(self):
+        """Alma 40166411 (Letter code is not valid) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Letter code is not valid.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.get_letter("NoSuchLetter")
+
+        assert "Letter code" in str(exc_info.value)
+
+
+class TestUpdateLetter:
+    """Tests for ``Configuration.update_letter`` (issue #33)."""
+
+    @staticmethod
+    def _valid_payload() -> Dict[str, Any]:
+        # PUT replaces the entire letter — payload mirrors what
+        # ``get_letter`` returns, including subject + XSL body.
+        return {
+            "code": "OverdueAndLostLoanLetter",
+            "letter_name": "Overdue and Lost Loan Letter",
+            "description": "Sent on overdue / lost loans.",
+            "enabled": {"value": "true"},
+            "subject": "Your loan is overdue",
+            "body": "<xsl:stylesheet>...</xsl:stylesheet>",
+            "letter_template_xsl": "<xsl:stylesheet>...</xsl:stylesheet>",
+        }
+
+    def test_update_letter_calls_correct_endpoint_and_returns_response(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={
+                "code": "OverdueAndLostLoanLetter",
+                "letter_name": "Overdue and Lost Loan Letter",
+                "subject": "Your loan is overdue",
+            }
+        )
+        config = Configuration(mock_client)
+
+        response = config.update_letter(
+            "OverdueAndLostLoanLetter", self._valid_payload()
+        )
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/conf/letters/OverdueAndLostLoanLetter"
+        )
+        # Body forwarded verbatim — full letter object on the wire.
+        assert call["data"] == self._valid_payload()
+        assert response is mock_client.put_response
+        assert response.data["code"] == "OverdueAndLostLoanLetter"
+
+    def test_update_letter_strips_whitespace_in_code(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"code": "OverdueAndLostLoanLetter"}
+        )
+        config = Configuration(mock_client)
+
+        config.update_letter(
+            "  OverdueAndLostLoanLetter  ", self._valid_payload()
+        )
+
+        assert (
+            mock_client.calls["put"][0]["endpoint"]
+            == "almaws/v1/conf/letters/OverdueAndLostLoanLetter"
+        )
+
+    def test_update_letter_rejects_empty_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter("", self._valid_payload())
+
+    def test_update_letter_rejects_whitespace_only_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter("   ", self._valid_payload())
+
+    def test_update_letter_rejects_non_string_code(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter(
+                123, self._valid_payload()  # type: ignore[arg-type]
+            )
+
+    def test_update_letter_rejects_empty_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter("OverdueAndLostLoanLetter", {})
+
+    def test_update_letter_rejects_non_dict_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter(
+                "OverdueAndLostLoanLetter",
+                "not a dict",  # type: ignore[arg-type]
+            )
+
+    def test_update_letter_rejects_none_payload(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.update_letter(
+                "OverdueAndLostLoanLetter",
+                None,  # type: ignore[arg-type]
+            )
+
+    def test_update_letter_propagates_api_error(self):
+        """Alma 60343 (The update failed) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "The update failed.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.update_letter(
+                "OverdueAndLostLoanLetter", self._valid_payload()
+            )
+
+        assert "update failed" in str(exc_info.value)
+
+    def test_update_letter_propagates_generic_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.update_letter(
+                "OverdueAndLostLoanLetter", self._valid_payload()
+            )
+
+
+class TestListPrinters:
+    """Tests for ``Configuration.list_printers`` (issue #33)."""
+
+    def test_list_printers_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "printer": [
+                    {
+                        "id": "1234",
+                        "name": "Main Desk Printer",
+                        "code": "MAIN_DESK",
+                    },
+                    {
+                        "id": "5678",
+                        "name": "Annex Printer",
+                        "code": "ANNEX",
+                    },
+                ],
+                "total_record_count": 2,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_printers()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/conf/printers"
+        # Single round-trip with generous page size.
+        assert call["params"] == {"limit": "100", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "1234"
+        assert result[1]["name"] == "Annex Printer"
+
+    def test_list_printers_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``printer`` key → empty list, not None."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        config = Configuration(mock_client)
+
+        assert config.list_printers() == []
+
+    def test_list_printers_handles_single_dict_response(self):
+        """A single printer returned as dict (not list) is normalised."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "printer": {"id": "ONLY", "name": "Only Printer"},
+                "total_record_count": 1,
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.list_printers()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "ONLY"
+
+    def test_list_printers_signature_takes_no_args(self):
+        """list_printers takes no positional / keyword args (AC)."""
+        import inspect
+        from almaapitk.domains.configuration import Configuration
+
+        sig = inspect.signature(Configuration.list_printers)
+        # Only ``self`` is allowed.
+        assert list(sig.parameters.keys()) == ["self"]
+
+    def test_list_printers_propagates_api_error(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "boom", status_code=500
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            config.list_printers()
+
+
+class TestGetPrinter:
+    """Tests for ``Configuration.get_printer`` (issue #33)."""
+
+    def test_get_printer_calls_correct_endpoint(self):
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "1234",
+                "name": "Main Desk Printer",
+                "code": "MAIN_DESK",
+                "description": "Front desk printer",
+            }
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_printer("1234")
+
+        assert len(mock_client.calls["get"]) == 1
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/printers/1234"
+        )
+        assert isinstance(result, dict)
+        assert result["id"] == "1234"
+        assert result["name"] == "Main Desk Printer"
+
+    def test_get_printer_returns_unwrapped_dict(self):
+        """``get_printer`` returns the raw object, not an envelope."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"id": "1234", "name": "Main Desk Printer"}
+        )
+        config = Configuration(mock_client)
+
+        result = config.get_printer("1234")
+
+        assert isinstance(result, dict)
+        # No envelope keys at the top level.
+        assert "printer" not in result
+        assert "total_record_count" not in result
+
+    def test_get_printer_strips_whitespace(self):
+        """Validator trims whitespace from the id before building URL."""
+        from almaapitk.domains.configuration import Configuration
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "1234"})
+        config = Configuration(mock_client)
+
+        config.get_printer("  1234  ")
+
+        assert (
+            mock_client.calls["get"][0]["endpoint"]
+            == "almaws/v1/conf/printers/1234"
+        )
+
+    def test_get_printer_rejects_empty_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_printer("")
+
+    def test_get_printer_rejects_whitespace_only(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_printer("   ")
+
+    def test_get_printer_rejects_non_string(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_printer(1234)  # type: ignore[arg-type]
+
+    def test_get_printer_rejects_none(self):
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaValidationError
+
+        config = Configuration(MockAlmaAPIClient())
+
+        with pytest.raises(AlmaValidationError):
+            config.get_printer(None)  # type: ignore[arg-type]
+
+    def test_get_printer_propagates_api_error(self):
+        """Alma 402899 (Invalid Printer ID) propagates verbatim."""
+        from almaapitk.domains.configuration import Configuration
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Invalid Printer ID.", status_code=400
+        )
+        config = Configuration(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            config.get_printer("NOPE")
+
+        assert "Printer ID" in str(exc_info.value)


### PR DESCRIPTION
## Chunk: `config-grab-bag-1`

Closes #30
Closes #33
Closes #35

## Implementation summary

Configuration class extended with deposit/import profile reads (#30), letters+printers reads + update_letter PUT (#33), and workflow runner + fee report + general config (#35). update_letter has a docstring 'Known limitation' warning: Alma letters PUT requires XML, current implementation sends JSON; tracked as #114.

## SANDBOX test summary

6 SANDBOX tests passed, 1 skipped. The skipped test (t-33-3 letter round-trip) is held against #114 because Alma's letters PUT rejects JSON; live verification confirmed the disabled letter was NEVER mutated. Both deferred fixtures (deposit_profile_id, printer_id) noted in scope text. All three issues labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/config-grab-bag-1/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
