### PR TITLE
chunk: users-grab-bag-1 (#39, #44, #45)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -1166,6 +1166,262 @@ class Users:
             )
             raise
 
+    # ------------------------------------------------------------------
+    # User deposits (issue #45)
+    # ------------------------------------------------------------------
+    #
+    # The deposits endpoints expose three reads (list/get/create) and one
+    # op-driven post (perform-action via ``op`` query param). The op-driven
+    # post mirrors exactly the shape established by the fines/fees op-posts
+    # (issue #44) — ``op`` and any caller-supplied scalars travel as query
+    # parameters; the request body is empty. The wrapper does NOT enumerate
+    # which ``op`` values are valid (Alma docs cite ``pay`` / ``refund`` /
+    # ``dispute`` / ``restore`` but a future Alma release may add more);
+    # we just validate non-empty and let Alma reject invalid ops with its
+    # own error response.
+    #
+    # Read patterns mirror ``list_user_attachments`` / ``get_user_attachment``
+    # (issue #39) and ``list_user_fees`` / ``get_user_fee`` (issue #44).
+
+    def list_user_deposits(self, user_id: str) -> List[Dict[str, Any]]:
+        """List a user's deposits.
+
+        Calls ``GET /almaws/v1/users/{user_id}/deposits`` and unwraps the
+        Alma response envelope (``{"deposit": [...], "total_record_count":
+        N}``) into a flat list.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+
+        Returns:
+            List of deposit dicts as returned by Alma. Returns an empty
+            list when the user has no deposits (or when the response
+            envelope is missing the ``deposit`` key).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: list_user_attachments (issue #39) for the
+        # "single GET, unwrap envelope, return list" idiom plus
+        # single-record-as-dict normalisation.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        endpoint = f"almaws/v1/users/{clean_id}/deposits"
+        self.logger.info(
+            f"Listing deposits for user {clean_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            payload = response.json() or {}
+            deposits = payload.get("deposit") or []
+            if isinstance(deposits, dict):
+                # Single-record responses can come back as a dict; normalise.
+                deposits = [deposits]
+            self.logger.info(
+                f"Retrieved {len(deposits)} deposits for user {clean_id}"
+            )
+            return deposits
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing deposits for user {clean_id}: {e}"
+            )
+            raise
+
+    def create_user_deposit(
+        self,
+        user_id: str,
+        deposit_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Create a new deposit on a user record.
+
+        Calls ``POST /almaws/v1/users/{user_id}/deposits`` with the
+        operator-supplied ``deposit_data`` dict as the JSON body. The
+        body is passed through verbatim — the caller is responsible for
+        supplying the Alma-required fields (see Alma's ``X parameter is
+        not valid.`` / ``Input parameter X (Y) is not numeric.`` /
+        ``General Error - An error has occurred while creating the
+        deposit.`` validation errors).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            deposit_data: Deposit body as a non-empty dict. Passed
+                through to Alma verbatim.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response. The created
+            deposit's identifier lives at ``response.data["id"]``.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty/not a string,
+                or if ``deposit_data`` is empty or not a dict.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: create_user_fee (issue #44) for the
+        # "validate, log entry without body, POST verbatim, log success
+        # with the new id" discipline.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(deposit_data, dict) or not deposit_data:
+            raise AlmaValidationError(
+                "deposit_data must be a non-empty dictionary"
+            )
+        clean_id = user_id.strip()
+
+        endpoint = f"almaws/v1/users/{clean_id}/deposits"
+        self.logger.info(
+            f"Creating deposit for user {clean_id}"
+        )
+        try:
+            response = self.client.post(endpoint, data=deposit_data)
+            deposit_id: Any = None
+            try:
+                deposit_id = (response.data or {}).get("id")
+            except (ValueError, AttributeError):
+                deposit_id = None
+            self.logger.info(
+                f"Created deposit for user {clean_id} "
+                f"(deposit_id={deposit_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating deposit for user {clean_id}: {e}"
+            )
+            raise
+
+    def get_user_deposit(
+        self,
+        user_id: str,
+        deposit_id: str,
+    ) -> Dict[str, Any]:
+        """Retrieve a single deposit's details.
+
+        Calls ``GET /almaws/v1/users/{user_id}/deposits/{deposit_id}``
+        and returns the unwrapped deposit dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            deposit_id: Deposit identifier as returned by
+                :meth:`list_user_deposits` (key ``id`` on each entry).
+                Must be a non-empty string.
+
+        Returns:
+            The deposit dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``deposit_id`` is
+                empty or not a string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the user or deposit does not exist).
+        """
+        # Pattern source: get_user_attachment (issue #39) / get_user_fee
+        # (issue #44) — same "validate two ids, GET, return dict" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(deposit_id, str) or not deposit_id.strip():
+            raise AlmaValidationError("Deposit ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_deposit_id = deposit_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/deposits/{clean_deposit_id}"
+        )
+        self.logger.info(
+            f"Retrieving deposit {clean_deposit_id} for user "
+            f"{clean_user_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved deposit {clean_deposit_id} for user "
+                f"{clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving deposit {clean_deposit_id} for "
+                f"user {clean_user_id}: {e}"
+            )
+            raise
+
+    def perform_user_deposit_action(
+        self,
+        user_id: str,
+        deposit_id: str,
+        op: str,
+    ) -> AlmaResponse:
+        """Perform an action on a single deposit.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/deposits/{deposit_id}?op=<op>``
+        with an empty request body. The ``op`` query parameter selects
+        the deposit action — Alma's documented values include ``"pay"``,
+        ``"refund"``, ``"dispute"``, and ``"restore"``, but the wrapper
+        does NOT enumerate / restrict the set: invalid ops are rejected
+        by Alma with its own error response (a future Alma release may
+        add new ops, and the wrapper should not be the bottleneck).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            deposit_id: Deposit identifier. Must be a non-empty string.
+            op: Action to perform. Must be a non-empty string. Common
+                values per Alma docs are ``"pay"``, ``"refund"``,
+                ``"dispute"``, ``"restore"`` — not validated client-side.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If ``user_id``, ``deposit_id``, or
+                ``op`` is empty/not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: restore_user_fee (issue #44) — same op-driven
+        # POST shape (op as query param, empty body). The wrapper is
+        # deliberately op-agnostic; per the issue ticket "let Alma
+        # reject invalid ops with its own error".
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(deposit_id, str) or not deposit_id.strip():
+            raise AlmaValidationError("Deposit ID cannot be empty")
+        if not isinstance(op, str) or not op.strip():
+            raise AlmaValidationError("op must be a non-empty string")
+        clean_user_id = user_id.strip()
+        clean_deposit_id = deposit_id.strip()
+        clean_op = op.strip()
+
+        params: Dict[str, Any] = {"op": clean_op}
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/deposits/{clean_deposit_id}"
+        )
+        self.logger.info(
+            f"Performing deposit action for user {clean_user_id} "
+            f"(deposit_id={clean_deposit_id!r}, op={clean_op!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Performed deposit action for user {clean_user_id} "
+                f"(deposit_id={clean_deposit_id!r}, op={clean_op!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error performing deposit action for user "
+                f"{clean_user_id} (deposit_id={clean_deposit_id!r}, "
+                f"op={clean_op!r}): {e}"
+            )
+            raise
+
     def update_user(self, user_id: str, user_data: Dict[str, Any]) -> AlmaResponse:
         """
         Update a user record.

--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -574,6 +574,598 @@ class Users:
             )
             raise
 
+    # ------------------------------------------------------------------
+    # User fines & fees (issue #44)
+    # ------------------------------------------------------------------
+    #
+    # The fines/fees endpoints expose three reads (list/get/create) and
+    # five op-driven posts (pay-all, pay, waive, dispute, restore). All
+    # five op-driven posts use the documented Alma convention of passing
+    # the operation and its scalar arguments as **query parameters**:
+    #
+    #   POST /users/{id}/fees/all?op=pay&amount=ALL&method=CASH
+    #   POST /users/{id}/fees/{fee_id}?op=waive&reason=...&amount=...
+    #
+    # The audit (2026-05-08) flagged three signature mismatches in the
+    # original spec and these methods correct them:
+    #   1. ``pay_all_user_fees`` defaults ``amount="ALL"`` (string sentinel,
+    #      not a number) and forwards ``op``, ``amount``, ``method`` as
+    #      **params** — never body.
+    #   2. ``dispute_user_fee.reason`` is OPTIONAL — only ``waive``
+    #      requires a reason.
+    #   3. ``method`` is only sent on ``op=pay`` / ``op=pay_all``; waive,
+    #      dispute, and restore have no ``method`` arg in their signature.
+    #
+    # Read patterns mirror ``Configuration.list_libraries`` /
+    # ``Configuration.get_library`` (issue #24) for "single GET, unwrap
+    # envelope, return list" and ``list_user_attachments`` /
+    # ``get_user_attachment`` (issue #39) for the fees envelope key
+    # discipline.
+
+    @staticmethod
+    def _validate_pay_amount(amount: str) -> None:
+        """Validate the ``amount`` argument for op=pay / op=pay_all.
+
+        Allowed: the literal string ``"ALL"`` (sentinel meaning "the full
+        outstanding balance"), or a numeric string consisting of digits
+        with at most one decimal point. Anything else raises
+        :class:`AlmaValidationError`.
+        """
+        if not isinstance(amount, str) or not amount.strip():
+            raise AlmaValidationError(
+                "amount must be a non-empty string ('ALL' or a numeric value)"
+            )
+        clean = amount.strip()
+        if clean == "ALL":
+            return
+        # Reject obviously non-numeric values. Allow optional leading
+        # minus only for a defensive future-proofing — Alma rejects
+        # negatives at the server, but the client validator is about
+        # *shape*, not policy.
+        candidate = clean[1:] if clean.startswith("-") else clean
+        if candidate.count(".") > 1 or not candidate.replace(".", "").isdigit():
+            raise AlmaValidationError(
+                f"amount must be 'ALL' or a numeric string, got: {amount!r}"
+            )
+
+    def list_user_fees(
+        self,
+        user_id: str,
+        status: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List a user's active fines and fees.
+
+        Calls ``GET /almaws/v1/users/{user_id}/fees`` and unwraps the
+        Alma response envelope (``{"fee": [...], "total_record_count":
+        N}``) into a flat list. The optional ``status`` filter is
+        forwarded as a query parameter when supplied; otherwise Alma
+        applies its own default (``ACTIVE``).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            status: Optional fee-status filter (e.g. ``"ACTIVE"``,
+                ``"INDISPUTE"``, ``"CLOSED"``). When ``None`` (default),
+                no ``status`` query parameter is sent and Alma returns
+                the default set.
+
+        Returns:
+            List of fee dicts as returned by Alma. Returns an empty list
+            when the user has no matching fees (or when the response
+            envelope is missing the ``fee`` key).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: list_user_attachments (above, issue #39) for
+        # the "single GET, unwrap envelope, return list" idiom plus
+        # single-record-as-dict normalisation. ``list_users``
+        # (issue #36) for the optional-filter forwarding pattern.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {}
+        if status is not None:
+            params["status"] = status
+
+        endpoint = f"almaws/v1/users/{clean_id}/fees"
+        self.logger.info(
+            f"Listing fees for user {clean_id} (status={status!r})"
+        )
+        try:
+            response = self.client.get(
+                endpoint, params=params if params else None
+            )
+            payload = response.json() or {}
+            fees = payload.get("fee") or []
+            if isinstance(fees, dict):
+                # Single-record responses can come back as a dict; normalise.
+                fees = [fees]
+            self.logger.info(
+                f"Retrieved {len(fees)} fees for user {clean_id}"
+            )
+            return fees
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing fees for user {clean_id}: {e}"
+            )
+            raise
+
+    def create_user_fee(
+        self,
+        user_id: str,
+        fee_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Create a new fine/fee on a user record.
+
+        Calls ``POST /almaws/v1/users/{user_id}/fees`` with the
+        operator-supplied ``fee_data`` dict as the JSON body. The body
+        is passed through verbatim — the caller is responsible for
+        supplying the Alma-required fields (``type``, ``original_amount``,
+        ``owner``, etc.; see Alma's ``user fine/fee type/amount/owner is
+        required`` validation errors).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_data: Fee body as a non-empty dict. Passed through to
+                Alma verbatim.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response. The created
+            fee's identifier lives at ``response.data["id"]``.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty/not a string,
+                or if ``fee_data`` is empty or not a dict.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: upload_user_attachment (above, issue #39) for
+        # the "validate, log entry without body, POST, log success with
+        # the new id" discipline. update_user (below) for the
+        # "fee_data passed through verbatim" pattern.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_data, dict) or not fee_data:
+            raise AlmaValidationError(
+                "fee_data must be a non-empty dictionary"
+            )
+        clean_id = user_id.strip()
+
+        endpoint = f"almaws/v1/users/{clean_id}/fees"
+        # Audit-log: the user_id and the fee type only (not amounts /
+        # comments / arbitrary caller-supplied fields).
+        fee_type = fee_data.get("type")
+        self.logger.info(
+            f"Creating fee for user {clean_id} (type={fee_type!r})"
+        )
+        try:
+            response = self.client.post(endpoint, data=fee_data)
+            fee_id: Any = None
+            try:
+                fee_id = (response.data or {}).get("id")
+            except (ValueError, AttributeError):
+                fee_id = None
+            self.logger.info(
+                f"Created fee for user {clean_id} (fee_id={fee_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating fee for user {clean_id}: {e}"
+            )
+            raise
+
+    def get_user_fee(self, user_id: str, fee_id: str) -> Dict[str, Any]:
+        """Retrieve a single fee's details.
+
+        Calls ``GET /almaws/v1/users/{user_id}/fees/{fee_id}`` and
+        returns the unwrapped fee dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_id: Fee identifier as returned by :meth:`list_user_fees`
+                (key ``id`` on each entry). Must be a non-empty string.
+
+        Returns:
+            The fee dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``fee_id`` is empty
+                or not a string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the user or fee does not exist).
+        """
+        # Pattern source: get_user_attachment (above, issue #39) — same
+        # "validate two ids, GET, return dict" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_id, str) or not fee_id.strip():
+            raise AlmaValidationError("Fee ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_fee_id = fee_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/fees/{clean_fee_id}"
+        )
+        self.logger.info(
+            f"Retrieving fee {clean_fee_id} for user {clean_user_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved fee {clean_fee_id} for user {clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving fee {clean_fee_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def pay_all_user_fees(
+        self,
+        user_id: str,
+        amount: str = "ALL",
+        method: str = "CASH",
+        external_transaction_id: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Pay all of a user's outstanding fees in one operation.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/fees/all?op=pay&amount=...&method=...``.
+        The ``op``, ``amount``, ``method``, and (when supplied)
+        ``external_transaction_id`` are sent as **query parameters**, not
+        in the request body — Alma's documented convention for this
+        endpoint.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            amount: The literal string ``"ALL"`` (default — pay the full
+                outstanding balance) or a numeric string (e.g.
+                ``"12.50"``). Validated client-side; non-conforming
+                values raise :class:`AlmaValidationError` before any
+                HTTP call is issued.
+            method: Payment method (Alma values: ``"CASH"``, ``"CREDIT"``,
+                ``"CHECK"``, ``"ONLINE"``, ``"WIRE"``). Defaults to
+                ``"CASH"``.
+            external_transaction_id: Optional external system identifier
+                (e.g. payment-gateway transaction id). Forwarded only
+                when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty/not a string,
+                or if ``amount`` is not ``"ALL"`` and not a numeric
+                string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: upload_user_attachment (issue #39) for the
+        # validate-and-POST discipline. This is the audit-corrected
+        # signature: ``amount="ALL"`` default + query-param transport.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        self._validate_pay_amount(amount)
+        if not isinstance(method, str) or not method.strip():
+            raise AlmaValidationError("method must be a non-empty string")
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {
+            "op": "pay",
+            "amount": amount.strip(),
+            "method": method.strip(),
+        }
+        if external_transaction_id is not None:
+            params["external_transaction_id"] = external_transaction_id
+
+        endpoint = f"almaws/v1/users/{clean_id}/fees/all"
+        self.logger.info(
+            f"Paying all fees for user {clean_id} "
+            f"(amount={params['amount']!r}, method={params['method']!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Paid all fees for user {clean_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error paying all fees for user {clean_id}: {e}"
+            )
+            raise
+
+    def pay_user_fee(
+        self,
+        user_id: str,
+        fee_id: str,
+        amount: str,
+        method: str = "CASH",
+        external_transaction_id: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Pay (in full or in part) a single fee.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/fees/{fee_id}?op=pay&amount=...&method=...``.
+        ``op``, ``amount``, ``method``, and (when supplied)
+        ``external_transaction_id`` are sent as **query parameters**.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_id: Fee identifier. Must be a non-empty string.
+            amount: ``"ALL"`` (sentinel — pay the full remaining balance)
+                or a numeric string (e.g. ``"5.00"``). Validated
+                client-side.
+            method: Payment method (default ``"CASH"``).
+            external_transaction_id: Optional external system identifier
+                forwarded only when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If any required input is empty/wrong
+                type, or if ``amount`` is malformed.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: pay_all_user_fees (above) — same op-driven
+        # POST shape, scoped to a specific fee.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_id, str) or not fee_id.strip():
+            raise AlmaValidationError("Fee ID cannot be empty")
+        self._validate_pay_amount(amount)
+        if not isinstance(method, str) or not method.strip():
+            raise AlmaValidationError("method must be a non-empty string")
+        clean_user_id = user_id.strip()
+        clean_fee_id = fee_id.strip()
+
+        params: Dict[str, Any] = {
+            "op": "pay",
+            "amount": amount.strip(),
+            "method": method.strip(),
+        }
+        if external_transaction_id is not None:
+            params["external_transaction_id"] = external_transaction_id
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/fees/{clean_fee_id}"
+        )
+        self.logger.info(
+            f"Paying fee {clean_fee_id} for user {clean_user_id} "
+            f"(amount={params['amount']!r}, method={params['method']!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Paid fee {clean_fee_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error paying fee {clean_fee_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def waive_user_fee(
+        self,
+        user_id: str,
+        fee_id: str,
+        reason: str,
+        amount: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Waive (in full or in part) a single fee.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/fees/{fee_id}?op=waive&reason=...``.
+        ``op``, ``reason``, and (when supplied) ``amount`` and
+        ``comment`` are sent as **query parameters**. ``method`` is NOT
+        sent on waive — only on pay / pay_all.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_id: Fee identifier. Must be a non-empty string.
+            reason: Reason for the waiver. **Required** for ``op=waive``;
+                empty / whitespace / non-string values raise
+                :class:`AlmaValidationError`.
+            amount: Optional partial-waive amount as a string (e.g.
+                ``"3.00"``). When ``None``, Alma waives the full balance.
+            comment: Optional free-text comment. Forwarded only when
+                non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If any required input is empty/wrong
+                type. ``reason`` is required.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: pay_user_fee (above) — same op-driven POST
+        # shape, but ``reason`` is required (audit fix #2: dispute does
+        # NOT require reason; only waive does).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_id, str) or not fee_id.strip():
+            raise AlmaValidationError("Fee ID cannot be empty")
+        if not isinstance(reason, str) or not reason.strip():
+            raise AlmaValidationError(
+                "reason is required for op=waive and must be a non-empty string"
+            )
+        clean_user_id = user_id.strip()
+        clean_fee_id = fee_id.strip()
+
+        params: Dict[str, Any] = {
+            "op": "waive",
+            "reason": reason.strip(),
+        }
+        if amount is not None:
+            params["amount"] = amount
+        if comment is not None:
+            params["comment"] = comment
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/fees/{clean_fee_id}"
+        )
+        self.logger.info(
+            f"Waiving fee {clean_fee_id} for user {clean_user_id} "
+            f"(reason={params['reason']!r}, amount={amount!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Waived fee {clean_fee_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error waiving fee {clean_fee_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def dispute_user_fee(
+        self,
+        user_id: str,
+        fee_id: str,
+        reason: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Mark a single fee as disputed.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/fees/{fee_id}?op=dispute``.
+        ``op`` is always sent; ``reason`` and ``comment`` are sent only
+        when non-``None``. ``method`` is NOT sent on dispute.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_id: Fee identifier. Must be a non-empty string.
+            reason: **Optional** dispute reason. The audit (2026-05-08)
+                corrected the original "reason required" bug — only
+                ``waive`` requires a reason. Forwarded only when
+                non-``None`` and non-empty.
+            comment: Optional free-text comment. Forwarded only when
+                non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``fee_id`` is empty.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: waive_user_fee (above) — same op-driven POST
+        # shape, but ``reason`` is OPTIONAL (audit fix #2).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_id, str) or not fee_id.strip():
+            raise AlmaValidationError("Fee ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_fee_id = fee_id.strip()
+
+        params: Dict[str, Any] = {"op": "dispute"}
+        # Only forward ``reason`` if a non-empty string was supplied —
+        # an empty / whitespace value would just clutter the query
+        # string. ``None`` default makes the arg fully optional.
+        if reason is not None and isinstance(reason, str) and reason.strip():
+            params["reason"] = reason.strip()
+        if comment is not None:
+            params["comment"] = comment
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/fees/{clean_fee_id}"
+        )
+        self.logger.info(
+            f"Disputing fee {clean_fee_id} for user {clean_user_id} "
+            f"(reason={params.get('reason')!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Disputed fee {clean_fee_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error disputing fee {clean_fee_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def restore_user_fee(
+        self,
+        user_id: str,
+        fee_id: str,
+        comment: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Restore a previously-disputed fee back to active status.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/fees/{fee_id}?op=restore``.
+        Only ``op`` and (optionally) ``comment`` are sent — no
+        ``reason``, no ``amount``, no ``method``.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            fee_id: Fee identifier. Must be a non-empty string.
+            comment: Optional free-text comment. Forwarded only when
+                non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``fee_id`` is empty.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: dispute_user_fee (above) — same op-driven POST
+        # shape; restore takes only the comment kwarg (audit fix #3:
+        # no reason / amount / method).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(fee_id, str) or not fee_id.strip():
+            raise AlmaValidationError("Fee ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_fee_id = fee_id.strip()
+
+        params: Dict[str, Any] = {"op": "restore"}
+        if comment is not None:
+            params["comment"] = comment
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/fees/{clean_fee_id}"
+        )
+        self.logger.info(
+            f"Restoring fee {clean_fee_id} for user {clean_user_id}"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Restored fee {clean_fee_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error restoring fee {clean_fee_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
     def update_user(self, user_id: str, user_data: Dict[str, Any]) -> AlmaResponse:
         """
         Update a user record.

