### PR TITLE
Release 0.4.2 — top-level docs surface Configuration + Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
-## [0.4.1] — 2026-05-11
+## [0.4.2] — 2026-05-11
 
-First publish of the 0.4.x series to PyPI. (0.4.0 was uploaded to
-TestPyPI during pre-publish verification but never released to real
-PyPI; doc-completeness corrections caught during the TestPyPI gate
-required a version bump to 0.4.1, mirroring the 0.3.0 → 0.3.1 path.)
+First publish of the 0.4.x series to PyPI. (`0.4.0` and `0.4.1` were
+uploaded to TestPyPI during pre-publish verification but never
+released to real PyPI; doc-completeness corrections caught during the
+TestPyPI gate required two version bumps in succession, mirroring the
+`0.3.0` → `0.3.1` path. The final bump to `0.4.2` added `Analytics`
+and `Configuration` to the top-level discoverability surfaces —
+`README.md`, `docs/index.md`, `docs/getting-started.md` — and noted
+that `Configuration` is the active expansion area going into 0.5.x.)
 The full 0.4.0 content set is preserved below.
 
 ### Added
@@ -109,6 +113,6 @@ to 0.3.1.)
   tree to `docs/alma_logging/` so the published wheel contains zero
   non-Python content.
 
-[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.1...HEAD
-[0.4.1]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.1
+[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.2
 [0.3.1]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.3.1

--- a/README.md
+++ b/README.md
@@ -10,11 +10,13 @@ A Python toolkit for interacting with the Ex Libris Alma ILS (Integrated Library
 - **Simple API Client**: Easy-to-use HTTP client with automatic authentication and error handling
 - **Domain Classes**: High-level abstractions for common Alma operations
   - `Acquisitions` - POL operations, invoicing, item receiving
+  - `Admin` - Sets management (BIB_MMS, USER), full CRUD + member management
   - `Analytics` - Analytics reports with pagination support
-  - `Users` - User management, email updates
   - `BibliographicRecords` - Bib records, holdings, items
-  - `Admin` - Sets management (BIB_MMS, USER)
+  - `Configuration` - Libraries/locations, code tables, letters, mapping tables
+    *(active expansion area — more endpoints land in each 0.x release)*
   - `ResourceSharing` - Lending/borrowing via Partners API
+  - `Users` - User management, loans, requests, CRUD, search, expiry processing
 - **Environment Support**: Seamless switching between Sandbox and Production
 - **Response Wrapper**: Consistent response handling with `AlmaResponse`
 - **Comprehensive Logging**: Built-in logging with automatic API key redaction

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # AlmaAPITK API Reference
 
-**Version:** 0.4.1
+**Version:** 0.4.2
 **Package:** `almaapitk`
 
 This document provides comprehensive API reference documentation for the AlmaAPITK Python library.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -284,11 +284,13 @@ AlmaAPITK provides specialized domain classes for common operations:
 ```python
 from almaapitk import (
     AlmaAPIClient,
-    Admin,           # Set management
-    Users,           # User operations
-    Acquisitions,    # POL and invoicing
-    BibliographicRecords,  # Bib records
-    ResourceSharing  # Lending/borrowing
+    Acquisitions,          # POL and invoicing
+    Admin,                 # Set management (full CRUD + members)
+    Analytics,             # Analytics reports
+    BibliographicRecords,  # Bib records, holdings, items
+    Configuration,         # Libraries, locations, code tables, letters (growing)
+    ResourceSharing,       # Lending/borrowing via Partners API
+    Users,                 # User CRUD, loans, requests, search
 )
 
 # Initialize client

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,10 +25,12 @@ Detailed documentation for each domain module:
 | Domain | Description | Documentation |
 |--------|-------------|---------------|
 | **Acquisitions** | Invoice management, POL operations, item receiving | [View Guide](domains/acquisitions.md) |
-| **Users** | User management, email operations, batch processing | [View Guide](domains/users.md) |
+| **Admin** | Sets management (BIB_MMS, USER), full CRUD + member management | [View Guide](domains/admin.md) |
+| **Analytics** | Analytics report headers and rows with built-in pagination | _no dedicated guide yet — see [api-reference.md](api-reference.md#analytics)_ |
 | **BibliographicRecords** | Bib records, holdings, items, digital representations | [View Guide](domains/bibliographicrecords.md) |
-| **Admin** | Sets management (BIB_MMS, USER) | [View Guide](domains/admin.md) |
+| **Configuration** | Libraries/locations, code tables, letters, mapping tables, deposit/import profiles. **Active growth area** — more endpoints land in each 0.x release | [View Guide](domains/configuration.md) |
 | **ResourceSharing** | Lending/borrowing requests via Partners API | [View Guide](domains/resourcesharing.md) |
+| **Users** | User management, loans, requests, CRUD, search, email/expiry processing | [View Guide](domains/users.md) |
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "almaapitk"
-version = "0.4.1"
+version = "0.4.2"
 description = "Python toolkit for the Ex Libris Alma ILS API"
 authors = [
     {name = "Hagay Bar", email = "hagaybar@gmail.com"}


### PR DESCRIPTION
## Summary

Follow-up to #126 (Release 0.4.1) — surfaces `Configuration` and `Analytics` on the top-level discoverability docs that the prior PR missed.

- **README.md**: add `Configuration` bullet with growth-area note; tighten `Admin` and `Users` descriptions to reflect 0.4.x; alphabetise the list.
- **docs/index.md**: domain class table goes 5 → 7 rows (Analytics + Configuration added).
- **docs/getting-started.md**: import example includes Analytics + Configuration.
- **docs/api-reference.md**: version header bumped.
- **pyproject.toml**: `0.4.1` → `0.4.2`.
- **CHANGELOG.md**: rename `[0.4.1]` → `[0.4.2]` with note explaining the second bump.

## Why a version bump

`0.4.1` was already uploaded to TestPyPI. TestPyPI doesn't allow re-uploading; same constraint as `0.3.0` → `0.3.1`.

## Test plan

- [x] Wheel rebuilds cleanly
- [ ] Re-upload to TestPyPI (`0.4.2`)
- [ ] Throwaway-venv install + smoke import from TestPyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)