### PR TITLE
chunk: users-loans (#40)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -1422,6 +1422,375 @@ class Users:
             )
             raise
 
+    # -----------------------------------------------------------------
+    # Loans (issue #40)
+    # -----------------------------------------------------------------
+
+    def list_user_loans(
+        self,
+        user_id: str,
+        limit: int = 10,
+        offset: int = 0,
+        expand: Optional[str] = None,
+        order_by: Optional[str] = None,
+    ) -> List[Dict[str, Any]]:
+        """List a user's active loans.
+
+        Calls ``GET /almaws/v1/users/{user_id}/loans`` and unwraps the
+        Alma response envelope (``{"item_loan": [...],
+        "total_record_count": N}``) into a flat list. Pagination
+        parameters are forwarded to Alma; ``expand`` and ``order_by``
+        are forwarded only when supplied.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            limit: Page size (Alma default 10, valid range 0-100).
+                Forwarded as ``limit`` query parameter.
+            offset: Page offset (Alma default 0). Forwarded as
+                ``offset`` query parameter.
+            expand: Optional comma-separated expand values
+                (e.g. ``"renewable"``). Forwarded only when non-``None``.
+            order_by: Optional sort key (e.g. ``"due_date"``,
+                ``"loan_date"``, ``"barcode"``, ``"title"``).
+                Forwarded only when non-``None``.
+
+        Returns:
+            List of loan dicts as returned by Alma. Returns an empty
+            list when the user has no loans (or when the response
+            envelope lacks the ``item_loan`` key).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: list_user_fees (issue #44) for the
+        # "single GET, unwrap envelope, return list" idiom plus
+        # single-record-as-dict normalisation; list_users (issue #36)
+        # for the optional-filter forwarding pattern. Swagger:
+        # GET /almaws/v1/users/{user_id}/loans returns rest_item_loans.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if expand is not None:
+            params["expand"] = expand
+        if order_by is not None:
+            params["order_by"] = order_by
+
+        endpoint = f"almaws/v1/users/{clean_id}/loans"
+        self.logger.info(
+            f"Listing loans for user {clean_id} "
+            f"(limit={limit}, offset={offset}, expand={expand!r}, "
+            f"order_by={order_by!r})"
+        )
+        try:
+            response = self.client.get(endpoint, params=params)
+            payload = response.json() or {}
+            loans = payload.get("item_loan") or []
+            if isinstance(loans, dict):
+                # Single-record responses can come back as a dict; normalise.
+                loans = [loans]
+            self.logger.info(
+                f"Retrieved {len(loans)} loans for user {clean_id}"
+            )
+            return loans
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing loans for user {clean_id}: {e}"
+            )
+            raise
+
+    def create_user_loan(
+        self,
+        user_id: str,
+        item_barcode: Optional[str] = None,
+        item_pid: Optional[str] = None,
+        user_id_type: Optional[str] = None,
+        loan_data: Optional[Dict[str, Any]] = None,
+    ) -> AlmaResponse:
+        """Create (loan) an item to a user.
+
+        Calls ``POST /almaws/v1/users/{user_id}/loans``. Per the Alma
+        OpenAPI spec, ``item_barcode``, ``item_pid``, and
+        ``user_id_type`` are **query parameters**; the request body is
+        the Loan object (``rest_item_loan-post.json``) carrying
+        ``circ_desk`` / ``library`` and any other Alma-accepted fields.
+        Exactly one of ``item_barcode`` or ``item_pid`` must be
+        supplied; ``loan_data`` is optional (Alma can derive
+        circ_desk / library from the operator context for some flows).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            item_barcode: The Item barcode. Mutually exclusive with
+                ``item_pid``; forwarded as a **query** parameter when
+                supplied.
+            item_pid: The Item PID. Mutually exclusive with
+                ``item_barcode``; forwarded as a **query** parameter when
+                supplied.
+            user_id_type: Optional user identifier type (any value from
+                the Alma "User Identifier Type" code table, e.g.
+                ``"all_unique"`` / ``"BARCODE"``). Forwarded as a
+                **query** parameter only when non-``None``.
+            loan_data: Optional Loan body dict (e.g.
+                ``{"circ_desk": {"value": "DEFAULT_CIRC_DESK"},
+                "library": {"value": "MAIN"}}``). When ``None``, no
+                body is sent and Alma applies its defaults.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response. The created
+            loan's identifier lives at ``response.data["loan_id"]``.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty / not a string,
+                if neither or both of ``item_barcode`` / ``item_pid``
+                are supplied, or if ``loan_data`` is supplied but is
+                not a dict.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: create_user_fee (issue #44) for "validate,
+        # log entry, POST with body, log success with new id"; and
+        # pay_user_fee (issue #44) for "build params dict dynamically,
+        # only include non-None keys". Swagger: POST
+        # /almaws/v1/users/{user_id}/loans uses query params for the
+        # item / user_id_type identifiers and accepts a Loan body.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if item_barcode is not None and item_pid is not None:
+            raise AlmaValidationError(
+                "Exactly one of item_barcode or item_pid must be supplied "
+                "(got both)"
+            )
+        if item_barcode is None and item_pid is None:
+            raise AlmaValidationError(
+                "Exactly one of item_barcode or item_pid must be supplied "
+                "(got neither)"
+            )
+        if loan_data is not None and not isinstance(loan_data, dict):
+            raise AlmaValidationError(
+                "loan_data must be a dict when supplied"
+            )
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {}
+        if item_barcode is not None:
+            params["item_barcode"] = item_barcode
+        if item_pid is not None:
+            params["item_pid"] = item_pid
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+
+        endpoint = f"almaws/v1/users/{clean_id}/loans"
+        # Audit-log: only the user_id and the item identifier — never
+        # the full loan_data (may carry patron-adjacent fields).
+        self.logger.info(
+            f"Creating loan for user {clean_id} "
+            f"(item_barcode={item_barcode!r}, item_pid={item_pid!r})"
+        )
+        try:
+            response = self.client.post(
+                endpoint,
+                data=loan_data,
+                params=params if params else None,
+            )
+            loan_id: Any = None
+            try:
+                loan_id = (response.data or {}).get("loan_id")
+            except (ValueError, AttributeError):
+                loan_id = None
+            self.logger.info(
+                f"Created loan for user {clean_id} (loan_id={loan_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating loan for user {clean_id} "
+                f"(item_barcode={item_barcode!r}, item_pid={item_pid!r}): {e}"
+            )
+            raise
+
+    def get_user_loan(
+        self,
+        user_id: str,
+        loan_id: str,
+    ) -> Dict[str, Any]:
+        """Retrieve a single loan's details.
+
+        Calls ``GET /almaws/v1/users/{user_id}/loans/{loan_id}`` and
+        returns the unwrapped loan dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            loan_id: Loan identifier. Must be a non-empty string.
+
+        Returns:
+            The loan dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``loan_id`` is empty
+                or not a string.
+            AlmaAPIError: If the API request fails (including 400 with
+                error code ``401823`` when the loan does not exist).
+        """
+        # Pattern source: get_user_fee (issue #44) — same
+        # "validate two ids, GET, return dict" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(loan_id, str) or not loan_id.strip():
+            raise AlmaValidationError("Loan ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_loan_id = loan_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/loans/{clean_loan_id}"
+        )
+        self.logger.info(
+            f"Retrieving loan {clean_loan_id} for user {clean_user_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved loan {clean_loan_id} for user {clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving loan {clean_loan_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def renew_user_loan(
+        self,
+        user_id: str,
+        loan_id: str,
+    ) -> AlmaResponse:
+        """Renew a single loan.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/loans/{loan_id}?op=renew``
+        with an empty request body. The swagger documents only
+        ``op=renew`` for this endpoint.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            loan_id: Loan identifier. Must be a non-empty string.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the renewed
+            loan body, including the new ``due_date``).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``loan_id`` is empty
+                or not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401822`` "Cannot renew loan" or ``401823``
+                "Loan ID does not exist").
+        """
+        # Pattern source: perform_user_deposit_action (issue #45) —
+        # same op-driven POST shape (op as query param, empty body).
+        # Pinned to op=renew per the swagger ("currently only op=renew
+        # is supported").
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(loan_id, str) or not loan_id.strip():
+            raise AlmaValidationError("Loan ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_loan_id = loan_id.strip()
+
+        params: Dict[str, Any] = {"op": "renew"}
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/loans/{clean_loan_id}"
+        )
+        self.logger.info(
+            f"Renewing loan {clean_loan_id} for user {clean_user_id}"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Renewed loan {clean_loan_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error renewing loan {clean_loan_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
+    def update_user_loan(
+        self,
+        user_id: str,
+        loan_id: str,
+        loan_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Update a loan (typically the due date).
+
+        Calls ``PUT /almaws/v1/users/{user_id}/loans/{loan_id}`` with
+        ``loan_data`` as the JSON body. The swagger documents this
+        endpoint as "Change loan due date" — Alma's typical use is to
+        ship a body containing at least ``{"due_date": "<ISO-8601>"}``.
+        The body is passed through verbatim; the caller is responsible
+        for the loan-object shape.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            loan_id: Loan identifier. Must be a non-empty string.
+            loan_data: Loan body as a non-empty dict. Passed through to
+                Alma verbatim.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the updated
+            loan body).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` / ``loan_id`` is empty,
+                or if ``loan_data`` is empty / not a dict.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401824`` "Due date is not in loan object" or
+                ``401681`` "Due date cannot be in the past").
+        """
+        # Pattern source: update_user (above) — same
+        # "validate ids + non-empty dict, PUT body verbatim" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(loan_id, str) or not loan_id.strip():
+            raise AlmaValidationError("Loan ID cannot be empty")
+        if not isinstance(loan_data, dict) or not loan_data:
+            raise AlmaValidationError(
+                "loan_data must be a non-empty dictionary"
+            )
+        clean_user_id = user_id.strip()
+        clean_loan_id = loan_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/loans/{clean_loan_id}"
+        )
+        # Audit-log: never log the full loan_data body (may include
+        # patron-adjacent free-text fields like notes).
+        self.logger.info(
+            f"Updating loan {clean_loan_id} for user {clean_user_id}"
+        )
+        try:
+            response = self.client.put(endpoint, data=loan_data)
+            self.logger.info(
+                f"Updated loan {clean_loan_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error updating loan {clean_loan_id} for user "
+                f"{clean_user_id}: {e}"
+            )
+            raise
+
     def create_user(self, user_data: Dict[str, Any]) -> AlmaResponse:
         """Create a new Alma user.
 

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -1,5 +1,6 @@
 """
-Unit tests for the Users domain class — issue #36 / #39 / #44 / #45 coverage:
+Unit tests for the Users domain class — issue #36 / #39 / #40 / #44 / #45
+coverage:
 
 - ``Users.list_users`` — list/search via ``GET /almaws/v1/users``
 - ``Users.search_users`` — convenience wrapper requiring ``q``
@@ -18,6 +19,8 @@ Unit tests for the Users domain class — issue #36 / #39 / #44 / #45 coverage:
   (issue #44)
 - ``Users.{list,create,get}_user_deposit`` and
   ``perform_user_deposit_action`` — deposits coverage (issue #45)
+- ``Users.{list,create,get}_user_loan`` plus ``renew_user_loan`` /
+  ``update_user_loan`` — loans coverage (issue #40)
 
 Tests use a mocked AlmaAPIClient stand-in (no real HTTP) following the
 mock-shape established in ``tests/unit/domains/test_configuration.py``.
@@ -71,9 +74,10 @@ class MockAlmaAPIClient:
         self.logger = MagicMock()
         self.get_response: MockAlmaResponse = MockAlmaResponse()
         self.post_response: MockAlmaResponse = MockAlmaResponse()
+        self.put_response: MockAlmaResponse = MockAlmaResponse()
         self.delete_response: MockAlmaResponse = MockAlmaResponse()
         self.next_exception: Optional[Exception] = None
-        self.calls = {"get": [], "post": [], "delete": []}
+        self.calls = {"get": [], "post": [], "put": [], "delete": []}
 
     def get_environment(self) -> str:
         return self.environment
@@ -112,6 +116,27 @@ class MockAlmaAPIClient:
             exc, self.next_exception = self.next_exception, None
             raise exc
         return self.post_response
+
+    def put(
+        self,
+        endpoint: str,
+        data: Any = None,
+        params: Optional[Dict[str, Any]] = None,
+        content_type: Optional[str] = None,
+        custom_headers: Optional[Dict[str, str]] = None,
+    ) -> MockAlmaResponse:
+        self.calls["put"].append(
+            {
+                "endpoint": endpoint,
+                "data": data,
+                "params": params,
+                "content_type": content_type,
+            }
+        )
+        if self.next_exception is not None:
+            exc, self.next_exception = self.next_exception, None
+            raise exc
+        return self.put_response
 
     def delete(
         self,
@@ -2680,3 +2705,666 @@ class TestDeleteUser:
         # The exception still carries the diagnostic fields callers need.
         assert exc_info.value.alma_code == "401890"
         assert exc_info.value.tracking_id == "tracking-abc-123"
+
+
+# ---------------------------------------------------------------------------
+# list_user_loans  (issue #40)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserLoans:
+    """Tests for ``Users.list_user_loans`` (issue #40)."""
+
+    def test_list_user_loans_calls_correct_endpoint_with_defaults(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "item_loan": [
+                    {"loan_id": "loan-1", "item_barcode": "B1"},
+                    {"loan_id": "loan-2", "item_barcode": "B2"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_loans("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans"
+        # Default limit/offset are forwarded; expand/order_by absent.
+        assert call["params"] == {"limit": 10, "offset": 0}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["loan_id"] == "loan-1"
+
+    def test_list_user_loans_forwards_limit_offset(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"item_loan": [], "total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        users.list_user_loans("u1", limit=50, offset=100)
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"limit": 50, "offset": 100}
+
+    def test_list_user_loans_forwards_expand(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"item_loan": []})
+        users = Users(mock_client)
+
+        users.list_user_loans("u1", expand="renewable")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "expand": "renewable",
+        }
+
+    def test_list_user_loans_forwards_order_by(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"item_loan": []})
+        users = Users(mock_client)
+
+        users.list_user_loans("u1", order_by="due_date")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "order_by": "due_date",
+        }
+
+    def test_list_user_loans_forwards_all_optional_params(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"item_loan": []})
+        users = Users(mock_client)
+
+        users.list_user_loans(
+            "u1", limit=25, offset=50, expand="renewable", order_by="barcode"
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 25,
+            "offset": 50,
+            "expand": "renewable",
+            "order_by": "barcode",
+        }
+
+    def test_list_user_loans_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"item_loan": []})
+        users = Users(mock_client)
+
+        users.list_user_loans("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans"
+
+    def test_list_user_loans_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_loans("u1")
+
+        assert result == []
+
+    def test_list_user_loans_handles_single_dict_response(self):
+        """A single loan returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "item_loan": {"loan_id": "only-loan"},
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_loans("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["loan_id"] == "only-loan"
+
+    def test_list_user_loans_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_loans("")
+
+    def test_list_user_loans_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_loans("   ")
+
+    def test_list_user_loans_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_loans(None)  # type: ignore[arg-type]
+
+    def test_list_user_loans_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_user_loans("u1")
+
+
+# ---------------------------------------------------------------------------
+# create_user_loan  (issue #40)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserLoan:
+    """Tests for ``Users.create_user_loan`` (issue #40)."""
+
+    def test_create_user_loan_with_item_barcode_only(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-99", "item_barcode": "B1"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_loan("u1", item_barcode="B1")
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans"
+        # item_barcode is a query param, NOT a body field.
+        assert call["params"] == {"item_barcode": "B1"}
+        # No body when loan_data is None.
+        assert call["data"] is None
+        assert response.data["loan_id"] == "loan-99"
+
+    def test_create_user_loan_with_item_pid_only(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_loan("u1", item_pid="23123456")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans"
+        assert call["params"] == {"item_pid": "23123456"}
+        assert call["data"] is None
+
+    def test_create_user_loan_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_loan(
+            "u1", item_barcode="B1", user_id_type="all_unique"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "item_barcode": "B1",
+            "user_id_type": "all_unique",
+        }
+
+    def test_create_user_loan_forwards_loan_data_as_body(self):
+        from almaapitk.domains.users import Users
+
+        loan_body = {
+            "circ_desk": {"value": "DEFAULT_CIRC_DESK"},
+            "library": {"value": "MAIN"},
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_loan(
+            "u1", item_barcode="B1", loan_data=loan_body
+        )
+
+        call = mock_client.calls["post"][0]
+        # loan_data forwarded verbatim as body.
+        assert call["data"] == loan_body
+        # Identifier still in query params.
+        assert call["params"] == {"item_barcode": "B1"}
+
+    def test_create_user_loan_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_loan("  u1  ", item_barcode="B1")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans"
+
+    def test_create_user_loan_raises_when_both_item_identifiers_supplied(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_loan(
+                "u1", item_barcode="B1", item_pid="23123456"
+            )
+        # No HTTP call should be made on validation failure.
+        assert mock_client.calls["post"] == []
+
+    def test_create_user_loan_raises_when_neither_item_identifier_supplied(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_loan("u1")
+        assert mock_client.calls["post"] == []
+
+    def test_create_user_loan_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_loan("", item_barcode="B1")
+
+    def test_create_user_loan_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_loan("   ", item_barcode="B1")
+
+    def test_create_user_loan_raises_on_non_dict_loan_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_loan(
+                "u1",
+                item_barcode="B1",
+                loan_data="not-a-dict",  # type: ignore[arg-type]
+            )
+
+    def test_create_user_loan_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Item is not loanable",
+            status_code=400,
+            alma_code="401651",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.create_user_loan("u1", item_barcode="B1")
+
+        assert exc_info.value.alma_code == "401651"
+
+
+# ---------------------------------------------------------------------------
+# get_user_loan  (issue #40)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserLoan:
+    """Tests for ``Users.get_user_loan`` (issue #40)."""
+
+    def test_get_user_loan_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "loan_id": "loan-1",
+                "item_barcode": "B1",
+                "due_date": "2026-06-01Z",
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_loan("u1", "loan-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+        # No params on a plain GET.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["loan_id"] == "loan-1"
+
+    def test_get_user_loan_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"loan_id": "loan-1"})
+        users = Users(mock_client)
+
+        users.get_user_loan("  u1  ", "  loan-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+
+    def test_get_user_loan_returns_empty_dict_on_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_loan("u1", "loan-1")
+
+        assert result == {}
+
+    def test_get_user_loan_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_loan("", "loan-1")
+
+    def test_get_user_loan_raises_on_empty_loan_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_loan("u1", "")
+
+    def test_get_user_loan_raises_on_non_string_loan_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_loan("u1", None)  # type: ignore[arg-type]
+
+    def test_get_user_loan_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Loan ID does not exist", status_code=400, alma_code="401823"
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.get_user_loan("u1", "loan-1")
+
+        assert exc_info.value.alma_code == "401823"
+
+
+# ---------------------------------------------------------------------------
+# renew_user_loan  (issue #40)
+# ---------------------------------------------------------------------------
+
+
+class TestRenewUserLoan:
+    """Tests for ``Users.renew_user_loan`` (issue #40)."""
+
+    def test_renew_user_loan_sends_op_renew_with_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"loan_id": "loan-1", "due_date": "2026-07-01Z"}
+        )
+        users = Users(mock_client)
+
+        response = users.renew_user_loan("u1", "loan-1")
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+        assert call["params"] == {"op": "renew"}
+        # Empty body — renewal is op-driven, not body-driven.
+        assert call["data"] is None
+        assert response.data["loan_id"] == "loan-1"
+
+    def test_renew_user_loan_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"loan_id": "loan-1"})
+        users = Users(mock_client)
+
+        users.renew_user_loan("  u1  ", "  loan-1  ")
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+
+    def test_renew_user_loan_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.renew_user_loan("", "loan-1")
+
+    def test_renew_user_loan_raises_on_empty_loan_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.renew_user_loan("u1", "")
+
+    def test_renew_user_loan_raises_on_non_string_ids(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.renew_user_loan(None, "loan-1")  # type: ignore[arg-type]
+        with pytest.raises(AlmaValidationError):
+            users.renew_user_loan("u1", None)  # type: ignore[arg-type]
+
+    def test_renew_user_loan_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Cannot renew loan", status_code=400, alma_code="401822"
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.renew_user_loan("u1", "loan-1")
+
+        assert exc_info.value.alma_code == "401822"
+
+
+# ---------------------------------------------------------------------------
+# update_user_loan  (issue #40)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserLoan:
+    """Tests for ``Users.update_user_loan`` (issue #40)."""
+
+    def test_update_user_loan_puts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        loan_body = {
+            "loan_id": "loan-1",
+            "due_date": "2026-08-01Z",
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"loan_id": "loan-1", "due_date": "2026-08-01Z"}
+        )
+        users = Users(mock_client)
+
+        response = users.update_user_loan("u1", "loan-1", loan_body)
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+        # Body is the operator-supplied dict verbatim.
+        assert call["data"] == loan_body
+        # No query params (notify_user is not exposed by the wrapper).
+        assert call["params"] is None
+        assert response.data["due_date"] == "2026-08-01Z"
+
+    def test_update_user_loan_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(body={"loan_id": "loan-1"})
+        users = Users(mock_client)
+
+        users.update_user_loan(
+            "  u1  ", "  loan-1  ", {"due_date": "2026-08-01Z"}
+        )
+
+        call = mock_client.calls["put"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/loans/loan-1"
+
+    def test_update_user_loan_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_loan("", "loan-1", {"due_date": "2026-08-01Z"})
+
+    def test_update_user_loan_raises_on_empty_loan_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_loan("u1", "", {"due_date": "2026-08-01Z"})
+
+    def test_update_user_loan_raises_on_empty_loan_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_loan("u1", "loan-1", {})
+
+    def test_update_user_loan_raises_on_non_dict_loan_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_loan(
+                "u1", "loan-1", "not-a-dict"  # type: ignore[arg-type]
+            )
+
+    def test_update_user_loan_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Due date cannot be in the past",
+            status_code=400,
+            alma_code="401681",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.update_user_loan(
+                "u1", "loan-1", {"due_date": "2020-01-01Z"}
+            )
+
+        assert exc_info.value.alma_code == "401681"


### PR DESCRIPTION
## Chunk: `users-loans`

Closes #40

## Implementation summary

Users CRUD for loans: list_user_loans, create_user_loan (mutually exclusive item_barcode/item_pid as query params; library/circ_desk in body via loan_data), get_user_loan, renew_user_loan, update_user_loan. 36 unit tests added. RULE 9 (read swagger before coding) caught five swagger-vs-issue-body discrepancies that the agent's summary documents.

## SANDBOX test summary

All 3 SANDBOX tests passed. t-40-3 round-trip created a loan, renewed it, then returned the item via in-band scan-in (BibliographicRecords.scan_in_item — same Alma endpoint serves both work-order placement and circ-desk returns). Net state clean. The expired-patron-card block (alma_code 401168) was hit on the first run; operator extended ST4710123 expiry in Alma UI; re-run passed cleanly. Issue labelled tested:passing-needs-review per R4.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/users-loans/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
