### PR TITLE
chunk: users-list-and-search (#36)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -127,6 +127,174 @@ class Users:
                 self.logger.error(f"API error retrieving user {user_id}: {e}")
             raise
     
+    def list_users(
+        self,
+        limit: int = 10,
+        offset: int = 0,
+        q: Optional[str] = None,
+        order_by: Optional[str] = None,
+        expand: Optional[str] = None,
+        source_user_id: Optional[str] = None,
+        source_institution_code: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List or search users via ``GET /almaws/v1/users``.
+
+        Calls the Alma users list/search endpoint and unwraps the
+        response envelope (``{"user": [...], "total_record_count": N}``)
+        into a flat list. ``q`` enables Alma's specialized SRU-style
+        query syntax — e.g. ``last_name~Smith`` or ``primary_id~ST123``.
+        Any non-``None`` filter is forwarded as a query parameter; ``None``
+        values are dropped so Alma applies its own defaults.
+
+        Args:
+            limit: Maximum number of users to return per request
+                (Alma caps at 100). Defaults to 10.
+            offset: Zero-based offset into the result set. Defaults to 0.
+            q: Alma query string (e.g. ``last_name~Smith``). Optional.
+            order_by: Field to sort by (e.g. ``last_name``). Optional.
+            expand: Additional data to include (e.g. ``loans,requests``).
+                Optional.
+            source_user_id: Filter by source-system user identifier
+                (fulfillment-network use case). Optional.
+            source_institution_code: Filter by source-institution code
+                (fulfillment-network use case). Optional.
+
+        Returns:
+            List of user dicts as returned by Alma. Returns an empty
+            list when no users match (or when the response envelope is
+            missing the ``user`` key).
+
+        Raises:
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_libraries
+        # (configuration.py line 218, issue #24) for the
+        # "single GET, unwrap envelope, return list" idiom. The audit
+        # (2026-05-01) flagged the prior narrower signature as missing
+        # several documented optional filters; surface them explicitly
+        # here so IDE/type-check users get autocompletion.
+        params: Dict[str, Any] = {
+            "limit": str(limit),
+            "offset": str(offset),
+        }
+        if q is not None:
+            params["q"] = q
+        if order_by is not None:
+            params["order_by"] = order_by
+        if expand is not None:
+            params["expand"] = expand
+        if source_user_id is not None:
+            params["source_user_id"] = source_user_id
+        if source_institution_code is not None:
+            params["source_institution_code"] = source_institution_code
+
+        self.logger.info(
+            f"Listing users (limit={limit}, offset={offset}, q={q!r})"
+        )
+        try:
+            response = self.client.get("almaws/v1/users", params=params)
+            payload = response.json() or {}
+            users = payload.get("user") or []
+            if isinstance(users, dict):
+                # Single-record responses can come back as a dict; normalise.
+                users = [users]
+            self.logger.info(f"Retrieved {len(users)} users")
+            return users
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing users: {e}",
+            )
+            raise
+
+    def search_users(
+        self,
+        q: str,
+        limit: int = 10,
+        offset: int = 0,
+        **kwargs: Any,
+    ) -> List[Dict[str, Any]]:
+        """Search users with a required Alma query string.
+
+        Convenience wrapper around :meth:`list_users` for the common
+        case of "find users matching this query". Validates that ``q``
+        is a non-empty string and forwards every other parameter to
+        :meth:`list_users`.
+
+        Args:
+            q: Alma query string (e.g. ``last_name~Smith``,
+                ``primary_id~ST123``). Required and must be a non-empty
+                string.
+            limit: Maximum number of users to return. Defaults to 10.
+            offset: Zero-based offset into the result set. Defaults to 0.
+            **kwargs: Additional optional filters forwarded to
+                :meth:`list_users` (``order_by``, ``expand``,
+                ``source_user_id``, ``source_institution_code``).
+
+        Returns:
+            List of user dicts matching the query. Returns an empty list
+            when no users match.
+
+        Raises:
+            AlmaValidationError: If ``q`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: list_users (above) — thin wrapper that adds a
+        # required-q validation gate before delegating.
+        if not isinstance(q, str) or not q.strip():
+            raise AlmaValidationError(
+                "Query string 'q' must be a non-empty string"
+            )
+        return self.list_users(
+            q=q.strip(),
+            limit=limit,
+            offset=offset,
+            **kwargs,
+        )
+
+    def get_user_personal_data(self, user_id: str) -> Dict[str, Any]:
+        """Fetch the GDPR personal-data export for a single user.
+
+        Calls ``GET /almaws/v1/users/{user_id}/personal-data`` and
+        returns the raw export payload as a dict. The response body is
+        sensitive (full GDPR data-portability export) — only the
+        ``user_id`` and result-shape are logged, never the body itself.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+
+        Returns:
+            The personal-data export dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails (including 404 / 400
+                + errorCode 401890 when the user does not exist).
+        """
+        # Pattern source: get_user (above) — validate, log entry, GET,
+        # log success without body, propagate API errors.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        endpoint = f"almaws/v1/users/{clean_id}/personal-data"
+        self.logger.info(f"Retrieving personal data for user {clean_id}")
+        try:
+            response = self.client.get(endpoint)
+            data: Dict[str, Any] = response.data or {}
+            # Personal-data responses are sensitive; log only the shape
+            # (top-level key count), never the body itself.
+            self.logger.info(
+                f"Retrieved personal data for user {clean_id} "
+                f"(top-level keys: {len(data)})"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving personal data for user {clean_id}: {e}"
+            )
+            raise
+
     def update_user(self, user_id: str, user_data: Dict[str, Any]) -> AlmaResponse:
         """
         Update a user record.

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -1,490 +1,518 @@
 """
-Enhanced Users Domain Class for Alma API
-Focused on user email management and expiry date processing
+Unit tests for the Users domain class — issue #36 coverage:
 
-This class builds upon your existing AlmaAPIClient foundation.
+- ``Users.list_users`` — list/search via ``GET /almaws/v1/users``
+- ``Users.search_users`` — convenience wrapper requiring ``q``
+- ``Users.get_user_personal_data`` — GDPR export via
+  ``GET /almaws/v1/users/{user_id}/personal-data``
+
+Tests use a mocked AlmaAPIClient stand-in (no real HTTP) following the
+mock-shape established in ``tests/unit/domains/test_configuration.py``.
 """
 
-import re
-import json
-from typing import Dict, List, Optional, Union, Any, Tuple
-from datetime import datetime, date
+from typing import Any, Dict, Optional
+from unittest.mock import MagicMock
 
-from almaapitk import AlmaAPIClient
+import pytest
 
 
-class AlmaUsersManager:
+class MockAlmaResponse:
+    """Lightweight stand-in for ``almaapitk.AlmaResponse``.
+
+    Mirrors ``test_configuration.MockAlmaResponse`` — just enough
+    surface area for the GET-shaped methods under test.
     """
-    Enhanced Users management class for Alma API operations.
-    Built on your existing AlmaAPIClient foundation.
-    
-    Focuses on:
-    - User retrieval and search
-    - Email management and updates
-    - Expiry date processing
-    - Bulk operations for user email updates
+
+    def __init__(
+        self,
+        body: Optional[Dict[str, Any]] = None,
+        status_code: int = 200,
+        success: bool = True,
+    ):
+        self._body = body if body is not None else {}
+        self.status_code = status_code
+        self.success = success
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+    @property
+    def data(self) -> Dict[str, Any]:
+        return self._body
+
+
+class MockAlmaAPIClient:
+    """Mock AlmaAPIClient for testing the Users domain.
+
+    Records GET calls (endpoint + params) and lets each test set the
+    next response via ``get_response`` or a one-shot ``next_exception``.
+    The Users.__init__ calls ``client.logger`` and
+    ``client.get_environment``; both are honoured here.
     """
-    
-    def __init__(self, environment: str = 'SANDBOX'):
-        """
-        Initialize the Users manager.
-        
-        Args:
-            environment: 'SANDBOX' or 'PRODUCTION'
-        """
-        self.client = AlmaAPIClient(environment)
+
+    def __init__(
+        self,
+        environment: str = 'SANDBOX',
+    ):
         self.environment = environment
-        
-    def get_user_by_id(self, user_id: str, expand: str = "none") -> Dict[str, Any]:
-        """
-        Retrieve a user by their ID with complete information.
-        
-        Args:
-            user_id: User identifier (primary ID, barcode, etc.)
-            expand: Additional data to include (loans, requests, fees)
-        
-        Returns:
-            Dict containing user data or error information
-        """
-        if not user_id or not user_id.strip():
-            return {
-                'success': False,
-                'error': 'User ID cannot be empty',
-                'user_id': user_id
-            }
-        
-        try:
-            endpoint = f'almaws/v1/users/{user_id.strip()}'
-            params = {'expand': expand} if expand != "none" else {}
-            
-            response = self.client.get(endpoint, params=params)
-            
-            if response.status_code == 200:
-                user_data = response.json()
-                return {
-                    'success': True,
-                    'user_data': user_data,
-                    'user_id': user_id,
-                    'primary_id': user_data.get('primary_id', ''),
-                    'full_name': f"{user_data.get('first_name', '')} {user_data.get('last_name', '')}".strip()
-                }
-            elif response.status_code == 404:
-                return {
-                    'success': False,
-                    'error': 'User not found',
-                    'user_id': user_id,
-                    'status_code': 404
-                }
-            else:
-                return {
-                    'success': False,
-                    'error': f'API error: {response.status_code}',
-                    'user_id': user_id,
-                    'status_code': response.status_code,
-                    'response_text': response.text[:200]
-                }
-                
-        except Exception as e:
-            return {
-                'success': False,
-                'error': f'Request failed: {str(e)}',
-                'user_id': user_id
-            }
-    
-    def get_users_bulk(self, user_id_list: List[str], max_concurrent: int = 10) -> List[Dict[str, Any]]:
-        """
-        Retrieve multiple users efficiently.
-        
-        Args:
-            user_id_list: List of user IDs to retrieve
-            max_concurrent: Maximum number of concurrent requests (respect rate limits)
-        
-        Returns:
-            List of user data dictionaries
-        """
-        if not user_id_list:
-            return []
-        
-        results = []
-        
-        print(f"Retrieving {len(user_id_list)} users from {self.environment}...")
-        
-        for i, user_id in enumerate(user_id_list, 1):
-            if i % 10 == 0:  # Progress indicator
-                print(f"  Progress: {i}/{len(user_id_list)} users processed")
-            
-            result = self.get_user_by_id(user_id)
-            results.append(result)
-            
-            # Basic rate limiting - respect Alma's limits
-            if i % 50 == 0:  # Every 50 requests, pause briefly
-                import time
-                time.sleep(1)
-        
-        print(f"Completed: {len(results)} users processed")
-        return results
-    
-    def extract_user_emails(self, user_data: Dict[str, Any]) -> List[Dict[str, str]]:
-        """
-        Extract all email addresses from user data.
-        
-        Args:
-            user_data: User data from Alma API
-        
-        Returns:
-            List of email dictionaries with type and address
-        """
-        emails = []
-        
-        try:
-            contact_info = user_data.get('contact_info', {})
-            email_list = contact_info.get('email', [])
-            
-            # Handle both single email and list of emails
-            if isinstance(email_list, dict):
-                email_list = [email_list]
-            elif not isinstance(email_list, list):
-                return emails
-            
-            for email_entry in email_list:
-                if isinstance(email_entry, dict):
-                    email_address = email_entry.get('email_address', '')
-                    email_type = email_entry.get('email_type', {})
-                    
-                    if email_address:
-                        emails.append({
-                            'address': email_address,
-                            'type': email_type.get('value', 'unknown') if isinstance(email_type, dict) else str(email_type),
-                            'preferred': email_entry.get('preferred', False)
-                        })
-        
-        except Exception as e:
-            print(f"Error extracting emails: {e}")
-        
-        return emails
-    
-    def get_user_expiry_date(self, user_data: Dict[str, Any]) -> Optional[str]:
-        """
-        Extract expiry date from user data.
-        
-        Args:
-            user_data: User data from Alma API
-        
-        Returns:
-            Expiry date as string (YYYY-MM-DDTZ format) or None
-        """
-        try:
-            return user_data.get('expiry_date')
-        except Exception:
-            return None
-    
-    def validate_email(self, email: str) -> bool:
-        """
-        Validate email format.
-        
-        Args:
-            email: Email address to validate
-        
-        Returns:
-            True if valid, False otherwise
-        """
-        if not email or not isinstance(email, str):
-            return False
-        
-        # Basic email validation regex
-        email_pattern = r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$'
-        return re.match(email_pattern, email.strip()) is not None
-    
-    def update_user_email(self, user_id: str, new_email: str, email_type: str = 'personal') -> Dict[str, Any]:
-        """
-        Update a user's primary email address.
-        
-        Args:
-            user_id: User identifier
-            new_email: New email address
-            email_type: Type of email (personal, work, etc.)
-        
-        Returns:
-            Dict with success status and details
-        """
-        if not self.validate_email(new_email):
-            return {
-                'success': False,
-                'error': 'Invalid email format',
-                'user_id': user_id,
-                'new_email': new_email
-            }
-        
-        try:
-            # First, get the current user data
-            user_result = self.get_user_by_id(user_id)
-            print("-----------------------------------------------\n")
-            print(f"This is user_result:\n{user_result}")
-            print("-----------------------------------------------\n")
-            if not user_result['success']:
-                return {
-                    'success': False,
-                    'error': f"Could not retrieve user: {user_result['error']}",
-                    'user_id': user_id,
-                    'new_email': new_email
-                }
-            
-            user_data = user_result['user_data']
-            print("-----------------------------------------------\n")
-            print(f"Updating email for user:\n{user_data}")
-            print("-----------------------------------------------\n")            
+        self.logger = MagicMock()
+        self.get_response: MockAlmaResponse = MockAlmaResponse()
+        self.next_exception: Optional[Exception] = None
+        self.calls = {"get": []}
 
-
-            
-            # Update the email in the user data
-            contact_info = user_data.get('contact_info', {})
-            print("-----------------------------------------------\n")
-            print(f"This is contact_info:\n{contact_info}")
-            print("-----------------------------------------------\n")            
-
-            email_list = contact_info.get('email', [])
-            print("-----------------------------------------------\n")
-            print(f"This is the email_list:\n{email_list}")
-            print("-----------------------------------------------\n")            
-            
-            
-            # Handle both single email and list of emails
-            if isinstance(email_list, dict):
-                print(f"Email list is a single dictionary, converting to list{type(email_list)}")
-                email_list = [email_list]
-            elif not isinstance(email_list, list):
-                print(f"Email list is not a list, initializing empty list{type(email_list)}")
-                email_list = []
-            else:
-                # this is crucial for the next steps. The AI did not realized that the email_list could be a list or a dict, so it was not handling the case where it is a list properly.
-                print(f"Email list is already a list{type(email_list)}") 
-            
-        #     # Update existing email or add new one
-        #     email_updated = False
-        #     for email_entry in email_list:
-        #         if email_entry.get('preferred', False) or len(email_list) == 1:
-        #             email_entry['email_address'] = new_email
-        #             email_updated = True
-        #             break
-            
-        #     # If no email found, add a new one
-        #     if not email_updated:
-        #         new_email_entry = {
-        #             'email_address': new_email,
-        #             'email_type': {'value': email_type},
-        #             'preferred': True
-        #         }
-        #         email_list.append(new_email_entry)
-            
-        #     # Update the contact info
-        #     contact_info['email'] = email_list
-        #     user_data['contact_info'] = contact_info
-            
-        #     # Send the update to Alma
-        #     endpoint = f'almaws/v1/users/{user_id}'
-        #     response = self.client.put(endpoint, data=user_data)
-            
-        #     if response.status_code == 200:
-        #         return {
-        #             'success': True,
-        #             'user_id': user_id,
-        #             'new_email': new_email,
-        #             'message': 'Email updated successfully'
-        #         }
-        #     else:
-        #         return {
-        #             'success': False,
-        #             'error': f'Update failed: {response.status_code}',
-        #             'user_id': user_id,
-        #             'new_email': new_email,
-        #             'status_code': response.status_code,
-        #             'response_text': response.text[:200]
-        #         }
-                
-        except Exception as e:
-            return {
-                'success': False,
-                'error': f'Update failed: {str(e)}',
-                'user_id': user_id,
-                'new_email': new_email
-            }
-    
-    def bulk_update_user_emails(self, updates_list: List[Dict[str, str]]) -> List[Dict[str, Any]]:
-        """
-        Update multiple users' emails in bulk.
-        
-        Args:
-            updates_list: List of dicts with 'user_id' and 'new_email' keys
-        
-        Returns:
-            List of update results
-        """
-        if not updates_list:
-            return []
-        
-        results = []
-        
-        print(f"Starting bulk email update for {len(updates_list)} users in {self.environment}...")
-        
-        for i, update in enumerate(updates_list, 1):
-            user_id = update.get('user_id', '')
-            new_email = update.get('new_email', '')
-            email_type = update.get('email_type', 'personal')
-            
-            if i % 5 == 0:  # Progress indicator
-                print(f"  Progress: {i}/{len(updates_list)} email updates processed")
-            
-            result = self.update_user_email(user_id, new_email, email_type)
-            result['update_index'] = i
-            results.append(result)
-            
-            # Rate limiting for bulk operations
-            if i % 25 == 0:  # Every 25 updates, pause briefly
-                import time
-                time.sleep(2)
-        
-        # Summary
-        successful = sum(1 for r in results if r['success'])
-        failed = len(results) - successful
-        
-        print(f"Bulk email update completed:")
-        print(f"  ✓ Successful: {successful}")
-        print(f"  ✗ Failed: {failed}")
-        
-        return results
-    
-    def analyze_user_expiry_dates(self, user_id_list: List[str], target_date: str = None) -> Dict[str, Any]:
-        """
-        Analyze expiry dates for a list of users.
-        
-        Args:
-            user_id_list: List of user IDs to analyze
-            target_date: Date to compare against (YYYY-MM-DD format), defaults to today
-        
-        Returns:
-            Analysis results with expired/expiring users
-        """
-        if target_date is None:
-            target_date = datetime.now().strftime('%Y-%m-%d')
-        
-        # Get all users
-        users = self.get_users_bulk(user_id_list)
-        
-        expired_users = []
-        expiring_soon = []  # Within 30 days
-        valid_users = []
-        error_users = []
-        
-        target_dt = datetime.strptime(target_date, '%Y-%m-%d')
-        
-        for user_result in users:
-            if not user_result['success']:
-                error_users.append(user_result)
-                continue
-            
-            user_data = user_result['user_data']
-            expiry_date_str = self.get_user_expiry_date(user_data)
-            
-            if not expiry_date_str:
-                continue
-            
-            try:
-                # Parse Alma date format (YYYY-MM-DDTZ)
-                expiry_date_clean = expiry_date_str.replace('Z', '')
-                expiry_dt = datetime.strptime(expiry_date_clean, '%Y-%m-%d')
-                
-                days_until_expiry = (expiry_dt - target_dt).days
-                
-                user_info = {
-                    'user_id': user_result['user_id'],
-                    'primary_id': user_result['primary_id'],
-                    'full_name': user_result['full_name'],
-                    'expiry_date': expiry_date_str,
-                    'days_until_expiry': days_until_expiry,
-                    'emails': self.extract_user_emails(user_data)
-                }
-                
-                if days_until_expiry < 0:
-                    expired_users.append(user_info)
-                elif days_until_expiry <= 30:
-                    expiring_soon.append(user_info)
-                else:
-                    valid_users.append(user_info)
-                    
-            except ValueError as e:
-                error_users.append({
-                    'user_id': user_result['user_id'],
-                    'error': f'Date parsing error: {e}',
-                    'expiry_date': expiry_date_str
-                })
-        
-        return {
-            'analysis_date': target_date,
-            'total_users': len(users),
-            'expired_users': expired_users,
-            'expiring_soon': expiring_soon,
-            'valid_users': valid_users,
-            'error_users': error_users,
-            'summary': {
-                'expired_count': len(expired_users),
-                'expiring_soon_count': len(expiring_soon),
-                'valid_count': len(valid_users),
-                'error_count': len(error_users)
-            }
-        }
-    
-    def switch_environment(self, new_environment: str):
-        """Switch between SANDBOX and PRODUCTION environments."""
-        self.client.switch_environment(new_environment)
-        self.environment = new_environment
-        print(f"✓ Switched to {new_environment} environment")
-    
     def get_environment(self) -> str:
-        """Get current environment."""
         return self.environment
 
+    def get(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["get"].append(
+            {"endpoint": endpoint, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.get_response
 
-# Example usage and testing
-if __name__ == "__main__":
+
+# ---------------------------------------------------------------------------
+# list_users
+# ---------------------------------------------------------------------------
+
+
+class TestListUsers:
+    """Tests for ``Users.list_users`` (issue #36)."""
+
+    def test_list_users_calls_correct_endpoint_with_defaults(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user": [
+                    {"primary_id": "u1", "first_name": "Ada"},
+                    {"primary_id": "u2", "first_name": "Linus"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_users()
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users"
+        # Defaults: limit=10, offset=0; no other filters present.
+        assert call["params"] == {"limit": "10", "offset": "0"}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["primary_id"] == "u1"
+
+    def test_list_users_forwards_q_and_pagination(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user": [{"primary_id": "u1"}],
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_users(
+            limit=50,
+            offset=100,
+            q="last_name~Smith",
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": "50",
+            "offset": "100",
+            "q": "last_name~Smith",
+        }
+        assert result[0]["primary_id"] == "u1"
+
+    def test_list_users_forwards_all_optional_filters(self):
+        """All documented optional filters must be forwarded when set."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user": [], "total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        users.list_users(
+            limit=25,
+            offset=0,
+            q="primary_id~ST123",
+            order_by="last_name",
+            expand="loans",
+            source_user_id="src-user-1",
+            source_institution_code="INST_A",
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": "25",
+            "offset": "0",
+            "q": "primary_id~ST123",
+            "order_by": "last_name",
+            "expand": "loans",
+            "source_user_id": "src-user-1",
+            "source_institution_code": "INST_A",
+        }
+
+    def test_list_users_omits_unset_optional_filters(self):
+        """``None`` filters must not appear in the query string."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user": [], "total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        users.list_users(limit=5, offset=0)
+
+        call = mock_client.calls["get"][0]
+        # Only the two pagination params should be present.
+        assert call["params"] == {"limit": "5", "offset": "0"}
+        for key in (
+            "q",
+            "order_by",
+            "expand",
+            "source_user_id",
+            "source_institution_code",
+        ):
+            assert key not in call["params"]
+
+    def test_list_users_returns_empty_list_on_missing_key(self):
+        """Alma envelope without ``user`` key → empty list, not None."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_users()
+
+        assert result == []
+
+    def test_list_users_handles_single_dict_response(self):
+        """A single user returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user": {"primary_id": "only-user"},
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_users()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["primary_id"] == "only-user"
+
+    def test_list_users_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_users()
+
+
+# ---------------------------------------------------------------------------
+# search_users
+# ---------------------------------------------------------------------------
+
+
+class TestSearchUsers:
+    """Tests for ``Users.search_users`` (issue #36)."""
+
+    def test_search_users_requires_non_empty_q(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.search_users(q="")
+
+    def test_search_users_requires_non_whitespace_q(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.search_users(q="   ")
+
+    def test_search_users_rejects_non_string_q(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.search_users(q=None)  # type: ignore[arg-type]
+
+    def test_search_users_forwards_to_list_users(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user": [{"primary_id": "ada"}],
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.search_users(q="last_name~Lovelace", limit=20)
+
+        # search_users delegates to list_users, which makes one GET.
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users"
+        assert call["params"]["q"] == "last_name~Lovelace"
+        assert call["params"]["limit"] == "20"
+        assert isinstance(result, list)
+        assert result[0]["primary_id"] == "ada"
+
+    def test_search_users_strips_q_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user": [], "total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        users.search_users(q="  primary_id~ST123  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"]["q"] == "primary_id~ST123"
+
+    def test_search_users_passes_through_kwargs(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user": [], "total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        users.search_users(
+            q="last_name~Smith",
+            limit=15,
+            offset=30,
+            order_by="last_name",
+            expand="loans",
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": "15",
+            "offset": "30",
+            "q": "last_name~Smith",
+            "order_by": "last_name",
+            "expand": "loans",
+        }
+
+
+# ---------------------------------------------------------------------------
+# get_user_personal_data
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserPersonalData:
+    """Tests for ``Users.get_user_personal_data`` (issue #36)."""
+
+    def test_get_user_personal_data_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "primary_id": "u1",
+                "first_name": "Ada",
+                "last_name": "Lovelace",
+                "contact_info": {"email": []},
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_personal_data("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/personal-data"
+        # No params on personal-data endpoint.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["primary_id"] == "u1"
+        assert result["first_name"] == "Ada"
+
+    def test_get_user_personal_data_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"primary_id": "u1"}
+        )
+        users = Users(mock_client)
+
+        users.get_user_personal_data("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/personal-data"
+
+    def test_get_user_personal_data_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_personal_data("")
+
+    def test_get_user_personal_data_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_personal_data("   ")
+
+    def test_get_user_personal_data_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_personal_data(None)  # type: ignore[arg-type]
+
+    def test_get_user_personal_data_returns_empty_dict_on_empty_body(self):
+        """A ``None`` body normalises to an empty dict."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        # MockAlmaResponse defaults to {} — explicit here for clarity.
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_personal_data("u1")
+
+        assert result == {}
+
+    def test_get_user_personal_data_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "User not found", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.get_user_personal_data("missing-user")
+
+    def test_get_user_personal_data_does_not_log_body(self):
+        """Personal-data body must never appear in log records."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        sensitive = {
+            "primary_id": "u1",
+            "first_name": "Ada",
+            "last_name": "Lovelace",
+            "contact_info": {
+                "email": [
+                    {"email_address": "ada@example.test"},
+                ],
+                "address": [
+                    {"line1": "123 Sensitive St"},
+                ],
+            },
+        }
+        mock_client.get_response = MockAlmaResponse(body=sensitive)
+        users = Users(mock_client)
+
+        # The Users class swaps ``self.logger`` to a real ``logging``
+        # logger in __init__, so capture log output via caplog rather
+        # than asserting on the mock_client.logger.
+        import logging
+
+        with _captured_logs("Users_SANDBOX") as records:
+            users.get_user_personal_data("u1")
+
+        # No log message may contain any sensitive value.
+        sensitive_strings = (
+            "ada@example.test",
+            "Ada",
+            "Lovelace",
+            "123 Sensitive St",
+        )
+        for rec in records:
+            msg = rec.getMessage()
+            for needle in sensitive_strings:
+                assert needle not in msg, (
+                    f"Sensitive value {needle!r} leaked into log: {msg!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+from contextlib import contextmanager
+import logging
+
+
+@contextmanager
+def _captured_logs(logger_name: str):
+    """Capture log records emitted by a named logger during a block.
+
+    The Users class builds its own non-propagating logger via
+    ``_setup_enhanced_logger``; pytest's ``caplog`` does not see those
+    records unless we attach a handler directly.
     """
-    Example usage of the AlmaUsersManager class
-    """
-    
-    def example_usage():
-        # Initialize manager
-        users_mgr = AlmaUsersManager('SANDBOX')
-        
-        # Example: Get a single user
-        # print("=== Getting Single User ===")
-        # user_result = users_mgr.get_user_by_id('333444555')
-        # if user_result['success']:
-        #     print(f"✓ Found user: {user_result['full_name']}")
-            
-        #     # Extract emails
-        #     emails = users_mgr.extract_user_emails(user_result['user_data'])
-        #     print(f"  Emails: {[e['address'] for e in emails]}")
-            
-        #     # Get expiry date
-        #     expiry = users_mgr.get_user_expiry_date(user_result['user_data'])
-        #     print(f"  Expiry: {expiry}")
-        # else:
-        #     print(f"✗ Error: {user_result['error']}")
-        
-        # # Example: Bulk user analysis
-        # print("\n=== Bulk User Analysis ===")
-        # user_ids = ['000191908', '000213751', '333444555']  # Your user list
-        # analysis = users_mgr.analyze_user_expiry_dates(user_ids)
-        
-        # print(f"Expired users: {analysis['summary']['expired_count']}")
-        # print(f"Expiring soon: {analysis['summary']['expiring_soon_count']}")
-        
-        # # Example: Update email
-        print("\n=== Update User Email ===")
-        update_result = users_mgr.update_user_email('333444555', 'new@email.com')
-        # if update_result['success']:
-        #     print("✓ Email updated successfully")
-        # else:
-        #     print(f"✗ Update failed: {update_result['error']}")
-    
-    # Uncomment to run examples
-    example_usage()
+    logger = logging.getLogger(logger_name)
+    records: list = []
+
+    class _ListHandler(logging.Handler):
+        def emit(self, record):  # noqa: D401 - simple capture
+            records.append(record)
+
+    handler = _ListHandler(level=logging.DEBUG)
+    logger.addHandler(handler)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)


### PR DESCRIPTION
## Chunk: `users-list-and-search`

Closes #36

## Implementation summary

Users class extended with list_users (full documented optional filter set: limit, offset, q, order_by, expand, source_user_id, source_institution_code), search_users (thin wrapper requiring non-empty q), and get_user_personal_data (GDPR export; body not logged). 21 unit tests added; tests/unit/domains/test_users.py replaced from a non-pytest stub to a proper pytest suite.

## SANDBOX test summary

Both SANDBOX tests passed. t-36-1 read smoke exercised list_users / search_users (echo-back on supplied test user) / get_user_personal_data; t-36-2 validation smoke exercised every AlmaValidationError guard. No state changes, no fixtures beyond the existing user_primary_id reused from prior chunks. Issue labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/users-list-and-search/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
