### PR TITLE
chunk: users-requests (#41)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -1791,6 +1791,494 @@ class Users:
             )
             raise
 
+    # -----------------------------------------------------------------
+    # Requests (issue #41)
+    # -----------------------------------------------------------------
+
+    def list_user_requests(
+        self,
+        user_id: str,
+        request_type: Optional[str] = None,
+        status: Optional[str] = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """List a user's requests (holds, bookings, digitization).
+
+        Calls ``GET /almaws/v1/users/{user_id}/requests`` and unwraps the
+        Alma response envelope (``{"user_request": [...],
+        "total_record_count": N}``) into a flat list. Pagination
+        parameters are forwarded to Alma; ``request_type`` and
+        ``status`` are forwarded only when supplied.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_type: Optional filter by request type. Per the
+                swagger, valid values are ``"HOLD"``, ``"DIGITIZATION"``,
+                ``"BOOKING"``. Forwarded only when non-``None``.
+            status: Optional status filter. Per the swagger,
+                ``"active"`` (default) or ``"history"`` (the latter is
+                only available when the customer's
+                ``should_anonymize_requests`` parameter is ``false`` at
+                request-completion time). Forwarded only when
+                non-``None``.
+            limit: Page size (Alma default 10, valid range 0-100).
+                Forwarded as ``limit`` query parameter.
+            offset: Page offset (Alma default 0). Forwarded as
+                ``offset`` query parameter.
+
+        Returns:
+            List of request dicts as returned by Alma. Returns an empty
+            list when the user has no requests (or when the response
+            envelope lacks the ``user_request`` key).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: list_user_loans (issue #40) for the
+        # "single GET, unwrap envelope, return list" idiom plus
+        # single-record-as-dict normalisation; list_users (issue #36)
+        # for the optional-filter forwarding pattern. Swagger:
+        # GET /almaws/v1/users/{user_id}/requests returns
+        # rest_user_requests; the envelope key is ``user_request``.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if request_type is not None:
+            params["request_type"] = request_type
+        if status is not None:
+            params["status"] = status
+
+        endpoint = f"almaws/v1/users/{clean_id}/requests"
+        self.logger.info(
+            f"Listing requests for user {clean_id} "
+            f"(limit={limit}, offset={offset}, "
+            f"request_type={request_type!r}, status={status!r})"
+        )
+        try:
+            response = self.client.get(endpoint, params=params)
+            payload = response.json() or {}
+            requests = payload.get("user_request") or []
+            if isinstance(requests, dict):
+                # Single-record responses can come back as a dict; normalise.
+                requests = [requests]
+            self.logger.info(
+                f"Retrieved {len(requests)} requests for user {clean_id}"
+            )
+            return requests
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing requests for user {clean_id}: {e}"
+            )
+            raise
+
+    def create_user_request(
+        self,
+        user_id: str,
+        request_data: Dict[str, Any],
+        mms_id: Optional[str] = None,
+        item_pid: Optional[str] = None,
+        holding_id: Optional[str] = None,
+        user_id_type: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Create a request (hold, booking, or digitization) for a user.
+
+        Calls ``POST /almaws/v1/users/{user_id}/requests``. Per the Alma
+        OpenAPI spec, ``mms_id``, ``item_pid``, and ``user_id_type`` are
+        **query parameters**; the request body is the request object
+        (``rest_user_request.xsd``) carrying request-type, pickup
+        location, and any other Alma-accepted fields. At least one of
+        ``mms_id`` / ``item_pid`` / ``holding_id`` must be supplied so
+        Alma knows what's being requested.
+
+        Note on ``holding_id``: it is NOT documented as a query param in
+        the public swagger (only ``mms_id`` and ``item_pid`` are), but
+        the issue ticket requires the wrapper to accept it; it is
+        forwarded as a query param when supplied so that Alma can apply
+        any institution-specific handling.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_data: Request body as a non-empty dict (e.g.
+                ``{"request_type": "HOLD", "pickup_location_type":
+                "LIBRARY", "pickup_location_library": "MAIN"}``).
+                Forwarded to Alma verbatim.
+            mms_id: The requested title's MMS ID. Required for
+                title-level requests. Forwarded as a **query** parameter
+                when supplied.
+            item_pid: The requested item's PID. Required for item-level
+                requests. Forwarded as a **query** parameter when
+                supplied.
+            holding_id: The requested holding's ID. Forwarded as a
+                **query** parameter when supplied. (Not documented in
+                the public swagger; see method note above.)
+            user_id_type: Optional user identifier type (any value from
+                the Alma "User Identifier Type" code table, e.g.
+                ``"all_unique"`` / ``"BARCODE"``). Forwarded as a
+                **query** parameter only when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the created
+            request body, including the new ``request_id``).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty / not a string,
+                if ``request_data`` is empty / not a dict, or if none of
+                ``mms_id`` / ``item_pid`` / ``holding_id`` are supplied.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401129`` "No items can fulfill the submitted request"
+                or ``401895`` "Pickup circulation desk not found").
+        """
+        # Pattern source: create_user_loan (issue #40) for "validate
+        # ids, identifier query params, body verbatim". Swagger: POST
+        # /almaws/v1/users/{user_id}/requests uses query params for
+        # mms_id / item_pid / user_id_type and accepts a Request body.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_data, dict) or not request_data:
+            raise AlmaValidationError(
+                "request_data must be a non-empty dictionary"
+            )
+        if mms_id is None and item_pid is None and holding_id is None:
+            raise AlmaValidationError(
+                "At least one of mms_id, item_pid, or holding_id must "
+                "be supplied so Alma knows what's being requested"
+            )
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {}
+        if mms_id is not None:
+            params["mms_id"] = mms_id
+        if item_pid is not None:
+            params["item_pid"] = item_pid
+        if holding_id is not None:
+            params["holding_id"] = holding_id
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+
+        endpoint = f"almaws/v1/users/{clean_id}/requests"
+        # Audit-log: only the user_id and the resource identifiers —
+        # never the full request_data (may carry pickup notes / patron
+        # comments — treat as PII-adjacent).
+        self.logger.info(
+            f"Creating request for user {clean_id} "
+            f"(mms_id={mms_id!r}, item_pid={item_pid!r}, "
+            f"holding_id={holding_id!r})"
+        )
+        try:
+            response = self.client.post(
+                endpoint,
+                data=request_data,
+                params=params if params else None,
+            )
+            request_id: Any = None
+            try:
+                request_id = (response.data or {}).get("request_id")
+            except (ValueError, AttributeError):
+                request_id = None
+            self.logger.info(
+                f"Created request for user {clean_id} "
+                f"(request_id={request_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating request for user {clean_id} "
+                f"(mms_id={mms_id!r}, item_pid={item_pid!r}, "
+                f"holding_id={holding_id!r}): {e}"
+            )
+            raise
+
+    def get_user_request(
+        self,
+        user_id: str,
+        request_id: str,
+    ) -> Dict[str, Any]:
+        """Retrieve a single request's details.
+
+        Calls ``GET /almaws/v1/users/{user_id}/requests/{request_id}``
+        and returns the unwrapped request dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Request identifier. Must be a non-empty string.
+
+        Returns:
+            The request dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``request_id`` is
+                empty or not a string.
+            AlmaAPIError: If the API request fails.
+        """
+        # Pattern source: get_user_loan (issue #40) — same
+        # "validate two ids, GET, return dict" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Retrieving request {clean_request_id} for user "
+            f"{clean_user_id}"
+        )
+        try:
+            response = self.client.get(endpoint)
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved request {clean_request_id} for user "
+                f"{clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving request {clean_request_id} for "
+                f"user {clean_user_id}: {e}"
+            )
+            raise
+
+    def cancel_user_request(
+        self,
+        user_id: str,
+        request_id: str,
+        reason: str,
+        note: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Cancel a single request.
+
+        Calls
+        ``DELETE /almaws/v1/users/{user_id}/requests/{request_id}``
+        with ``reason`` (required) and ``note`` (optional) as query
+        parameters. Per the swagger this endpoint returns ``204 No
+        Content``, so ``response.data`` will typically be empty.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Request identifier. Must be a non-empty string.
+            reason: Cancel reason code from the
+                ``RequestCancellationReasons`` code table. **Required**
+                per the swagger — Alma rejects DELETE without this
+                parameter.
+            note: Optional free-text note with additional information
+                about the cancellation. Forwarded as a query parameter
+                only when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the (typically empty 204)
+            response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` / ``request_id`` is
+                empty or not a string, or if ``reason`` is empty / not a
+                string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401694`` "Request Identifier not found" or ``401890``
+                "User not found").
+        """
+        # Pattern source: delete_user (issue #37) for the
+        # "validate id / log / DELETE / log" shape; ``reason`` is
+        # required per the swagger so it's promoted from optional to a
+        # mandatory positional kwarg. Swagger response is 204 No
+        # Content — callers should not expect a body.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        if not isinstance(reason, str) or not reason.strip():
+            raise AlmaValidationError(
+                "reason must be a non-empty string (required by the "
+                "Alma cancel-request endpoint)"
+            )
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+        clean_reason = reason.strip()
+
+        params: Dict[str, Any] = {"reason": clean_reason}
+        if note is not None:
+            # Note is operator-supplied free text; forward verbatim
+            # (don't strip — Alma may want trailing whitespace
+            # significant). Don't audit-log the note value (PII-
+            # adjacent).
+            params["note"] = note
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Cancelling request {clean_request_id} for user "
+            f"{clean_user_id} (reason={clean_reason!r}, "
+            f"note_supplied={note is not None})"
+        )
+        try:
+            response = self.client.delete(endpoint, params=params)
+            self.logger.info(
+                f"Cancelled request {clean_request_id} for user "
+                f"{clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error cancelling request {clean_request_id} for "
+                f"user {clean_user_id}: {e}"
+            )
+            raise
+
+    def perform_user_request_action(
+        self,
+        user_id: str,
+        request_id: str,
+        op: str,
+    ) -> AlmaResponse:
+        """Perform an action on a single request.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/requests/{request_id}?op=<op>``
+        with an empty request body. Per the swagger, ``op=next_step``
+        is currently the only documented value (used to advance a
+        digitization request through its workflow). The wrapper does
+        NOT enumerate / restrict the set: invalid ops are rejected by
+        Alma with its own error response (a future Alma release may
+        add new ops, and the wrapper should not be the bottleneck).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Request identifier. Must be a non-empty string.
+            op: Action to perform. Must be a non-empty string. Per
+                Alma docs, currently only ``"next_step"`` is supported
+                — not validated client-side.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response.
+
+        Raises:
+            AlmaValidationError: If ``user_id``, ``request_id``, or
+                ``op`` is empty / not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401907`` "Failed to find a request for the given
+                request ID" or ``401932`` "Request is not a
+                Digitization request").
+        """
+        # Pattern source: perform_user_deposit_action (issue #45) and
+        # renew_user_loan (issue #40) — same op-driven POST shape (op
+        # as query param, empty body). The wrapper is deliberately
+        # op-agnostic; per the same convention, "let Alma reject
+        # invalid ops with its own error".
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        if not isinstance(op, str) or not op.strip():
+            raise AlmaValidationError("op must be a non-empty string")
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+        clean_op = op.strip()
+
+        params: Dict[str, Any] = {"op": clean_op}
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Performing request action for user {clean_user_id} "
+            f"(request_id={clean_request_id!r}, op={clean_op!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Performed request action for user {clean_user_id} "
+                f"(request_id={clean_request_id!r}, op={clean_op!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error performing request action for user "
+                f"{clean_user_id} (request_id={clean_request_id!r}, "
+                f"op={clean_op!r}): {e}"
+            )
+            raise
+
+    def update_user_request(
+        self,
+        user_id: str,
+        request_id: str,
+        request_data: Dict[str, Any],
+    ) -> AlmaResponse:
+        """Update a request.
+
+        Calls
+        ``PUT /almaws/v1/users/{user_id}/requests/{request_id}`` with
+        ``request_data`` as the JSON body. The body is passed through
+        verbatim; the caller is responsible for the request-object
+        shape (e.g., updated pickup location, partial-digitization
+        volume / issue, etc.).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Request identifier. Must be a non-empty string.
+            request_data: Request body as a non-empty dict. Passed
+                through to Alma verbatim.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the updated
+            request body).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` / ``request_id`` is
+                empty, or if ``request_data`` is empty / not a dict.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``60330`` "Invalid partial digitization volume or
+                issue").
+        """
+        # Pattern source: update_user_loan (issue #40) — same
+        # "validate ids + non-empty dict, PUT body verbatim" shape.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        if not isinstance(request_data, dict) or not request_data:
+            raise AlmaValidationError(
+                "request_data must be a non-empty dictionary"
+            )
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}/requests/{clean_request_id}"
+        )
+        # Audit-log: never log the full request_data body (may include
+        # pickup notes / patron comments — treat as PII-adjacent).
+        self.logger.info(
+            f"Updating request {clean_request_id} for user "
+            f"{clean_user_id}"
+        )
+        try:
+            response = self.client.put(endpoint, data=request_data)
+            self.logger.info(
+                f"Updated request {clean_request_id} for user "
+                f"{clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error updating request {clean_request_id} for "
+                f"user {clean_user_id}: {e}"
+            )
+            raise
+
     def create_user(self, user_data: Dict[str, Any]) -> AlmaResponse:
         """Create a new Alma user.
 

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -3368,3 +3368,918 @@ class TestUpdateUserLoan:
             )
 
         assert exc_info.value.alma_code == "401681"
