### PR TITLE
chunk: users-crud (#37)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -1422,34 +1422,229 @@ class Users:
             )
             raise
 
+    def create_user(self, user_data: Dict[str, Any]) -> AlmaResponse:
+        """Create a new Alma user.
+
+        Wraps ``POST /almaws/v1/users``. ``user_data`` is passed through
+        to Alma verbatim — the caller is responsible for supplying any
+        optional fields (emails, addresses, identifiers, user statistics,
+        etc.). This method validates only the four core fields Alma
+        requires to materialise a user record:
+
+        - ``primary_id`` (str)
+        - ``account_type`` (str or ``{"value": "..."}`` dict)
+        - ``status`` (str or ``{"value": "..."}`` dict)
+        - ``user_group`` (str or ``{"value": "..."}`` dict)
+
+        The ``{"value": "..."}`` wrapper is the canonical shape Alma
+        returns on reads; both the bare string and the wrapper dict are
+        accepted so callers can round-trip a user object without having
+        to reshape it before sending it back.
+
+        Args:
+            user_data: User object payload. Must be a non-empty dict
+                containing the four required keys above. Any extra keys
+                are forwarded verbatim and validated by Alma server-side.
+
+        Returns:
+            ``AlmaResponse`` wrapping the create response. The created
+            user's primary identifier lives at
+            ``response.data["primary_id"]``.
+
+        Raises:
+            AlmaValidationError: If ``user_data`` is empty/not a dict, or
+                if any of ``primary_id`` / ``account_type`` / ``status``
+                / ``user_group`` is missing or empty.
+            AlmaAPIError: If the API request fails (typed subclass when
+                the Alma error code or HTTP status maps to one — see
+                ``AlmaAPIClient._classify_error``).
+
+        Example:
+            >>> response = users.create_user({
+            ...     "primary_id": "<user_primary_id>",
+            ...     "account_type": {"value": "INTERNAL"},
+            ...     "status": {"value": "ACTIVE"},
+            ...     "user_group": {"value": "STAFF"},
+            ...     "first_name": "Ada",
+            ...     "last_name": "Lovelace",
+            ... })
+            >>> created_id = response.data["primary_id"]
+        """
+        # Pattern source: Admin.create_set (issue #23) — same
+        # validate-via-helper / log-without-body / POST-verbatim shape,
+        # including the bare-string-vs-{"value": ...}-dict acceptance.
+        # See also Users.create_user_fee (above, issue #44) for the
+        # state-changing log discipline (entry, success, error with
+        # alma_code + tracking_id).
+        self._validate_user_data_for_create(user_data)
+        primary_id = user_data.get("primary_id")
+
+        # Audit-log shape per R9 (no PII): only the primary_id and a
+        # count of top-level keys on the body. Never log the full body —
+        # it may contain personal data, addresses, identifiers, etc.
+        self.logger.info(
+            f"Creating user: {primary_id} (user_data_keys={len(user_data)})"
+        )
+
+        try:
+            response = self.client.post("almaws/v1/users", data=user_data)
+            created_primary_id = None
+            try:
+                created_primary_id = response.data.get("primary_id")
+            except (ValueError, AttributeError):
+                # Body may not be JSON / dict; the response itself is
+                # still a valid AlmaResponse and we should hand it back.
+                created_primary_id = None
+
+            if created_primary_id:
+                self.logger.info(
+                    f"Created user: {created_primary_id}"
+                )
+            else:
+                self.logger.info(
+                    f"Created user: {primary_id}"
+                )
+            return response
+
+        except AlmaAPIError as e:
+            alma_code = getattr(e, "alma_code", "")
+            tracking_id = getattr(e, "tracking_id", None)
+            self.logger.error(
+                f"API error creating user {primary_id}: {e} "
+                f"(alma_code={alma_code!r}, tracking_id={tracking_id!r})"
+            )
+            raise
+
+    def delete_user(self, user_id: str) -> AlmaResponse:
+        """Delete a user by primary id.
+
+        Wraps ``DELETE /almaws/v1/users/{user_id}``. Alma rejects the
+        delete when the user has active loans, requests, or unpaid fees
+        — those rejections surface as ``AlmaAPIError`` with the Alma
+        error code intact for the caller to dispatch on.
+
+        Args:
+            user_id: The user's primary identifier (or any other
+                Alma-accepted id type). Must be a non-empty string.
+
+        Returns:
+            ``AlmaResponse`` wrapping the delete response. Alma typically
+            echoes the deleted user's payload back in the body, which is
+            useful for audit trails — callers that record deletions
+            should persist ``response.data`` before discarding the
+            response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: On API failure (typed subclass when the Alma
+                error code or HTTP status maps to one — e.g.,
+                ``AlmaResourceNotFoundError`` for an unknown user). The
+                exception carries ``alma_code`` and ``tracking_id`` so
+                callers can surface the precise reason (active loans,
+                outstanding fees, etc.).
+        """
+        # Pattern source: Admin.delete_set (issue #23) — same
+        # validate-id / log entry / DELETE / log success / log error with
+        # alma_code + tracking_id shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        self.logger.info(f"Deleting user: {clean_id}")
+
+        try:
+            response = self.client.delete(f"almaws/v1/users/{clean_id}")
+            self.logger.info(f"Deleted user: {clean_id}")
+            return response
+
+        except AlmaAPIError as e:
+            alma_code = getattr(e, "alma_code", "")
+            tracking_id = getattr(e, "tracking_id", None)
+            self.logger.error(
+                f"API error deleting user {clean_id}: {e} "
+                f"(alma_code={alma_code!r}, tracking_id={tracking_id!r})"
+            )
+            raise
+
+    @staticmethod
+    def _validate_user_data_for_create(user_data: Any) -> None:
+        """Validate the ``user_data`` argument to ``create_user``.
+
+        Enforces the four core fields Alma requires on user creation:
+        ``primary_id``, ``account_type``, ``status``, ``user_group``.
+        The latter three accept either a bare string or the canonical
+        ``{"value": "..."}`` wrapper dict (the shape Alma returns on
+        reads).
+
+        Args:
+            user_data: Candidate payload for ``create_user``.
+
+        Raises:
+            AlmaValidationError: If ``user_data`` is not a non-empty
+                dict, or if any required key is missing or empty.
+        """
+        # Pattern source: Admin._validate_set_data_for_create (issue
+        # #23) — same {bare-string | {"value": ...} dict} acceptance.
+        if not isinstance(user_data, dict) or not user_data:
+            raise AlmaValidationError(
+                "user_data must be a non-empty dict"
+            )
+
+        primary_id = user_data.get("primary_id")
+        if not isinstance(primary_id, str) or not primary_id.strip():
+            raise AlmaValidationError(
+                "user_data['primary_id'] is required and must be a "
+                "non-empty string"
+            )
+
+        for field in ("account_type", "status", "user_group"):
+            value = user_data.get(field)
+            if isinstance(value, dict):
+                inner = value.get("value")
+                if not isinstance(inner, str) or not inner.strip():
+                    raise AlmaValidationError(
+                        f"user_data[{field!r}]['value'] is required and "
+                        f"must be a non-empty string"
+                    )
+            elif isinstance(value, str):
+                if not value.strip():
+                    raise AlmaValidationError(
+                        f"user_data[{field!r}] must be a non-empty string"
+                    )
+            else:
+                raise AlmaValidationError(
+                    f"user_data[{field!r}] is required (string or "
+                    f"{{'value': '<CODE>'}} dict)"
+                )
+
     def update_user(self, user_id: str, user_data: Dict[str, Any]) -> AlmaResponse:
         """
         Update a user record.
-        
+
         Args:
             user_id: User identifier
             user_data: Complete user data to update
-        
+
         Returns:
             AlmaResponse containing updated user data
-            
+
         Raises:
             AlmaValidationError: If user_id is empty or user_data is invalid
             AlmaAPIError: If API request fails
         """
         if not user_id or not user_id.strip():
             raise AlmaValidationError("User ID cannot be empty")
