### PR TITLE
Release 0.4.3 — fix __version__ drift + R10 regression test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.3] — 2026-05-11
+
+### Fixed
+
+- `almaapitk.__version__` now reads dynamically from the installed
+  distribution's metadata (`importlib.metadata.version("almaapitk")`)
+  instead of a hardcoded string. The hardcoded value had drifted —
+  `0.4.2` shipped to PyPI with `__version__ == "0.3.1"` baked into
+  `src/almaapitk/__init__.py` because the version-bump step only
+  touched `pyproject.toml`. A regression test at `tests/test_version.py`
+  now asserts `__version__` matches the installed-metadata version,
+  per CLAUDE.md R10 (bug-driven regression tests).
+
 ## [0.4.2] — 2026-05-11
 
 First publish of the 0.4.x series to PyPI. (`0.4.0` and `0.4.1` were
@@ -113,6 +126,7 @@ to 0.3.1.)
   tree to `docs/alma_logging/` so the published wheel contains zero
   non-Python content.
 
-[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.2...HEAD
+[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.3...HEAD
+[0.4.3]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.3
 [0.4.2]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.2
 [0.3.1]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.3.1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # AlmaAPITK API Reference
 
-**Version:** 0.4.2
+**Version:** 0.4.3
 **Package:** `almaapitk`
 
 This document provides comprehensive API reference documentation for the AlmaAPITK Python library.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "almaapitk"
-version = "0.4.2"
+version = "0.4.3"
 description = "Python toolkit for the Ex Libris Alma ILS API"
 authors = [
     {name = "Hagay Bar", email = "hagaybar@gmail.com"}

--- a/src/almaapitk/__init__.py
+++ b/src/almaapitk/__init__.py
@@ -55,7 +55,16 @@
 #
 # =============================================================================
 
-__version__ = "0.3.1"
+# Resolved at import-time from the installed distribution's metadata so
+# this string is *always* in sync with pyproject.toml. The hardcoded
+# previous value drifted (shipped as "0.3.1" inside the 0.4.2 wheel);
+# tests/test_version.py guards against the same regression.
+from importlib.metadata import version as _pkg_version, PackageNotFoundError as _PackageNotFoundError
+
+try:
+    __version__ = _pkg_version("almaapitk")
+except _PackageNotFoundError:  # pragma: no cover — only fires when running from a non-installed tree
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     # Package metadata

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,46 @@
+"""Regression test: `almaapitk.__version__` must always match the installed
+package's metadata version.
+
+Before `0.4.3`, `src/almaapitk/__init__.py` had `__version__ = "0.3.1"`
+hardcoded and was never updated when `pyproject.toml` was bumped. The
+`0.4.2` release shipped to PyPI with `__version__ == "0.3.1"` even though
+`pip install almaapitk==0.4.2` correctly resolved 0.4.2 from PyPI metadata.
+
+This test fails if anyone reintroduces a hardcoded `__version__`, or if
+the dynamic resolution path breaks. Per CLAUDE.md R10 (bug-driven
+regression tests), it ships with the fix in the same commit.
+"""
+from __future__ import annotations
+
+from importlib.metadata import version as _pkg_version
+
+import almaapitk
+
+
+def test_version_matches_package_metadata():
+    """The package's runtime `__version__` must equal its installed-metadata
+    version.
+
+    Mismatch indicates either: (a) someone reintroduced a hardcoded
+    `__version__` literal, or (b) the dynamic resolution path broke (e.g.
+    package renamed, metadata not packaged).
+    """
+    metadata_version = _pkg_version("almaapitk")
+    assert almaapitk.__version__ == metadata_version, (
+        f"almaapitk.__version__ is {almaapitk.__version__!r} but installed-package "
+        f"metadata reports {metadata_version!r}. See tests/test_version.py docstring "
+        f"for the 0.4.2 regression that motivated this guard."
+    )
+
+
+def test_version_is_not_unknown_fallback():
+    """Sanity: the `PackageNotFoundError` fallback indicates a broken install.
+
+    If this fires in a normal test run, the package isn't installed properly —
+    `poetry install` / `pip install -e .` should resolve it.
+    """
+    assert almaapitk.__version__ != "0.0.0+unknown", (
+        "almaapitk.__version__ resolved to the 'unknown package' fallback. "
+        "The package metadata is not installed in the current environment — "
+        "re-run `poetry install` or `pip install -e .`."
+    )


### PR DESCRIPTION
## Summary

Post-release fix surfaced by the `0.4.2` post-release smoke: `almaapitk.__version__` reported `0.3.1` even though `pip install almaapitk==0.4.2` correctly installed the 0.4.2 distribution. Cause: `src/almaapitk/__init__.py:58` had `__version__ = "0.3.1"` hardcoded; the release pipeline only edited `pyproject.toml`.

## Fix

- `__version__` resolves dynamically via `importlib.metadata.version("almaapitk")`. `pyproject.toml` is now the single source of truth.
- `tests/test_version.py` (new) asserts `almaapitk.__version__ == importlib.metadata.version("almaapitk")` — per R10, the regression test ships with the fix.
- Bump `0.4.2` → `0.4.3` (PyPI doesn't allow re-uploading; mirrors `0.3.0` → `0.3.1`).
- CHANGELOG `[0.4.3]` section above the existing `[0.4.2]` section.
- `docs/api-reference.md` Version header bumped.

## Test plan

- [x] `poetry run pytest tests/test_version.py` passes on this branch
- [x] Confirmed the regression test would have **failed** on the 0.4.2 tree (sanity-checked while writing it)
- [ ] Build wheel for 0.4.3
- [ ] TestPyPI upload + throwaway-venv install + dynamic-`__version__` smoke (this time the smoke command reads `__version__` instead of hardcoding the string, catching this class of bug at the TestPyPI gate)
- [ ] Real PyPI publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)