+
+
+# ---------------------------------------------------------------------------
+# list_user_requests  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserRequests:
+    """Tests for ``Users.list_user_requests`` (issue #41)."""
+
+    def test_list_user_requests_calls_correct_endpoint_with_defaults(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user_request": [
+                    {"request_id": "req-1", "request_type": "HOLD"},
+                    {"request_id": "req-2", "request_type": "BOOKING"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_requests("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests"
+        # Default limit/offset are forwarded; request_type / status absent.
+        assert call["params"] == {"limit": 10, "offset": 0}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["request_id"] == "req-1"
+
+    def test_list_user_requests_forwards_request_type(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"user_request": []})
+        users = Users(mock_client)
+
+        users.list_user_requests("u1", request_type="HOLD")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "request_type": "HOLD",
+        }
+
+    def test_list_user_requests_forwards_status(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"user_request": []})
+        users = Users(mock_client)
+
+        users.list_user_requests("u1", status="history")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "status": "history",
+        }
+
+    def test_list_user_requests_forwards_limit_offset(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"user_request": []})
+        users = Users(mock_client)
+
+        users.list_user_requests("u1", limit=50, offset=100)
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"limit": 50, "offset": 100}
+
+    def test_list_user_requests_forwards_all_filters(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"user_request": []})
+        users = Users(mock_client)
+
+        users.list_user_requests(
+            "u1",
+            request_type="DIGITIZATION",
+            status="active",
+            limit=25,
+            offset=50,
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 25,
+            "offset": 50,
+            "request_type": "DIGITIZATION",
+            "status": "active",
+        }
+
+    def test_list_user_requests_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"user_request": []})
+        users = Users(mock_client)
+
+        users.list_user_requests("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests"
+
+    def test_list_user_requests_returns_empty_list_on_missing_key(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_requests("u1")
+
+        assert result == []
+
+    def test_list_user_requests_handles_single_dict_response(self):
+        """A single request returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user_request": {"request_id": "only-req"},
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_requests("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["request_id"] == "only-req"
+
+    def test_list_user_requests_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_requests("")
+
+    def test_list_user_requests_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_requests("   ")
+
+    def test_list_user_requests_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_requests(None)  # type: ignore[arg-type]
+
+    def test_list_user_requests_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError("boom", status_code=500)
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError):
+            users.list_user_requests("u1")
+
+
+# ---------------------------------------------------------------------------
+# create_user_request  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserRequest:
+    """Tests for ``Users.create_user_request`` (issue #41)."""
+
+    def test_create_user_request_with_mms_id_only(self):
+        from almaapitk.domains.users import Users
+
+        body = {
+            "request_type": "HOLD",
+            "pickup_location_type": "LIBRARY",
+            "pickup_location_library": "MAIN",
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99", "request_type": "HOLD"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_request(
+            "u1", request_data=body, mms_id="9981234567"
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests"
+        assert call["params"] == {"mms_id": "9981234567"}
+        # request_data forwarded verbatim as body.
+        assert call["data"] == body
+        assert response.data["request_id"] == "req-99"
+
+    def test_create_user_request_with_item_pid_only(self):
+        from almaapitk.domains.users import Users
+
+        body = {"request_type": "BOOKING"}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_request(
+            "u1", request_data=body, item_pid="23123456"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests"
+        assert call["params"] == {"item_pid": "23123456"}
+        assert call["data"] == body
+
+    def test_create_user_request_with_holding_id_only(self):
+        from almaapitk.domains.users import Users
+
+        body = {"request_type": "HOLD"}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_request(
+            "u1", request_data=body, holding_id="hol-1"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"holding_id": "hol-1"}
+        assert call["data"] == body
+
+    def test_create_user_request_with_mms_and_item_pid(self):
+        from almaapitk.domains.users import Users
+
+        body = {"request_type": "HOLD"}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99"}
+        )
+        users = Users(mock_client)
+
+        # The wrapper does NOT enforce title-vs-item exclusivity; both
+        # are forwarded so Alma can apply the institution-specific
+        # rules. Cf. create_user_loan, which DOES enforce one-of for
+        # item_barcode/item_pid — but the request endpoint takes a
+        # different shape per swagger.
+        users.create_user_request(
+            "u1",
+            request_data=body,
+            mms_id="9981234567",
+            item_pid="23123456",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "mms_id": "9981234567",
+            "item_pid": "23123456",
+        }
+
+    def test_create_user_request_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        body = {"request_type": "HOLD"}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_request(
+            "u1",
+            request_data=body,
+            mms_id="9981234567",
+            user_id_type="all_unique",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "mms_id": "9981234567",
+            "user_id_type": "all_unique",
+        }
+
+    def test_create_user_request_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-99"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_request(
+            "  u1  ",
+            request_data={"request_type": "HOLD"},
+            mms_id="9981234567",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests"
+
+    def test_create_user_request_raises_when_no_resource_identifier_supplied(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_request(
+                "u1", request_data={"request_type": "HOLD"}
+            )
+        # No HTTP call should be made on validation failure.
+        assert mock_client.calls["post"] == []
+
+    def test_create_user_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_request(
+                "",
+                request_data={"request_type": "HOLD"},
+                mms_id="9981234567",
+            )
+
+    def test_create_user_request_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_request(
+                "   ",
+                request_data={"request_type": "HOLD"},
+                mms_id="9981234567",
+            )
+
+    def test_create_user_request_raises_on_empty_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_request(
+                "u1", request_data={}, mms_id="9981234567"
+            )
+
+    def test_create_user_request_raises_on_non_dict_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_request(
+                "u1",
+                request_data="not-a-dict",  # type: ignore[arg-type]
+                mms_id="9981234567",
+            )
+
+    def test_create_user_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "No items can fulfill the submitted request",
+            status_code=400,
+            alma_code="401129",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.create_user_request(
+                "u1",
+                request_data={"request_type": "HOLD"},
+                mms_id="9981234567",
+            )
+
+        assert exc_info.value.alma_code == "401129"
+
+
+# ---------------------------------------------------------------------------
+# get_user_request  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserRequest:
+    """Tests for ``Users.get_user_request`` (issue #41)."""
+
+    def test_get_user_request_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "request_id": "req-1",
+                "request_type": "HOLD",
+                "request_status": "ACTIVE",
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_request("u1", "req-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        # No params on a plain GET.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["request_id"] == "req-1"
+
+    def test_get_user_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"request_id": "req-1"}
+        )
+        users = Users(mock_client)
+
+        users.get_user_request("  u1  ", "  req-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+
+    def test_get_user_request_returns_empty_dict_on_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_request("u1", "req-1")
+
+        assert result == {}
+
+    def test_get_user_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_request("", "req-1")
+
+    def test_get_user_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_request("u1", "")
+
+    def test_get_user_request_raises_on_non_string_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_request("u1", None)  # type: ignore[arg-type]
+
+    def test_get_user_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Request Identifier not found",
+            status_code=400,
+            alma_code="401694",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.get_user_request("u1", "req-1")
+
+        assert exc_info.value.alma_code == "401694"
+
+
+# ---------------------------------------------------------------------------
+# cancel_user_request  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelUserRequest:
+    """Tests for ``Users.cancel_user_request`` (issue #41)."""
+
+    def test_cancel_user_request_with_reason_only(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        # Swagger says 204 No Content — body is empty.
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        response = users.cancel_user_request(
+            "u1", "req-1", reason="CancelledAtPatronRequest"
+        )
+
+        assert len(mock_client.calls["delete"]) == 1
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        # Reason is forwarded as a QUERY param on DELETE.
+        assert call["params"] == {"reason": "CancelledAtPatronRequest"}
+        # Empty body for 204 response — wrapper still returns it.
+        assert response.data == {}
+
+    def test_cancel_user_request_with_reason_and_note(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_request(
+            "u1",
+            "req-1",
+            reason="CancelledAtPatronRequest",
+            note="Patron called and asked to cancel",
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["params"] == {
+            "reason": "CancelledAtPatronRequest",
+            "note": "Patron called and asked to cancel",
+        }
+
+    def test_cancel_user_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_request(
+            "  u1  ",
+            "  req-1  ",
+            reason="  CancelledAtPatronRequest  ",
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        # Reason whitespace is stripped.
+        assert call["params"] == {"reason": "CancelledAtPatronRequest"}
+
+    def test_cancel_user_request_raises_on_empty_reason(self):
+        """Reason is REQUIRED per the swagger."""
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_request("u1", "req-1", reason="")
+        # No HTTP call on validation failure.
+        assert mock_client.calls["delete"] == []
+
+    def test_cancel_user_request_raises_on_whitespace_reason(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_request("u1", "req-1", reason="   ")
+
+    def test_cancel_user_request_raises_on_non_string_reason(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_request(
+                "u1", "req-1", reason=None  # type: ignore[arg-type]
+            )
+
+    def test_cancel_user_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_request(
+                "", "req-1", reason="CancelledAtPatronRequest"
+            )
+
+    def test_cancel_user_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_request(
+                "u1", "", reason="CancelledAtPatronRequest"
+            )
+
+    def test_cancel_user_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Request Identifier not found",
+            status_code=400,
+            alma_code="401694",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.cancel_user_request(
+                "u1", "req-1", reason="CancelledAtPatronRequest"
+            )
+
+        assert exc_info.value.alma_code == "401694"
+
+
+# ---------------------------------------------------------------------------
+# perform_user_request_action  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformUserRequestAction:
+    """Tests for ``Users.perform_user_request_action`` (issue #41)."""
+
+    def test_perform_user_request_action_sends_op_as_param(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "req-1", "request_status": "IN_PROCESS"}
+        )
+        users = Users(mock_client)
+
+        response = users.perform_user_request_action(
+            "u1", "req-1", op="next_step"
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        assert call["params"] == {"op": "next_step"}
+        # Empty body — action is op-driven, not body-driven.
+        assert call["data"] is None
+        assert response.data["request_id"] == "req-1"
+
+    def test_perform_user_request_action_accepts_arbitrary_op(self):
+        """Wrapper does not enumerate ops; Alma rejects invalid ones."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_request_action(
+            "u1", "req-1", op="some_future_op"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"op": "some_future_op"}
+
+    def test_perform_user_request_action_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_request_action(
+            "  u1  ", "  req-1  ", op="  next_step  "
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        assert call["params"] == {"op": "next_step"}
+
+    def test_perform_user_request_action_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_request_action("", "req-1", op="next_step")
+
+    def test_perform_user_request_action_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_request_action("u1", "", op="next_step")
+
+    def test_perform_user_request_action_raises_on_empty_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_request_action("u1", "req-1", op="")
+
+    def test_perform_user_request_action_raises_on_whitespace_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_request_action("u1", "req-1", op="   ")
+
+    def test_perform_user_request_action_raises_on_non_string_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_request_action(
+                "u1", "req-1", op=None  # type: ignore[arg-type]
+            )
+
+    def test_perform_user_request_action_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Failed to find a request for the given request ID",
+            status_code=400,
+            alma_code="401907",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.perform_user_request_action(
+                "u1", "req-1", op="next_step"
+            )
+
+        assert exc_info.value.alma_code == "401907"
+
+
+# ---------------------------------------------------------------------------
+# update_user_request  (issue #41)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateUserRequest:
+    """Tests for ``Users.update_user_request`` (issue #41)."""
+
+    def test_update_user_request_puts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        body = {
+            "request_type": "HOLD",
+            "pickup_location_library": "OTHER_LIB",
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"request_id": "req-1", "pickup_location_library": "OTHER_LIB"}
+        )
+        users = Users(mock_client)
+
+        response = users.update_user_request("u1", "req-1", body)
+
+        assert len(mock_client.calls["put"]) == 1
+        call = mock_client.calls["put"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+        # Body forwarded verbatim.
+        assert call["data"] == body
+        # No query params on update.
+        assert call["params"] is None
+        assert response.data["request_id"] == "req-1"
+
+    def test_update_user_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.put_response = MockAlmaResponse(
+            body={"request_id": "req-1"}
+        )
+        users = Users(mock_client)
+
+        users.update_user_request(
+            "  u1  ", "  req-1  ", {"request_type": "HOLD"}
+        )
+
+        call = mock_client.calls["put"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/requests/req-1"
+
+    def test_update_user_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_request("", "req-1", {"request_type": "HOLD"})
+
+    def test_update_user_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_request("u1", "", {"request_type": "HOLD"})
+
+    def test_update_user_request_raises_on_empty_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_request("u1", "req-1", {})
+
+    def test_update_user_request_raises_on_non_dict_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.update_user_request(
+                "u1", "req-1", "not-a-dict"  # type: ignore[arg-type]
+            )
+
+    def test_update_user_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Invalid partial digitization volume or issue",
+            status_code=400,
+            alma_code="60330",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.update_user_request(
+                "u1", "req-1", {"request_type": "DIGITIZATION"}
+            )
+
+        assert exc_info.value.alma_code == "60330"


### PR DESCRIPTION
## Chunk: `users-requests`

Closes #41

## Implementation summary

Added six new methods to the Users domain class covering the user-requests resource: list_user_requests, create_user_request, get_user_request, cancel_user_request (DELETE with required reason per audit), perform_user_request_action, and update_user_request. All methods validate inputs at the top and raise AlmaValidationError, log via self.logger, and propagate AlmaAPIError. Swagger discrepancies (DELETE returns 204; holding_id not in public swagger but accepted per issue body) are documented in inline comments and docstrings. 38 new unit tests cover happy paths, every optional-param permutation, validation guards, and AlmaAPIError propagation with realistic Alma error codes.

## SANDBOX test summary

All three SANDBOX tests passed. t-41-1 exercised the read-only methods (list_user_requests + get_user_request). t-41-2 exercised all 38 input-validation guards on the six new methods. t-41-3 ran the realistic loan-then-hold scenario per operator guidance: User A borrowed a circulating item, User B placed a HOLD via create_user_request against the loaned item, fetched it via get_user_request, and cancelled it in-band via cancel_user_request(reason=...) — proving the full create -> get -> cancel cycle against a real hold-eligible scenario. Cleanup OK; no skips.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/users-requests/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