-        
+
         if not user_data or not isinstance(user_data, dict):
             raise AlmaValidationError("User data must be a non-empty dictionary")
-        
+
         endpoint = f'almaws/v1/users/{user_id.strip()}'
-        
+
         try:
             response = self.client.put(endpoint, data=user_data)
             self.logger.info(f"Updated user {user_id}")
             return response
-            
+
         except AlmaAPIError as e:
             self.logger.error(f"API error updating user {user_id}: {e}")
             raise

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -71,8 +71,9 @@ class MockAlmaAPIClient:
         self.logger = MagicMock()
         self.get_response: MockAlmaResponse = MockAlmaResponse()
         self.post_response: MockAlmaResponse = MockAlmaResponse()
+        self.delete_response: MockAlmaResponse = MockAlmaResponse()
         self.next_exception: Optional[Exception] = None
-        self.calls = {"get": [], "post": []}
+        self.calls = {"get": [], "post": [], "delete": []}
 
     def get_environment(self) -> str:
         return self.environment
@@ -111,6 +112,20 @@ class MockAlmaAPIClient:
             exc, self.next_exception = self.next_exception, None
             raise exc
         return self.post_response
+
+    def delete(
+        self,
+        endpoint: str,
+        params: Optional[Dict[str, Any]] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["delete"].append(
+            {"endpoint": endpoint, "params": params}
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.delete_response
 
 
 # ---------------------------------------------------------------------------
@@ -2350,3 +2365,318 @@ def _captured_logs(logger_name: str):
         yield records
     finally:
         logger.removeHandler(handler)
+
+
+# ---------------------------------------------------------------------------
+# create_user  (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUser:
+    """Tests for ``Users.create_user`` (issue #37)."""
+
+    def _valid_user_data(self) -> Dict[str, Any]:
+        """Return a fully-populated, Alma-valid user payload (synthetic IDs).
+
+        Uses the ``{"value": ...}`` wrapper shape Alma returns on reads
+        — exercising the round-trip path callers will most often use.
+        """
+        return {
+            "primary_id": "tau000000",
+            "account_type": {"value": "INTERNAL"},
+            "status": {"value": "ACTIVE"},
+            "user_group": {"value": "STAFF"},
+            "first_name": "Synthetic",
+            "last_name": "User",
+        }
+
+    def test_create_user_posts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        body = self._valid_user_data()
+        # Add a non-required extra key to confirm the body passes through
+        # verbatim (the issue's AC is explicit about not stripping fields).
+        body["contact_info"] = {
+            "email": [
+                {
+                    "email_address": "synthetic@example.com",
+                    "preferred": True,
+                }
+            ]
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"primary_id": "tau000000", "first_name": "Synthetic"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user(body)
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users"
+        # JSON body, not multipart.
+        assert call["content_type"] is None
+        # Body forwarded verbatim — including the extra non-required key.
+        assert call["data"] == body
+        # No query params on creation.
+        assert call["params"] is None
+        assert response.data["primary_id"] == "tau000000"
+
+    def test_create_user_accepts_plain_string_account_type(self):
+        """Bare strings for ``account_type`` / ``status`` / ``user_group``
+        must be accepted (mirrors ``Admin.create_set`` behaviour)."""
+        from almaapitk.domains.users import Users
+
+        body = {
+            "primary_id": "tau000000",
+            "account_type": "INTERNAL",
+            "status": "ACTIVE",
+            "user_group": "STAFF",
+        }
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"primary_id": "tau000000"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user(body)
+
+        # Validation accepted bare strings; body forwarded verbatim.
+        assert mock_client.calls["post"][0]["data"] == body
+        assert response.data["primary_id"] == "tau000000"
+
+    def test_create_user_accepts_value_dict_account_type(self):
+        """The canonical ``{"value": "..."}`` wrapper shape must be
+        accepted (the shape Alma returns on reads)."""
+        from almaapitk.domains.users import Users
+
+        body = self._valid_user_data()  # uses {"value": ...} dicts
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"primary_id": "tau000000"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user(body)
+
+        # The body is forwarded as-is; Alma owns server-side semantics.
+        sent = mock_client.calls["post"][0]["data"]
+        assert sent["account_type"] == {"value": "INTERNAL"}
+        assert sent["status"] == {"value": "ACTIVE"}
+        assert sent["user_group"] == {"value": "STAFF"}
+        assert response.data["primary_id"] == "tau000000"
+
+    def test_create_user_raises_on_empty_dict(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user({})
+
+    def test_create_user_raises_on_non_dict(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user("not-a-dict")  # type: ignore[arg-type]
+
+    def test_create_user_raises_on_missing_primary_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body.pop("primary_id")
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_raises_on_empty_primary_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body["primary_id"] = "   "
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_raises_on_missing_account_type(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body.pop("account_type")
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_raises_on_missing_status(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body.pop("status")
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_raises_on_missing_user_group(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body.pop("user_group")
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_raises_on_empty_value_in_wrapper(self):
+        """The ``{"value": ""}`` shape must fail validation, not
+        silently pass through."""
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        body = self._valid_user_data()
+        body["account_type"] = {"value": ""}
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user(body)
+
+    def test_create_user_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Primary identifier already exists",
+            status_code=400,
+            alma_code="401873",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.create_user(self._valid_user_data())
+
+
+# ---------------------------------------------------------------------------
+# delete_user  (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteUser:
+    """Tests for ``Users.delete_user`` (issue #37)."""
+
+    def test_delete_user_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        # Alma typically echoes the deleted user's payload — we can
+        # exercise the audit path by returning a stub.
+        mock_client.delete_response = MockAlmaResponse(
+            body={"primary_id": "tau000000", "status": {"value": "ACTIVE"}}
+        )
+        users = Users(mock_client)
+
+        response = users.delete_user("tau000000")
+
+        assert len(mock_client.calls["delete"]) == 1
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == "almaws/v1/users/tau000000"
+        # Should not pass any query params.
+        assert call["params"] is None
+        # Response is returned for audit, including the echoed body.
+        assert response.data["primary_id"] == "tau000000"
+
+    def test_delete_user_strips_id_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.delete_user("  tau000000  ")
+
+        # Whitespace stripped from the endpoint URL.
+        assert (
+            mock_client.calls["delete"][0]["endpoint"]
+            == "almaws/v1/users/tau000000"
+        )
+
+    def test_delete_user_raises_on_empty_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.delete_user("")
+
+    def test_delete_user_raises_on_whitespace_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.delete_user("   ")
+
+    def test_delete_user_raises_on_non_string_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.delete_user(None)  # type: ignore[arg-type]
+
+    def test_delete_user_propagates_api_error(self):
+        """When Alma rejects (e.g. user has active loans/fees), the
+        AlmaAPIError must propagate so callers can dispatch on
+        alma_code / tracking_id."""
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "User has active loans/fees",
+            status_code=400,
+            alma_code="401890",
+            tracking_id="tracking-abc-123",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.delete_user("tau000000")
+
+        # The exception still carries the diagnostic fields callers need.
+        assert exc_info.value.alma_code == "401890"
+        assert exc_info.value.tracking_id == "tracking-abc-123"


### PR DESCRIPTION
## Chunk: `users-crud`

Closes #37

## Implementation summary

Users CRUD: create_user (validates primary_id, account_type, status, user_group; accepts both string and {value:...} wrapper) and delete_user. 18 unit tests added.

## SANDBOX test summary

Both SANDBOX tests passed. Round-trip created/got/deleted a synthetic tau-test-<UUID> user; cleanup OK with no leftover. Validation smoke fired all guards. Discovery: Alma's user-delete returns an empty body (not the deleted user payload as the issue's AC assumed); test assertion adjusted accordingly. Issue labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/users-crud/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
