### PR TITLE
Release 0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.5] — 2026-05-18
+
+### Fixed
+
+- **Logging: `TextFormatter` no longer leaks `Authorization` header values
+  to stderr** (issue #142, problem #1). The toolkit's `redact_sensitive_data()`
+  helper was wired into `JSONFormatter` only — `TextFormatter` (the stderr
+  console handler) rendered structured fields straight from
+  `record.__dict__`, so every `api_client` DEBUG request line printed
+  `headers={'Authorization': 'apikey <real_key>', ...}` in plain text.
+  `TextFormatter.format()` now recursively redacts custom fields the same
+  way `JSONFormatter` does, using the same default pattern set
+  (`apikey`, `api_key`, `password`, `token`, `secret`, `authorization`).
+  The module-level default in `redact_sensitive_data()` was also expanded
+  to include `'authorization'` so direct callers of the helper get the
+  same protection. R10 regression suite:
+  `tests/unit/regressions/test_issue_142.py`.
+
+  **Strongly recommended for anyone running the toolkit with DEBUG-level
+  logging enabled.** This was the cause of the 2026-05-18 in-session
+  leaks documented in the rotation history of the maintainer's keys.
+
+  Note: this is the narrow patch fix for problem #1 from issue #142.
+  Problems #2 (CWD `FileHandler` default) and #3 (logger namespace
+  fragmentation) remain open and target 0.5.0.
+
+### Rollback
+
+If 0.4.5 misbehaves in your environment, three rollback paths are
+available:
+
+1. **PyPI yank** — maintainer-side, via the PyPI web UI's "Yank this
+   release" button on the 0.4.5 release page. Pinned consumers continue
+   to resolve 0.4.5; new installs see 0.4.4 as the latest.
+2. **Explicit downgrade** — `pip install almaapitk==0.4.4` (or
+   `poetry add almaapitk@0.4.4`). One command, immediate revert.
+3. **Git tag** — `git checkout v0.4.4` returns the source tree to the
+   previous release state.
+
+The 0.4.4 → 0.4.5 surface change is intentionally minimal (one method
+in `alma_logging/formatters.py` plus a regression test). If a downstream
+fault is observed, the rollback to 0.4.4 is safe; the only behavior
+change in 0.4.5 is *more redaction*, never less data fidelity for
+non-secret fields.
+
 ## [0.4.3] — 2026-05-11
 
 ### Fixed
@@ -137,7 +182,8 @@ to 0.3.1.)
   tree to `docs/alma_logging/` so the published wheel contains zero
   non-Python content.
 