--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -4,12 +4,14 @@ Aligned with AlmaAPIClient integration patterns and focused on email update work
 for users expired 2+ years from Alma sets.
 """
 
+import base64
 import logging
 import os
 import re
 import sys
 import time
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 # Import the working AlmaAPIClient and its response/error classes
@@ -292,6 +294,283 @@ class Users:
         except AlmaAPIError as e:
             self.logger.error(
                 f"API error retrieving personal data for user {clean_id}: {e}"
+            )
+            raise
+
+    # ------------------------------------------------------------------
+    # User attachments (issue #39)
+    # ------------------------------------------------------------------
+    #
+    # The user-attachments endpoints expose three operations: list, get,
+    # and upload. Alma documents (and the public Swagger) does NOT expose
+    # a DELETE endpoint, and live SANDBOX probing on 2026-05-08 confirmed
+    # that ``DELETE /almaws/v1/users/{id}/attachments/{att_id}`` is not
+    # routed (alma_code 401861, "User with identifier ... not found"
+    # because the router collapses the path into a malformed user
+    # lookup). No ``delete_user_attachment`` is provided.
+    #
+    # Upload is JSON+base64 (verified live 2026-05-08), NOT multipart.
+    # The request body's ``type`` field is a plain string ("GENERAL"),
+    # NOT the ``{"value": "GENERAL"}`` wrapper Alma uses elsewhere — that
+    # wrapper produces 400 ("Cannot deserialize value of type
+    # java.lang.String from Object value"). File contents and the base64
+    # payload are NEVER logged (matches the GDPR-discipline established
+    # by ``get_user_personal_data`` above).
+    #
+    # Read patterns mirror ``Configuration.list_libraries`` /
+    # ``Configuration.get_library`` (issue #24): single GET, unwrap the
+    # Alma envelope, return list/dict.
+
+    def list_user_attachments(self, user_id: str) -> List[Dict[str, Any]]:
+        """List all attachments for a user.
+
+        Calls ``GET /almaws/v1/users/{user_id}/attachments`` and unwraps
+        the Alma response envelope into a flat list. The envelope key
+        observed in live SANDBOX is ``user_attachment``; fall back to
+        ``attachment`` defensively in case the endpoint reverts to the
+        legacy shape on a future Alma release.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+
+        Returns:
+            List of attachment dicts as returned by Alma. Returns an
+            empty list when the user has no attachments (or when the
+            response envelope is missing both candidate keys).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: Configuration.list_libraries (configuration.py
+        # line 218, issue #24) for the "single GET, unwrap envelope,
+        # return list" idiom. ``user_id`` validation mirrors
+        # ``get_user_personal_data`` (above).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        endpoint = f"almaws/v1/users/{clean_id}/attachments"
+        self.logger.info(
+            f"Listing attachments for user {clean_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            payload = response.json() or {}
+            # The live response envelope is ``user_attachment``; some
+            # legacy / undocumented variants use plain ``attachment``.
+            attachments = (
+                payload.get("user_attachment")
+                or payload.get("attachment")
+                or []
+            )
+            if isinstance(attachments, dict):
+                # Single-record responses can come back as a dict; normalise.
+                attachments = [attachments]
+            self.logger.info(
+                f"Retrieved {len(attachments)} attachments for user {clean_id}"
+            )
+            return attachments
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing attachments for user {clean_id}: {e}"
+            )
+            raise
+
+    def get_user_attachment(
+        self,
+        user_id: str,
+        attachment_id: str,
+        expand: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retrieve a single attachment's metadata (and optionally content).
+
+        Calls ``GET /almaws/v1/users/{user_id}/attachments/{attachment_id}``.
+        The ``expand`` query parameter is forwarded only when non-``None``
+        and supports Alma's documented values ``"content"`` (returns the
+        base64-encoded file inline) and ``"content_no_encoding"`` (returns
+        raw content).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            attachment_id: Attachment identifier as returned by
+                :meth:`list_user_attachments` (key ``id`` on each entry).
+                Must be a non-empty string.
+            expand: Optional Alma ``expand`` directive. Pass
+                ``"content"`` to receive the file bytes inline (the
+                ``content`` key in the response will hold the base64
+                payload), ``"content_no_encoding"`` for unencoded
+                bytes, or ``None`` for metadata only. Defaults to
+                ``None``.
+
+        Returns:
+            The attachment dict as returned by Alma. Callers that
+            requested ``expand="content"`` are responsible for
+            base64-decoding ``result["content"]`` themselves.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``attachment_id`` is
+                empty or not a string.
+            AlmaAPIError: If the API request fails (including 404 when
+                the user or attachment does not exist).
+        """
+        # Pattern source: Configuration.get_library (configuration.py
+        # line 270, issue #24) — validate, log entry, GET, log success,
+        # propagate API errors.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(attachment_id, str) or not attachment_id.strip():
+            raise AlmaValidationError("Attachment ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_attachment_id = attachment_id.strip()
+
+        params: Dict[str, Any] = {}
+        if expand is not None:
+            params["expand"] = expand
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/attachments/"
+            f"{clean_attachment_id}"
+        )
+        self.logger.info(
+            f"Retrieving attachment {clean_attachment_id} for user "
+            f"{clean_user_id} (expand={expand!r})"
+        )
+        try:
+            response = self.client.get(
+                endpoint, params=params if params else None
+            )
+            data: Dict[str, Any] = response.json() or {}
+            # Never log the body — when expand="content" the response
+            # carries the file payload itself.
+            self.logger.info(
+                f"Retrieved attachment {clean_attachment_id} for user "
+                f"{clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving attachment {clean_attachment_id} "
+                f"for user {clean_user_id}: {e}"
+            )
+            raise
+
+    def upload_user_attachment(
+        self,
+        user_id: str,
+        file_path: str,
+        attachment_data: Optional[Dict[str, Any]] = None,
+    ) -> AlmaResponse:
+        """Upload a new attachment to a user record.
+
+        Calls ``POST /almaws/v1/users/{user_id}/attachments`` with a
+        JSON body containing the file's base64-encoded contents. The
+        body shape was verified against live SANDBOX on 2026-05-08:
+
+        .. code-block:: json
+
+            {
+              "type": "GENERAL",
+              "note": "<description>",
+              "file_name": "<filename>",
+              "content": "<base64-encoded file bytes>"
+            }
+
+        Notably, ``type`` is a **plain string**, not the
+        ``{"value": "GENERAL"}`` wrapper Alma uses elsewhere — the
+        wrapped form returns 400 ("Cannot deserialize value of type
+        java.lang.String from Object value"). The file's bytes and the
+        base64 payload are never logged; only ``user_id``, ``file_name``,
+        and ``size_bytes`` reach the audit trail.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            file_path: Filesystem path to the file to upload. Must be a
+                non-empty string and must point to an existing file.
+            attachment_data: Optional override dict for the request
+                body. When supplied it is shallow-copied; ``file_name``
+                defaults to the basename of ``file_path`` (when not
+                already set), ``content`` is overridden with the
+                base64-encoded file bytes, and ``type`` defaults to
+                ``"GENERAL"`` when not already set. Useful for
+                supplying ``note`` / ``description`` fields without
+                rebuilding the body shape.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response. The created
+            attachment's identifier lives at ``response.data["id"]``.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``file_path`` is
+                empty / not a string, or if ``file_path`` does not point
+                to an existing file.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: get_user_personal_data (above) for the
+        # "validate inputs, log without leaking sensitive content"
+        # discipline; Configuration.list_libraries for the
+        # AlmaResponse handoff pattern.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(file_path, str) or not file_path.strip():
+            raise AlmaValidationError(
+                "file_path is required and must be a non-empty string"
+            )
+
+        clean_user_id = user_id.strip()
+        path = Path(file_path)
+        if not path.is_file():
+            raise AlmaValidationError(
+                f"file_path does not point to an existing file: {file_path}"
+            )
+
+        # Read file bytes and base64-encode. The encoded payload is
+        # passed to Alma as a UTF-8 string — never logged.
+        file_bytes = path.read_bytes()
+        size_bytes = len(file_bytes)
+        encoded = base64.b64encode(file_bytes).decode("ascii")
+
+        # Build the JSON body. Shallow-copy any caller-supplied dict so
+        # we never mutate the operator's data.
+        body: Dict[str, Any] = (
+            dict(attachment_data) if attachment_data else {}
+        )
+        body.setdefault("type", "GENERAL")
+        body.setdefault("file_name", path.name)
+        # Always override content with the freshly-read base64 payload
+        # so a caller-supplied stale ``content`` cannot win.
+        body["content"] = encoded
+
+        endpoint = f"almaws/v1/users/{clean_user_id}/attachments"
+        # Audit-log: identifier + filename + size only. NEVER the body
+        # or the base64 payload.
+        self.logger.info(
+            f"Uploading attachment for user {clean_user_id} "
+            f"(file_name={body['file_name']!r}, size_bytes={size_bytes})"
+        )
+        try:
+            response = self.client.post(endpoint, data=body)
+            attachment_id: Any = None
+            try:
+                attachment_id = (response.data or {}).get("id")
+            except (ValueError, AttributeError):
+                # Non-JSON / unparseable body — surface the AlmaResponse
+                # to the caller anyway; the error path below logs only
+                # the status code, not any body content.
+                attachment_id = None
+            self.logger.info(
+                f"Uploaded attachment for user {clean_user_id} "
+                f"(attachment_id={attachment_id!r}, "
+                f"file_name={body['file_name']!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error uploading attachment for user "
+                f"{clean_user_id} (file_name={body['file_name']!r}): {e}"
             )
             raise
 

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -1,5 +1,5 @@
 """
-Unit tests for the Users domain class — issue #36 / #39 coverage:
+Unit tests for the Users domain class — issue #36 / #39 / #44 / #45 coverage:
 
 - ``Users.list_users`` — list/search via ``GET /almaws/v1/users``
 - ``Users.search_users`` — convenience wrapper requiring ``q``
@@ -12,6 +12,12 @@ Unit tests for the Users domain class — issue #36 / #39 coverage:
   (issue #39)
 - ``Users.upload_user_attachment`` — upload an attachment via
   ``POST /almaws/v1/users/{user_id}/attachments`` (issue #39)
+- ``Users.{list,create,get}_user_fee`` and op-driven posts
+  (``pay_all_user_fees`` / ``pay_user_fee`` / ``waive_user_fee`` /
+  ``dispute_user_fee`` / ``restore_user_fee``) — fines/fees coverage
+  (issue #44)
+- ``Users.{list,create,get}_user_deposit`` and
+  ``perform_user_deposit_action`` — deposits coverage (issue #45)
 
 Tests use a mocked AlmaAPIClient stand-in (no real HTTP) following the
 mock-shape established in ``tests/unit/domains/test_configuration.py``.
@@ -1905,6 +1911,413 @@ class TestRestoreUserFee:
 
         with pytest.raises(AlmaAPIError):
             users.restore_user_fee("u1", "fee-1")
+
+
+# ---------------------------------------------------------------------------
+# list_user_deposits  (issue #45)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserDeposits:
+    """Tests for ``Users.list_user_deposits`` (issue #45)."""
+
+    def test_list_user_deposits_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "deposit": [
+                    {"id": "dep-1", "amount": "10.00"},
+                    {"id": "dep-2", "amount": "20.00"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_deposits("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits"
+        # No params expected for list.
+        assert call["params"] is None
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "dep-1"
+
+    def test_list_user_deposits_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"deposit": []})
+        users = Users(mock_client)
+
+        users.list_user_deposits("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits"
+
+    def test_list_user_deposits_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_deposits("u1")
+
+        assert result == []
+
+    def test_list_user_deposits_handles_single_dict_response(self):
+        """A single deposit returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"deposit": {"id": "only-dep"}, "total_record_count": 1}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_deposits("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "only-dep"
+
+    def test_list_user_deposits_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_deposits("")
+
+    def test_list_user_deposits_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_deposits(None)  # type: ignore[arg-type]
+
+    def test_list_user_deposits_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Failed to get deposits.", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_user_deposits("u1")
+
+
+# ---------------------------------------------------------------------------
+# create_user_deposit  (issue #45)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserDeposit:
+    """Tests for ``Users.create_user_deposit`` (issue #45)."""
+
+    def test_create_user_deposit_posts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        deposit_body = {
+            "amount": "50.00",
+            "currency": {"value": "USD"},
+            "type": {"value": "CASH"},
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "dep-99", "amount": "50.00"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_deposit("u1", deposit_body)
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits"
+        # JSON body, not multipart.
+        assert call["content_type"] is None
+        # Body is the operator-supplied dict verbatim.
+        assert call["data"] == deposit_body
+        # No query params on creation.
+        assert call["params"] is None
+        assert response.data["id"] == "dep-99"
+
+    def test_create_user_deposit_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "dep-1"})
+        users = Users(mock_client)
+
+        users.create_user_deposit("  u1  ", {"amount": "5.00"})
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits"
+
+    def test_create_user_deposit_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_deposit("", {"amount": "5.00"})
+
+    def test_create_user_deposit_raises_on_empty_deposit_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_deposit("u1", {})
+
+    def test_create_user_deposit_raises_on_non_dict_deposit_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_deposit("u1", "not-a-dict")  # type: ignore[arg-type]
+
+    def test_create_user_deposit_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "X parameter is not valid.", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.create_user_deposit("u1", {"amount": "5.00"})
+
+
+# ---------------------------------------------------------------------------
+# get_user_deposit  (issue #45)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserDeposit:
+    """Tests for ``Users.get_user_deposit`` (issue #45)."""
+
+    def test_get_user_deposit_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "dep-1",
+                "amount": "25.00",
+                "currency": {"value": "USD"},
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_deposit("u1", "dep-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits/dep-1"
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["id"] == "dep-1"
+
+    def test_get_user_deposit_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "dep-1"})
+        users = Users(mock_client)
+
+        users.get_user_deposit("  u1  ", "  dep-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits/dep-1"
+
+    def test_get_user_deposit_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_deposit("", "dep-1")
+
+    def test_get_user_deposit_raises_on_empty_deposit_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_deposit("u1", "")
+
+    def test_get_user_deposit_raises_on_non_string_ids(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_deposit(None, "dep-1")  # type: ignore[arg-type]
+        with pytest.raises(AlmaValidationError):
+            users.get_user_deposit("u1", None)  # type: ignore[arg-type]
+
+    def test_get_user_deposit_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Failed to get deposit.", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.get_user_deposit("u1", "dep-1")
+
+
+# ---------------------------------------------------------------------------
+# perform_user_deposit_action  (issue #45)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformUserDepositAction:
+    """Tests for ``Users.perform_user_deposit_action`` (issue #45)."""
+
+    def test_perform_user_deposit_action_sends_op_as_param(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        response = users.perform_user_deposit_action("u1", "dep-1", "pay")
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits/dep-1"
+        # op travels as query param, body is empty.
+        assert call["data"] is None
+        assert call["params"] == {"op": "pay"}
+        assert response.data == {"status": "ok"}
+
+    def test_perform_user_deposit_action_accepts_arbitrary_op(self):
+        """Wrapper does NOT restrict op values; arbitrary strings reach Alma."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        # Use an op that's neither pay/refund/dispute/restore — wrapper
+        # should still forward it.
+        users.perform_user_deposit_action("u1", "dep-1", "future_op_x")
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"op": "future_op_x"}
+
+    def test_perform_user_deposit_action_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.perform_user_deposit_action("  u1  ", "  dep-1  ", "  refund  ")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/deposits/dep-1"
+        assert call["params"] == {"op": "refund"}
+
+    def test_perform_user_deposit_action_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_deposit_action("", "dep-1", "pay")
+
+    def test_perform_user_deposit_action_raises_on_empty_deposit_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_deposit_action("u1", "", "pay")
+
+    def test_perform_user_deposit_action_raises_on_empty_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_deposit_action("u1", "dep-1", "")
+
+    def test_perform_user_deposit_action_raises_on_whitespace_only_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_deposit_action("u1", "dep-1", "   ")
+
+    def test_perform_user_deposit_action_raises_on_non_string_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_deposit_action("u1", "dep-1", None)  # type: ignore[arg-type]
+
+    def test_perform_user_deposit_action_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "General Error - An error has occurred while updating the deposit.",
+            status_code=400,
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.perform_user_deposit_action("u1", "dep-1", "pay")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -1024,6 +1024,890 @@ class TestUploadUserAttachment:
 
 
 # ---------------------------------------------------------------------------
+# list_user_fees  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserFees:
+    """Tests for ``Users.list_user_fees`` (issue #44)."""
+
+    def test_list_user_fees_calls_correct_endpoint_no_status(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "fee": [
+                    {"id": "fee-1", "type": {"value": "OVERDUEFINEFEE"}},
+                    {"id": "fee-2", "type": {"value": "LOSTITEMREPLACEMENTFEE"}},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_fees("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees"
+        # No status filter → params should be None (not empty dict).
+        assert call["params"] is None
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "fee-1"
+
+    def test_list_user_fees_forwards_status_filter(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"fee": [{"id": "fee-1"}], "total_record_count": 1}
+        )
+        users = Users(mock_client)
+
+        users.list_user_fees("u1", status="ACTIVE")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"status": "ACTIVE"}
+
+    def test_list_user_fees_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"fee": []})
+        users = Users(mock_client)
+
+        users.list_user_fees("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees"
+
+    def test_list_user_fees_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_fees("u1")
+
+        assert result == []
+
+    def test_list_user_fees_handles_single_dict_response(self):
+        """A single fee returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"fee": {"id": "only-fee"}, "total_record_count": 1}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_fees("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "only-fee"
+
+    def test_list_user_fees_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_fees("")
+
+    def test_list_user_fees_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_fees(None)  # type: ignore[arg-type]
+
+    def test_list_user_fees_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_user_fees("u1")
+
+
+# ---------------------------------------------------------------------------
+# create_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserFee:
+    """Tests for ``Users.create_user_fee`` (issue #44)."""
+
+    def test_create_user_fee_posts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        fee_body = {
+            "type": {"value": "CREDIT"},
+            "original_amount": "10.00",
+            "balance": "10.00",
+            "owner": {"value": "MAIN"},
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "fee-99", "type": {"value": "CREDIT"}}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_fee("u1", fee_body)
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees"
+        # JSON body, not multipart.
+        assert call["content_type"] is None
+        # Body is the operator-supplied dict verbatim.
+        assert call["data"] == fee_body
+        # No query params on creation.
+        assert call["params"] is None
+        assert response.data["id"] == "fee-99"
+
+    def test_create_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_fee("", {"type": "X"})
+
+    def test_create_user_fee_raises_on_empty_fee_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_fee("u1", {})
+
+    def test_create_user_fee_raises_on_non_dict_fee_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_fee("u1", "not-a-dict")  # type: ignore[arg-type]
+
+    def test_create_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "User fine/fee type is required.", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.create_user_fee("u1", {"original_amount": "5.00"})
+
+
+# ---------------------------------------------------------------------------
+# get_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserFee:
+    """Tests for ``Users.get_user_fee`` (issue #44)."""
+
+    def test_get_user_fee_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "fee-1",
+                "type": {"value": "OVERDUEFINEFEE"},
+                "original_amount": "5.00",
+                "balance": "5.00",
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_fee("u1", "fee-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["id"] == "fee-1"
+
+    def test_get_user_fee_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "fee-1"})
+        users = Users(mock_client)
+
+        users.get_user_fee("  u1  ", "  fee-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+
+    def test_get_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_fee("", "fee-1")
+
+    def test_get_user_fee_raises_on_empty_fee_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_fee("u1", "")
+
+    def test_get_user_fee_returns_empty_dict_on_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_fee("u1", "fee-1")
+
+        assert result == {}
+
+    def test_get_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Not found", status_code=404
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.get_user_fee("u1", "missing-fee")
+
+
+# ---------------------------------------------------------------------------
+# pay_all_user_fees  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestPayAllUserFees:
+    """Tests for ``Users.pay_all_user_fees`` (issue #44)."""
+
+    def test_pay_all_user_fees_defaults_send_op_amount_method_as_params(self):
+        """Default call: op=pay, amount=ALL, method=CASH as query params."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_all_user_fees("u1")
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/all"
+        # No body — all transport is via query params.
+        assert call["data"] is None
+        assert call["params"] == {
+            "op": "pay",
+            "amount": "ALL",
+            "method": "CASH",
+        }
+
+    def test_pay_all_user_fees_forwards_numeric_amount_and_method(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_all_user_fees("u1", amount="12.50", method="CREDIT")
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "pay",
+            "amount": "12.50",
+            "method": "CREDIT",
+        }
+
+    def test_pay_all_user_fees_forwards_external_transaction_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_all_user_fees(
+            "u1",
+            amount="ALL",
+            method="ONLINE",
+            external_transaction_id="txn-abc",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"]["external_transaction_id"] == "txn-abc"
+
+    def test_pay_all_user_fees_omits_external_transaction_id_when_none(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_all_user_fees("u1")
+
+        call = mock_client.calls["post"][0]
+        assert "external_transaction_id" not in call["params"]
+
+    def test_pay_all_user_fees_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_all_user_fees("")
+        # No HTTP call on failed validation.
+        assert mock_client.calls["post"] == []
+
+    def test_pay_all_user_fees_rejects_non_numeric_non_all_amount(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_all_user_fees("u1", amount="not-a-number")
+        assert mock_client.calls["post"] == []
+
+    def test_pay_all_user_fees_rejects_amount_with_two_decimals(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_all_user_fees("u1", amount="1.2.3")
+
+    def test_pay_all_user_fees_rejects_empty_amount(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_all_user_fees("u1", amount="")
+
+    def test_pay_all_user_fees_rejects_empty_method(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_all_user_fees("u1", method="")
+
+    def test_pay_all_user_fees_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=400)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.pay_all_user_fees("u1")
+
+
+# ---------------------------------------------------------------------------
+# pay_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestPayUserFee:
+    """Tests for ``Users.pay_user_fee`` (issue #44)."""
+
+    def test_pay_user_fee_sends_op_amount_method_as_params(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_user_fee("u1", "fee-1", amount="5.00")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+        assert call["data"] is None
+        assert call["params"] == {
+            "op": "pay",
+            "amount": "5.00",
+            "method": "CASH",
+        }
+
+    def test_pay_user_fee_accepts_amount_all_sentinel(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_user_fee("u1", "fee-1", amount="ALL", method="CREDIT")
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "pay",
+            "amount": "ALL",
+            "method": "CREDIT",
+        }
+
+    def test_pay_user_fee_forwards_external_transaction_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.pay_user_fee(
+            "u1",
+            "fee-1",
+            amount="3.00",
+            external_transaction_id="ext-xyz",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"]["external_transaction_id"] == "ext-xyz"
+
+    def test_pay_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_user_fee("", "fee-1", amount="1.00")
+
+    def test_pay_user_fee_raises_on_empty_fee_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_user_fee("u1", "", amount="1.00")
+
+    def test_pay_user_fee_rejects_bad_amount(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.pay_user_fee("u1", "fee-1", amount="abc")
+
+    def test_pay_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "The fee is API Restricted by library.", status_code=400
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.pay_user_fee("u1", "fee-1", amount="5.00")
+
+
+# ---------------------------------------------------------------------------
+# waive_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestWaiveUserFee:
+    """Tests for ``Users.waive_user_fee`` (issue #44)."""
+
+    def test_waive_user_fee_required_reason_sent_as_param(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.waive_user_fee("u1", "fee-1", reason="GOODWILL")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+        assert call["data"] is None
+        assert call["params"] == {"op": "waive", "reason": "GOODWILL"}
+        # method must NOT be sent on waive.
+        assert "method" not in call["params"]
+
+    def test_waive_user_fee_with_partial_amount_and_comment(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.waive_user_fee(
+            "u1",
+            "fee-1",
+            reason="GOODWILL",
+            amount="2.50",
+            comment="Partial waive per supervisor",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "waive",
+            "reason": "GOODWILL",
+            "amount": "2.50",
+            "comment": "Partial waive per supervisor",
+        }
+
+    def test_waive_user_fee_strips_reason_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.waive_user_fee("u1", "fee-1", reason="  GOODWILL  ")
+
+        call = mock_client.calls["post"][0]
+        assert call["params"]["reason"] == "GOODWILL"
+
+    def test_waive_user_fee_raises_on_missing_reason(self):
+        """Reason is REQUIRED for op=waive."""
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.waive_user_fee("u1", "fee-1", reason="")
+        assert mock_client.calls["post"] == []
+
+    def test_waive_user_fee_raises_on_whitespace_reason(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.waive_user_fee("u1", "fee-1", reason="   ")
+
+    def test_waive_user_fee_raises_on_non_string_reason(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.waive_user_fee(
+                "u1", "fee-1", reason=None  # type: ignore[arg-type]
+            )
+
+    def test_waive_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.waive_user_fee("", "fee-1", reason="GOODWILL")
+
+    def test_waive_user_fee_raises_on_empty_fee_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.waive_user_fee("u1", "", reason="GOODWILL")
+
+    def test_waive_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=400)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.waive_user_fee("u1", "fee-1", reason="GOODWILL")
+
+
+# ---------------------------------------------------------------------------
+# dispute_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestDisputeUserFee:
+    """Tests for ``Users.dispute_user_fee`` (issue #44).
+
+    Audit fix #2: ``reason`` is OPTIONAL on dispute (not required).
+    """
+
+    def test_dispute_user_fee_minimal_no_reason_no_comment(self):
+        """Dispute with just user_id + fee_id sends only op=dispute."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.dispute_user_fee("u1", "fee-1")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+        assert call["data"] is None
+        assert call["params"] == {"op": "dispute"}
+        # reason MUST be absent when not provided (audit fix).
+        assert "reason" not in call["params"]
+        # method MUST NOT be sent on dispute.
+        assert "method" not in call["params"]
+        # comment MUST be absent when not provided.
+        assert "comment" not in call["params"]
+
+    def test_dispute_user_fee_with_reason(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.dispute_user_fee("u1", "fee-1", reason="LOST_RECEIPT")
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "dispute",
+            "reason": "LOST_RECEIPT",
+        }
+
+    def test_dispute_user_fee_with_comment_only(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.dispute_user_fee(
+            "u1", "fee-1", comment="Patron filed a written objection"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "dispute",
+            "comment": "Patron filed a written objection",
+        }
+        assert "reason" not in call["params"]
+
+    def test_dispute_user_fee_with_reason_and_comment(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.dispute_user_fee(
+            "u1", "fee-1", reason="LOST_RECEIPT", comment="See ticket #123"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "dispute",
+            "reason": "LOST_RECEIPT",
+            "comment": "See ticket #123",
+        }
+
+    def test_dispute_user_fee_drops_empty_reason_string(self):
+        """An empty/whitespace reason string is dropped (treated as None)."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.dispute_user_fee("u1", "fee-1", reason="   ")
+
+        call = mock_client.calls["post"][0]
+        assert "reason" not in call["params"]
+
+    def test_dispute_user_fee_does_not_require_reason(self):
+        """Regression: the audit-fixed signature must NOT raise on no reason."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        # Should not raise.
+        users.dispute_user_fee("u1", "fee-1")
+        assert len(mock_client.calls["post"]) == 1
+
+    def test_dispute_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.dispute_user_fee("", "fee-1")
+
+    def test_dispute_user_fee_raises_on_empty_fee_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.dispute_user_fee("u1", "")
+
+    def test_dispute_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.dispute_user_fee("u1", "fee-1")
+
+
+# ---------------------------------------------------------------------------
+# restore_user_fee  (issue #44)
+# ---------------------------------------------------------------------------
+
+
+class TestRestoreUserFee:
+    """Tests for ``Users.restore_user_fee`` (issue #44)."""
+
+    def test_restore_user_fee_sends_only_op(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.restore_user_fee("u1", "fee-1")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+        assert call["data"] is None
+        assert call["params"] == {"op": "restore"}
+        # No reason/amount/method on restore.
+        assert "reason" not in call["params"]
+        assert "amount" not in call["params"]
+        assert "method" not in call["params"]
+
+    def test_restore_user_fee_with_comment(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.restore_user_fee(
+            "u1", "fee-1", comment="Dispute resolved against patron"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "restore",
+            "comment": "Dispute resolved against patron",
+        }
+
+    def test_restore_user_fee_strips_whitespace_in_ids(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"status": "ok"})
+        users = Users(mock_client)
+
+        users.restore_user_fee("  u1  ", "  fee-1  ")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/fees/fee-1"
+
+    def test_restore_user_fee_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.restore_user_fee("", "fee-1")
+
+    def test_restore_user_fee_raises_on_empty_fee_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.restore_user_fee("u1", "")
+
+    def test_restore_user_fee_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=400)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.restore_user_fee("u1", "fee-1")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -1,10 +1,17 @@
 """
-Unit tests for the Users domain class — issue #36 coverage:
+Unit tests for the Users domain class — issue #36 / #39 coverage:
 
 - ``Users.list_users`` — list/search via ``GET /almaws/v1/users``
 - ``Users.search_users`` — convenience wrapper requiring ``q``
 - ``Users.get_user_personal_data`` — GDPR export via
   ``GET /almaws/v1/users/{user_id}/personal-data``
+- ``Users.list_user_attachments`` — list attachments via
+  ``GET /almaws/v1/users/{user_id}/attachments`` (issue #39)
+- ``Users.get_user_attachment`` — retrieve a single attachment via
+  ``GET /almaws/v1/users/{user_id}/attachments/{attachment_id}``
+  (issue #39)
+- ``Users.upload_user_attachment`` — upload an attachment via
+  ``POST /almaws/v1/users/{user_id}/attachments`` (issue #39)
 
 Tests use a mocked AlmaAPIClient stand-in (no real HTTP) following the
 mock-shape established in ``tests/unit/domains/test_configuration.py``.
@@ -57,8 +64,9 @@ class MockAlmaAPIClient:
         self.environment = environment
         self.logger = MagicMock()
         self.get_response: MockAlmaResponse = MockAlmaResponse()
+        self.post_response: MockAlmaResponse = MockAlmaResponse()
         self.next_exception: Optional[Exception] = None
-        self.calls = {"get": []}
+        self.calls = {"get": [], "post": []}
 
     def get_environment(self) -> str:
         return self.environment
@@ -76,6 +84,27 @@ class MockAlmaAPIClient:
             exc, self.next_exception = self.next_exception, None
             raise exc
         return self.get_response
+
+    def post(
+        self,
+        endpoint: str,
+        data: Any = None,
+        params: Optional[Dict[str, Any]] = None,
+        content_type: Optional[str] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["post"].append(
+            {
+                "endpoint": endpoint,
+                "data": data,
+                "params": params,
+                "content_type": content_type,
+            }
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.post_response
 
 
 # ---------------------------------------------------------------------------
@@ -483,6 +512,514 @@ class TestGetUserPersonalData:
             for needle in sensitive_strings:
                 assert needle not in msg, (
                     f"Sensitive value {needle!r} leaked into log: {msg!r}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# list_user_attachments  (issue #39)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserAttachments:
+    """Tests for ``Users.list_user_attachments`` (issue #39)."""
+
+    def test_list_user_attachments_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user_attachment": [
+                    {"id": "att-1", "file_name": "a.pdf"},
+                    {"id": "att-2", "file_name": "b.pdf"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_attachments("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/attachments"
+        # No params on the list endpoint.
+        assert call["params"] is None
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "att-1"
+
+    def test_list_user_attachments_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_attachment": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_attachments("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/attachments"
+
+    def test_list_user_attachments_falls_back_to_attachment_key(self):
+        """Defensive: handle the legacy ``attachment`` envelope key."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"attachment": [{"id": "att-1"}]}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_attachments("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "att-1"
+
+    def test_list_user_attachments_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_attachments("u1")
+
+        assert result == []
+
+    def test_list_user_attachments_handles_single_dict_response(self):
+        """A single attachment as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_attachment": {"id": "only-att"}}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_attachments("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "only-att"
+
+    def test_list_user_attachments_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_attachments("")
+
+    def test_list_user_attachments_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_attachments(None)  # type: ignore[arg-type]
+
+    def test_list_user_attachments_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_user_attachments("u1")
+
+
+# ---------------------------------------------------------------------------
+# get_user_attachment  (issue #39)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserAttachment:
+    """Tests for ``Users.get_user_attachment`` (issue #39)."""
+
+    def test_get_user_attachment_without_expand(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "att-1",
+                "file_name": "a.pdf",
+                "type": "GENERAL",
+                "size": 1024,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_attachment("u1", "att-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/users/u1/attachments/att-1"
+        )
+        # No ``expand`` supplied → params is None (not {"expand": None}).
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["id"] == "att-1"
+        assert result["file_name"] == "a.pdf"
+
+    def test_get_user_attachment_with_expand_content(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "id": "att-1",
+                "file_name": "a.pdf",
+                # Pretend Alma echoes the base64 payload back here.
+                "content": "aGVsbG8=",
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_attachment(
+            "u1", "att-1", expand="content"
+        )
+
+        call = mock_client.calls["get"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/users/u1/attachments/att-1"
+        )
+        assert call["params"] == {"expand": "content"}
+        # The method must NOT base64-decode for the caller — leave it
+        # as-is so callers control decoding.
+        assert result["content"] == "aGVsbG8="
+
+    def test_get_user_attachment_with_expand_content_no_encoding(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"id": "att-1"}
+        )
+        users = Users(mock_client)
+
+        users.get_user_attachment(
+            "u1", "att-1", expand="content_no_encoding"
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"expand": "content_no_encoding"}
+
+    def test_get_user_attachment_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "att-1"})
+        users = Users(mock_client)
+
+        users.get_user_attachment("  u1  ", "  att-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert (
+            call["endpoint"]
+            == "almaws/v1/users/u1/attachments/att-1"
+        )
+
+    def test_get_user_attachment_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_attachment("", "att-1")
+
+    def test_get_user_attachment_raises_on_empty_attachment_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_attachment("u1", "")
+
+    def test_get_user_attachment_raises_on_non_string_attachment_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_attachment("u1", None)  # type: ignore[arg-type]
+
+    def test_get_user_attachment_returns_empty_dict_on_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_attachment("u1", "att-1")
+
+        assert result == {}
+
+    def test_get_user_attachment_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Not found", status_code=404
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.get_user_attachment("u1", "missing-att")
+
+
+# ---------------------------------------------------------------------------
+# upload_user_attachment  (issue #39)
+# ---------------------------------------------------------------------------
+
+
+class TestUploadUserAttachment:
+    """Tests for ``Users.upload_user_attachment`` (issue #39)."""
+
+    def test_upload_user_attachment_happy_path(self, tmp_path):
+        """Upload posts JSON+base64 with the verified body shape."""
+        import base64
+
+        from almaapitk.domains.users import Users
+
+        # Create a small file with deterministic bytes.
+        file_bytes = b"hello world"
+        file_path = tmp_path / "hello.txt"
+        file_path.write_bytes(file_bytes)
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={
+                "id": "12345",
+                "type": "GENERAL",
+                "size": len(file_bytes),
+                "file_name": "hello.txt",
+            }
+        )
+        users = Users(mock_client)
+
+        response = users.upload_user_attachment("u1", str(file_path))
+
+        # One POST to the correct endpoint.
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/attachments"
+        # JSON body, NOT multipart — content_type must be the default.
+        assert call["content_type"] is None
+
+        body = call["data"]
+        assert isinstance(body, dict)
+        # ``type`` is a plain string, NOT a {"value": "..."} wrapper.
+        assert body["type"] == "GENERAL"
+        assert body["file_name"] == "hello.txt"
+        # ``content`` is base64-encoded file bytes.
+        assert body["content"] == base64.b64encode(file_bytes).decode("ascii")
+
+        # Returned AlmaResponse exposes the new attachment's id.
+        assert response.data["id"] == "12345"
+
+    def test_upload_user_attachment_uses_supplied_attachment_data(
+        self, tmp_path
+    ):
+        """Caller-supplied attachment_data overrides defaults except content."""
+        import base64
+
+        from almaapitk.domains.users import Users
+
+        file_bytes = b"abc123"
+        file_path = tmp_path / "doc.pdf"
+        file_path.write_bytes(file_bytes)
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "att-1"})
+        users = Users(mock_client)
+
+        users.upload_user_attachment(
+            "u1",
+            str(file_path),
+            attachment_data={
+                "type": "GENERAL",
+                "note": "Operator-supplied note",
+                # A stale ``content`` value MUST be overridden by the
+                # freshly-encoded file bytes.
+                "content": "STALE_BASE64",
+            },
+        )
+
+        call = mock_client.calls["post"][0]
+        body = call["data"]
+        assert body["type"] == "GENERAL"
+        assert body["note"] == "Operator-supplied note"
+        assert body["file_name"] == "doc.pdf"
+        # Content is the live encoding of the file, NOT the stale value.
+        assert body["content"] == base64.b64encode(file_bytes).decode("ascii")
+        assert body["content"] != "STALE_BASE64"
+
+    def test_upload_user_attachment_does_not_mutate_caller_dict(
+        self, tmp_path
+    ):
+        """``attachment_data`` must be shallow-copied, not mutated in place."""
+        from almaapitk.domains.users import Users
+
+        file_bytes = b"x"
+        file_path = tmp_path / "x.bin"
+        file_path.write_bytes(file_bytes)
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "x"})
+        users = Users(mock_client)
+
+        caller_data = {"type": "GENERAL", "note": "n"}
+        snapshot = dict(caller_data)
+        users.upload_user_attachment(
+            "u1", str(file_path), attachment_data=caller_data
+        )
+
+        # Caller's dict must remain untouched (no ``content`` /
+        # ``file_name`` injected).
+        assert caller_data == snapshot
+
+    def test_upload_user_attachment_defaults_type_to_general(self, tmp_path):
+        from almaapitk.domains.users import Users
+
+        file_path = tmp_path / "f.txt"
+        file_path.write_bytes(b"abc")
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "x"})
+        users = Users(mock_client)
+
+        users.upload_user_attachment("u1", str(file_path))
+
+        body = mock_client.calls["post"][0]["data"]
+        assert body["type"] == "GENERAL"
+
+    def test_upload_user_attachment_raises_on_missing_file(self, tmp_path):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        missing_path = tmp_path / "does_not_exist.bin"
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.upload_user_attachment("u1", str(missing_path))
+        # No HTTP call should have been issued.
+        assert mock_client.calls["post"] == []
+
+    def test_upload_user_attachment_raises_on_directory_path(self, tmp_path):
+        """A directory is not a file — must raise validation error."""
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.upload_user_attachment("u1", str(tmp_path))
+
+    def test_upload_user_attachment_raises_on_empty_file_path(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.upload_user_attachment("u1", "")
+
+    def test_upload_user_attachment_raises_on_non_string_file_path(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.upload_user_attachment(
+                "u1", None  # type: ignore[arg-type]
+            )
+
+    def test_upload_user_attachment_raises_on_empty_user_id(self, tmp_path):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        file_path = tmp_path / "f.txt"
+        file_path.write_bytes(b"abc")
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.upload_user_attachment("", str(file_path))
+
+    def test_upload_user_attachment_propagates_api_error(self, tmp_path):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        file_path = tmp_path / "f.txt"
+        file_path.write_bytes(b"abc")
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.upload_user_attachment("u1", str(file_path))
+
+    def test_upload_user_attachment_does_not_log_file_body_or_base64(
+        self, tmp_path
+    ):
+        """File contents and base64 payload must never appear in logs."""
+        import base64
+
+        from almaapitk.domains.users import Users
+
+        # Use a recognisable byte sequence that we can grep for in logs.
+        file_bytes = b"SUPER_SECRET_FILE_CONTENT_MARKER"
+        file_path = tmp_path / "secret.bin"
+        file_path.write_bytes(file_bytes)
+        encoded = base64.b64encode(file_bytes).decode("ascii")
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "x"})
+        users = Users(mock_client)
+
+        with _captured_logs("Users_SANDBOX") as records:
+            users.upload_user_attachment("u1", str(file_path))
+
+        sensitive_strings = (
+            file_bytes.decode("ascii"),  # raw content
+            encoded,                     # base64 payload
+        )
+        for rec in records:
+            msg = rec.getMessage()
+            for needle in sensitive_strings:
+                assert needle not in msg, (
+                    f"Sensitive value leaked into log: {msg!r}"
                 )
 
 


### PR DESCRIPTION
## Chunk: `users-grab-bag-1`

Closes #39
Closes #44
Closes #45

## Implementation summary

Users class extended with attachments (#39: list/get/upload — verified live JSON+base64 with type as plain string; NO delete because Alma exposes none), fines & fees (#44: list/create/get + 5 op-driven posts with audit-corrected behaviors — pay_all amount validation, dispute reason optional, method only on pay ops), and deposits (#45: list/create/get/perform-action). 106 unit tests added across the three issues.

## SANDBOX test summary

All 7 SANDBOX tests passed. Read smokes + validation guards across all three issues, plus one operator-authorized live attachment upload (t-39-3) that succeeded but leaves a probe attachment on the test user requiring manual UI cleanup (Alma has no DELETE endpoint). Fee/deposit writes are unit-test-only (no pre-existing fixtures, marked unmappable). All three issues labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/users-grab-bag-1/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