-[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.3...HEAD
+[Unreleased]: https://github.com/hagaybar/AlmaAPITK/compare/v0.4.5...HEAD
+[0.4.5]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.5
 [0.4.3]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.3
 [0.4.2]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.4.2
 [0.3.1]: https://github.com/hagaybar/AlmaAPITK/releases/tag/v0.3.1

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,6 +1,6 @@
 # AlmaAPITK API Reference
 
-**Version:** 0.4.3
+**Version:** 0.4.5
 **Package:** `almaapitk`
 
 This document provides comprehensive API reference documentation for the AlmaAPITK Python library.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started with AlmaAPITK
 
-**Version:** 0.4.3 | **License:** MIT | **Author:** Hagay Bar
+**Version:** 0.4.5 | **License:** MIT | **Author:** Hagay Bar
 
 AlmaAPITK is a Python toolkit for interacting with the Ex Libris Alma ILS (Integrated Library System) API. It provides a structured approach to API operations with domain-specific classes and comprehensive error handling.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ title: Home
 
 # AlmaAPITK Documentation
 
-**Version:** 0.4.3 | **Python:** >=3.12 | **License:** MIT
+**Version:** 0.4.5 | **Python:** >=3.12 | **License:** MIT
 
 AlmaAPITK is a Python toolkit for interacting with the Ex Libris Alma ILS (Integrated Library System) API. It provides a structured approach to API operations with domain-specific classes, comprehensive error handling, and built-in logging.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "almaapitk"
-version = "0.4.3"
+version = "0.4.5"
 description = "Python toolkit for the Ex Libris Alma ILS API"
 authors = [
     {name = "Hagay Bar", email = "hagaybar@gmail.com"}

--- a/src/almaapitk/alma_logging/formatters.py
+++ b/src/almaapitk/alma_logging/formatters.py
@@ -127,15 +127,22 @@ class TextFormatter(logging.Formatter):
         'RESET': '\033[0m'        # Reset
     }
 
-    def __init__(self, use_colors: bool = True):
+    def __init__(self, use_colors: bool = True, redact_patterns: Optional[list] = None):
         """
         Initialize text formatter.
 
         Args:
             use_colors: Whether to use ANSI color codes (default: True)
+            redact_patterns: List of field-name substrings to redact from
+                structured custom fields before rendering. Defaults to the
+                same list used by ``JSONFormatter`` so the two formatters
+                give identical redaction behavior (issue #142).
         """
         super().__init__()
         self.use_colors = use_colors
+        self.redact_patterns = redact_patterns or [
+            'apikey', 'api_key', 'password', 'token', 'secret', 'authorization'
+        ]
 
     def format(self, record: logging.LogRecord) -> str:
         """
@@ -176,13 +183,24 @@ class TextFormatter(logging.Formatter):
             'exc_info', 'exc_text', 'stack_info', 'getMessage', 'domain', 'environment'
         }
 
-        custom_fields = []
+        # Build a dict first so the recursive redactor can walk nested
+        # structures (e.g., headers={'Authorization': 'apikey ...'})
+        # exactly the way JSONFormatter does. Then render as text.
+        # Without this redaction step the formatter leaks API keys and
+        # other secrets to stderr — see issue #142.
+        custom_fields_dict = {}
         for key, value in record.__dict__.items():
             if key not in standard_attrs and not key.startswith('_'):
-                custom_fields.append(f"{key}={value}")
+                custom_fields_dict[key] = value
 
-        if custom_fields:
-            parts.append(f"({', '.join(custom_fields)})")
+        if custom_fields_dict:
+            custom_fields_dict = redact_sensitive_data(
+                custom_fields_dict, self.redact_patterns
+            )
+            rendered = ', '.join(
+                f"{k}={v}" for k, v in custom_fields_dict.items()
+            )
+            parts.append(f"({rendered})")
 
         result = " ".join(parts)
 
@@ -210,7 +228,11 @@ def redact_sensitive_data(data: Any, patterns: list = None) -> Any:
         {"apikey": "***REDACTED***", "user": "john"}
     """
     if patterns is None:
-        patterns = ['apikey', 'api_key', 'password', 'token', 'secret']
+        # Keep this list in lock-step with JSONFormatter/TextFormatter's
+        # default. Missing 'authorization' here would mean that direct
+        # callers of redact_sensitive_data() leak HTTP Authorization
+        # headers — see issue #142.
+        patterns = ['apikey', 'api_key', 'password', 'token', 'secret', 'authorization']
 
     # TODO: Phase 1.1 - Implement recursive redaction for dicts
     # TODO: Phase 1.1 - Implement recursive redaction for lists

--- a/tests/unit/regressions/test_issue_142.py
+++ b/tests/unit/regressions/test_issue_142.py
@@ -1,0 +1,173 @@
+"""R10 regression test for issue #142 — TextFormatter PII leak.
+
+Bug discovered 2026-05-18 during live SANDBOX testing of the bib-record
+roundtrip (``BibliographicRecords.get_record``): the ``api_client``
+logger emits a DEBUG record on every request carrying the full
+``headers`` dict, including ``Authorization: apikey <real_key>``.
+
+The toolkit ships a ``redact_sensitive_data()`` helper in
+``almaapitk.alma_logging.formatters`` whose default patterns include
+``'authorization'`` — but the helper is only wired into
+``JSONFormatter.format()``. ``TextFormatter.format()`` (the formatter
+used on the stderr console handler) writes ``record.__dict__`` entries
+straight as ``key=value`` text without ever calling the redactor.
+Consequence: every request prints the live API key to stderr.
+
+These tests pin the *symptom* — given a LogRecord that carries a
+``headers`` custom field containing an ``Authorization: apikey ...``
+value, the formatted output must NOT contain the literal value. The
+fix wires ``redact_sensitive_data`` into ``TextFormatter.format()``
+the same way ``JSONFormatter`` already does.
+
+Pattern source: ``tests/unit/regressions/test_issue_119_user_note_write_shape.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from almaapitk.alma_logging.formatters import (
+    JSONFormatter,
+    TextFormatter,
+    redact_sensitive_data,
+)
+
+
+# A clearly-fake API key string. Synthetic; matches the *shape* of an
+# Alma key but the digits are all zero except for a short marker so it
+# is easy to grep for in the captured output. Per CLAUDE.md R9 the
+# test must never contain a real tenant key.
+FAKE_APIKEY_VALUE = "FAKETEST_apikey_value_THAT_MUST_BE_REDACTED_42"
+FAKE_AUTHORIZATION = f"apikey {FAKE_APIKEY_VALUE}"
+
+
+def _make_record(custom_fields: dict) -> logging.LogRecord:
+    """Build a LogRecord that mirrors how the toolkit's loggers emit
+    request lines — message plus a dict of structured kwargs attached as
+    attributes."""
+    record = logging.LogRecord(
+        name="almapi.api_client",
+        level=logging.DEBUG,
+        pathname=__file__,
+        lineno=1,
+        msg="API Request: GET almaws/v1/bibs/<mms_id>",
+        args=(),
+        exc_info=None,
+    )
+    for key, value in custom_fields.items():
+        setattr(record, key, value)
+    return record
+
+
+# --- TextFormatter redaction (the leak we hit) ----------------------------
+
+
+def test_text_formatter_redacts_authorization_header_value():
+    """The literal ``Authorization`` header value must not appear in
+    ``TextFormatter`` output. This is the headline bug from #142."""
+    record = _make_record(
+        {
+            "method": "GET",
+            "endpoint": "almaws/v1/bibs/990000000000000000",
+            "headers": {"Authorization": FAKE_AUTHORIZATION},
+        }
+    )
+    formatter = TextFormatter(use_colors=False)
+    out = formatter.format(record)
+    # The fake key must be gone; the structural shell stays so operators
+    # can still see *that* an Authorization header was sent.
+    assert FAKE_APIKEY_VALUE not in out, (
+        "TextFormatter leaked the Authorization header value into the "
+        "formatted record. See issue #142. Output was:\n" + out
+    )
+    assert FAKE_AUTHORIZATION not in out, (
+        "TextFormatter leaked the full Authorization header value into the "
+        "formatted record. See issue #142. Output was:\n" + out
+    )
+
+
+def test_text_formatter_redacts_apikey_dict_value():
+    """A top-level ``apikey`` custom field must also be redacted (mirrors
+    the existing JSONFormatter pattern set)."""
+    record = _make_record({"apikey": FAKE_APIKEY_VALUE})
+    formatter = TextFormatter(use_colors=False)
+    out = formatter.format(record)
+    assert FAKE_APIKEY_VALUE not in out, (
+        "TextFormatter leaked the apikey field value. Output was:\n" + out
+    )
+
+
+def test_text_formatter_redacts_nested_authorization():
+    """Nested dicts inside custom fields must also be redacted (the
+    request-headers case is exactly this nesting)."""
+    record = _make_record(
+        {
+            "request": {
+                "headers": {
+                    "Authorization": FAKE_AUTHORIZATION,
+                    "Accept": "application/json",
+                },
+                "method": "GET",
+            }
+        }
+    )
+    formatter = TextFormatter(use_colors=False)
+    out = formatter.format(record)
+    assert FAKE_APIKEY_VALUE not in out, (
+        "TextFormatter leaked a nested Authorization value. Output was:\n" + out
+    )
+    # Non-sensitive nested fields should still be present (the formatter
+    # didn't accidentally strip everything).
+    assert "Accept" in out, (
+        "TextFormatter dropped a non-sensitive nested field while "
+        "redacting. Output was:\n" + out
+    )
+
+
+def test_text_formatter_keeps_non_secret_fields_visible():
+    """Verify the redactor doesn't over-redact — non-secret fields stay
+    visible so the formatter is still useful for operators."""
+    record = _make_record(
+        {
+            "method": "GET",
+            "endpoint": "almaws/v1/bibs/990000000000000000",
+            "duration_ms": 591.2,
+        }
+    )
+    formatter = TextFormatter(use_colors=False)
+    out = formatter.format(record)
+    assert "method=GET" in out
+    assert "endpoint=almaws/v1/bibs/990000000000000000" in out
+    assert "duration_ms=591.2" in out
+
+
+# --- JSONFormatter parity (regression-guard so the existing path stays --
+# fixed even after the TextFormatter change) -----------------------------
+
+
+def test_json_formatter_redaction_still_works():
+    """Pin existing behavior: the JSONFormatter already redacts. This
+    test guards against an accidental regression while we're editing the
+    formatters module."""
+    record = _make_record(
+        {"headers": {"Authorization": FAKE_AUTHORIZATION}}
+    )
+    out = JSONFormatter().format(record)
+    assert FAKE_APIKEY_VALUE not in out, (
+        "JSONFormatter regression: Authorization value leaked. "
+        "Output was:\n" + out
+    )
+
+
+# --- redact_sensitive_data helper (sanity check on the pattern set) -----
+
+
+def test_redactor_default_patterns_cover_authorization():
+    """The default pattern list must include 'authorization' so the
+    common case (HTTP Authorization header) is covered without
+    consumers having to configure it."""
+    result = redact_sensitive_data(
+        {"Authorization": FAKE_AUTHORIZATION, "User-Agent": "almaapitk/test"}
+    )
+    assert result["Authorization"] == "***REDACTED***"
+    assert result["User-Agent"] == "almaapitk/test"


### PR DESCRIPTION
## Summary

Patch release `0.4.5` containing one fix:

- **`TextFormatter` no longer leaks `Authorization` header values to stderr** (issue #142, problem #1). The toolkit's `redact_sensitive_data()` helper was wired into `JSONFormatter` only — `TextFormatter` (the stderr console handler) rendered structured fields straight from `record.__dict__`. Every `api_client` DEBUG request line printed `headers={'Authorization': 'apikey <real_key>', ...}` in plain text. `TextFormatter.format()` now recursively redacts custom fields the same way `JSONFormatter` does. The module-level default in `redact_sensitive_data()` was also expanded to include `'authorization'` so direct callers of the helper get the same protection.

Issue #142 stays open. Problems #2 (CWD `FileHandler` default) and #3 (logger namespace fragmentation) remain in scope and target 0.5.0 as a follow-up minor release.

## Version

`0.4.3` → `0.4.5` (skipping 0.4.4; no 0.4.4 was published).

## R10 regression test

`tests/unit/regressions/test_issue_142.py` — six tests covering the symptom (Authorization header value, apikey field value, nested Authorization), non-secret-fields-preserved, JSONFormatter parity regression-guard, and pattern-default coverage.

## Validation passed

- `poetry run python scripts/smoke_import.py` — pass
- `poetry run pytest tests/test_public_api_contract.py` — 29 pass
- `poetry run pytest tests/test_version.py` — 2 pass (version-drift guard)
- `poetry run pytest tests/unit/ tests/logging/ tests/integration/client/ tests/meta/ tests/agentic/` — 829 pass
- `scripts/agentic/chunks regression-smoke` — 12/15 pass, 2 skipped, 1 environmentally blocked (users-requests t-41-3 hit Alma error 401129 availability-cache race; documented quirk, not a code regression)
- TestPyPI install verified version 0.4.5 across `__version__` attribute, package metadata, and explicit assertion
- Installed wheel exercises the redaction: `Authorization` value replaced with `***REDACTED***` in `TextFormatter` output

## Post-merge actions

After squash-merge:

- Phase J: rebuild on main, `twine upload` to real PyPI
- Phase K: tag `v0.4.5` + create GitHub Release
- Phase L: fresh-venv install from real PyPI with strict version check; comment on issue #142 with partial-fix note; file followups for problems #2 + #3

## Rollback paths

If 0.4.5 misbehaves post-publish:

1. PyPI web UI yank (deters new installs; pinned consumers unaffected)
2. `pip install almaapitk==0.4.4` — explicit downgrade
3. `git checkout v0.4.3` — source-tree revert (or to the actually-published prior tag)

## TestPyPI

https://test.pypi.org/project/almaapitk/0.4.5/

🤖 Generated with [Claude Code](https://claude.com/claude-code)