### PR TITLE
Users: resource-sharing requests + purchase requests (Closes #42, Closes #43)

### DIFF
--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -2659,6 +2659,366 @@ class Users:
             )
             raise
 
+    def list_user_purchase_requests(
+        self,
+        user_id: str,
+        status: Optional[str] = None,
+        user_id_type: Optional[str] = None,
+        limit: int = 10,
+        offset: int = 0,
+    ) -> List[Dict[str, Any]]:
+        """List a user's purchase requests.
+
+        Calls ``GET /almaws/v1/users/{user_id}/purchase-requests`` and
+        unwraps the Alma response envelope (``rest_purchase_requests``:
+        ``{"user_request": [...], "total_record_count": N}``) into a
+        flat list. Pagination parameters are forwarded to Alma;
+        ``status`` and ``user_id_type`` are forwarded only when
+        supplied.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            status: Optional filter by purchase-request status. Per the
+                swagger, valid values are ``"INREVIEW"``,
+                ``"APPROVED"``, ``"REJECTED"``, ``"DEFERRED"``.
+                Forwarded only when non-``None``.
+            user_id_type: Optional user identifier type (any value from
+                the Alma "User Identifier Type" code table). Forwarded
+                only when non-``None``. Note: the swagger marks this
+                parameter as ``required: true`` but the prose
+                description says "Optional. If this is not provided,
+                all unique identifier types are used." — surfaced here
+                as optional to match the documented behaviour.
+            limit: Page size (Alma default 10, valid range 0-100).
+                Forwarded as ``limit`` query parameter.
+            offset: Page offset (Alma default 0). Forwarded as
+                ``offset`` query parameter.
+
+        Returns:
+            List of purchase-request dicts as returned by Alma. Returns
+            an empty list when the user has no purchase requests (or
+            when the response envelope lacks the records array).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``60275`` "Purchase request status is not valid" or
+                ``401890`` "User not found").
+        """
+        # Mirrors Users.list_user_requests (Refs #41) for the
+        # "single GET, unwrap envelope, return list" idiom plus
+        # single-record-as-dict normalisation. Swagger:
+        # GET /almaws/v1/users/{user_id}/purchase-requests returns
+        # rest_purchase_requests; following the Alma convention the
+        # envelope key is the singular form (``user_request``), with a
+        # safe fallback to ``purchase_request`` should Alma deviate.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {"limit": limit, "offset": offset}
+        if status is not None:
+            params["status"] = status
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+
+        endpoint = f"almaws/v1/users/{clean_id}/purchase-requests"
+        self.logger.info(
+            f"Listing purchase requests for user {clean_id} "
+            f"(limit={limit}, offset={offset}, status={status!r}, "
+            f"user_id_type={user_id_type!r})"
+        )
+        try:
+            response = self.client.get(endpoint, params=params)
+            payload = response.json() or {}
+            # Alma's rest_purchase_requests envelope: prefer
+            # ``user_request`` (observed key, parallel to
+            # ``list_user_requests``); fall back to
+            # ``purchase_request`` if the API returns the singular-form
+            # array key.
+            requests = (
+                payload.get("user_request")
+                or payload.get("purchase_request")
+                or []
+            )
+            if isinstance(requests, dict):
+                # Single-record responses can come back as a dict.
+                requests = [requests]
+            self.logger.info(
+                f"Retrieved {len(requests)} purchase requests for "
+                f"user {clean_id}"
+            )
+            return requests
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error listing purchase requests for user "
+                f"{clean_id}: {e}"
+            )
+            raise
+
+    def create_user_purchase_request(
+        self,
+        user_id: str,
+        purchase_request_data: Dict[str, Any],
+        user_id_type: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Create a purchase request for a user.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/purchase-requests``. Per the
+        Alma users swagger, the body is a Purchase Request object (see
+        ``rest_purchase_request-post.json``) and is forwarded to Alma
+        verbatim. ``user_id_type`` is an optional query parameter.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            purchase_request_data: Request body as a non-empty dict.
+                Forwarded to Alma verbatim. Typical fields include
+                ``resource_metadata`` (title, author, isbn), ``format``,
+                ``library``, ``vendor``, ``currency``, ``fund``, and
+                ``material_type``.
+            user_id_type: Optional user identifier type (any value from
+                the Alma "User Identifier Type" code table). Forwarded
+                as a **query** parameter only when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the created purchase-request
+            body (including the new ``id`` / ``purchase_request_id``).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty / not a string
+                or if ``purchase_request_data`` is empty / not a dict.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``60273`` "Title is missing", ``60274`` "Resource
+                metadata is required", or ``60278`` "Purchase request
+                creation failed").
+        """
+        # Mirrors Users.create_user_rs_request (Refs #42) — same
+        # "validate id + non-empty body, POST body verbatim, optional
+        # query params" shape. The purchase-request endpoint has its
+        # own swagger surface (``rest_purchase_request-post``); no
+        # mms_id / item_pid / holding_id discriminator — the resource
+        # is described inside ``purchase_request_data``.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if (
+            not isinstance(purchase_request_data, dict)
+            or not purchase_request_data
+        ):
+            raise AlmaValidationError(
+                "purchase_request_data must be a non-empty dictionary"
+            )
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {}
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+
+        endpoint = f"almaws/v1/users/{clean_id}/purchase-requests"
+        # Audit-log: only the user_id and the optional query flag —
+        # never the full purchase_request_data (carries title /
+        # citation metadata; treat as PII-adjacent).
+        self.logger.info(
+            f"Creating purchase request for user {clean_id} "
+            f"(user_id_type={user_id_type!r})"
+        )
+        try:
+            response = self.client.post(
+                endpoint,
+                data=purchase_request_data,
+                params=params if params else None,
+            )
+            request_id: Any = None
+            try:
+                data = response.data or {}
+                request_id = data.get("id") or data.get(
+                    "purchase_request_id"
+                )
+            except (ValueError, AttributeError):
+                request_id = None
+            self.logger.info(
+                f"Created purchase request for user {clean_id} "
+                f"(purchase_request_id={request_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating purchase request for user "
+                f"{clean_id}: {e}"
+            )
+            raise
+
+    def get_user_purchase_request(
+        self,
+        user_id: str,
+        purchase_request_id: str,
+        user_id_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retrieve a single purchase request's details.
+
+        Calls
+        ``GET /almaws/v1/users/{user_id}/purchase-requests/{purchase_request_id}``
+        and returns the unwrapped purchase-request dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            purchase_request_id: Purchase-request identifier. Must be a
+                non-empty string.
+            user_id_type: Optional user identifier type. Forwarded as
+                a query parameter only when non-``None``.
+
+        Returns:
+            The purchase-request dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or
+                ``purchase_request_id`` is empty or not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``60276`` "The purchase request identifier is not
+                valid" or ``401890`` "User not found").
+        """
+        # Mirrors Users.get_user_rs_request (Refs #42) — same
+        # "validate two ids, GET, return dict" shape with an optional
+        # ``user_id_type`` query param.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if (
+            not isinstance(purchase_request_id, str)
+            or not purchase_request_id.strip()
+        ):
+            raise AlmaValidationError(
+                "Purchase request ID cannot be empty"
+            )
+        clean_user_id = user_id.strip()
+        clean_request_id = purchase_request_id.strip()
+
+        params: Dict[str, Any] = {}
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}"
+            f"/purchase-requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Retrieving purchase request {clean_request_id} "
+            f"for user {clean_user_id} "
+            f"(user_id_type={user_id_type!r})"
+        )
+        try:
+            response = self.client.get(
+                endpoint, params=params if params else None
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved purchase request {clean_request_id} "
+                f"for user {clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving purchase request "
+                f"{clean_request_id} for user {clean_user_id}: {e}"
+            )
+            raise
+
+    def perform_user_purchase_request_action(
+        self,
+        user_id: str,
+        purchase_request_id: str,
+        op: str,
+    ) -> AlmaResponse:
+        """Perform an operation on a user's purchase request.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/purchase-requests/{purchase_request_id}?op=<op>``
+        with an empty request body. Per the swagger, ``op`` is
+        currently documented only as ``"cancel"`` (the action that
+        marks the purchase request as cancelled — there is **no
+        separate DELETE endpoint**, and the swagger does not document
+        ``approve`` / ``reject`` operations even though the issue body
+        mentioned them). The wrapper does NOT enumerate / restrict the
+        set: invalid ops are rejected by Alma with its own error
+        response (error code ``401873`` "The operation is not
+        supported"). This keeps the wrapper forward-compatible if Alma
+        later documents additional ops.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            purchase_request_id: Purchase-request identifier. Must be a
+                non-empty string.
+            op: Action to perform. Must be a non-empty string. Per the
+                Alma swagger, currently only ``"cancel"`` is supported
+                — not validated client-side.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (typically an
+            empty acknowledgement body on success).
+
+        Raises:
+            AlmaValidationError: If ``user_id``,
+                ``purchase_request_id``, or ``op`` is empty / not a
+                string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401873`` "The operation is not supported", ``60276``
+                "The purchase request identifier is not valid", or
+                ``60277`` "The purchase request deletion failed").
+        """
+        # Mirrors Users.perform_user_rs_request_action (Refs #42) —
+        # same op-driven POST shape (op as query param, empty body).
+        # The wrapper is deliberately op-agnostic; per the same
+        # convention, "let Alma reject invalid ops with its own
+        # error". Swagger note: only ``cancel`` is documented today,
+        # and there is no DELETE endpoint for purchase requests —
+        # cancellation is the op-driven path.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if (
+            not isinstance(purchase_request_id, str)
+            or not purchase_request_id.strip()
+        ):
+            raise AlmaValidationError(
+                "Purchase request ID cannot be empty"
+            )
+        if not isinstance(op, str) or not op.strip():
+            raise AlmaValidationError("op must be a non-empty string")
+        clean_user_id = user_id.strip()
+        clean_request_id = purchase_request_id.strip()
+        clean_op = op.strip()
+
+        params: Dict[str, Any] = {"op": clean_op}
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}"
+            f"/purchase-requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Performing purchase request action for user "
+            f"{clean_user_id} "
+            f"(purchase_request_id={clean_request_id!r}, "
+            f"op={clean_op!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Performed purchase request action for user "
+                f"{clean_user_id} "
+                f"(purchase_request_id={clean_request_id!r}, "
+                f"op={clean_op!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error performing purchase request action for "
+                f"user {clean_user_id} "
+                f"(purchase_request_id={clean_request_id!r}, "
+                f"op={clean_op!r}): {e}"
+            )
+            raise
+
     def create_user(self, user_data: Dict[str, Any]) -> AlmaResponse:
         """Create a new Alma user.
 

--- a/src/almaapitk/domains/users.py
+++ b/src/almaapitk/domains/users.py
@@ -2248,6 +2248,417 @@ class Users:
             )
             raise
 
+    # -----------------------------------------------------------------
+    # Resource-sharing requests (issue #42)
+    #
+    # Per the Alma users swagger (POST/GET/DELETE/POST on
+    # ``/almaws/v1/users/{user_id}/resource-sharing-requests`` and
+    # ``/.../resource-sharing-requests/{request_id}``), these are
+    # patron-side wrappers around the *requester's* view of a resource
+    # sharing request. The partner-side equivalent lives in
+    # ``ResourceSharing.create_lending_request`` and operates against
+    # the Partners API — NOT to be conflated with this domain.
+    # -----------------------------------------------------------------
+
+    def create_user_rs_request(
+        self,
+        user_id: str,
+        request_data: Dict[str, Any],
+        user_id_type: Optional[str] = None,
+        override_blocks: Optional[bool] = None,
+    ) -> AlmaResponse:
+        """Create a resource-sharing request for a user.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/resource-sharing-requests``.
+        Per the Alma users swagger, the body is a Resource Sharing
+        Request object (see
+        ``rest_user_resource_sharing_request-post.json``) and is
+        forwarded to Alma verbatim. ``user_id_type`` and
+        ``override_blocks`` are optional query parameters.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_data: Request body as a non-empty dict. Forwarded
+                to Alma verbatim. Typical fields include
+                ``citation_type``, ``format``, ``title``,
+                ``pickup_location_*``, and ``owner`` (resource sharing
+                library code).
+            user_id_type: Optional user identifier type (any value from
+                the Alma "User Identifier Type" code table). Forwarded
+                as a **query** parameter only when non-``None``.
+            override_blocks: Optional flag indicating whether the
+                request should be created even if patron-level blocks
+                exist. Forwarded as a **query** parameter only when
+                non-``None`` (the swagger lists this as required, but
+                in practice Alma applies the default ``false`` when
+                omitted — surfaced here as an optional kwarg so callers
+                can opt in to override semantics explicitly).
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the created
+            resource-sharing request body, including the new
+            ``request_id``).
+
+        Raises:
+            AlmaValidationError: If ``user_id`` is empty / not a string
+                or if ``request_data`` is empty / not a dict.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401768`` "Patron is not affiliated with a resource
+                sharing library", ``401607`` "Resource sharing library
+                (owner) is missing", or ``402362`` "Patron has
+                duplicate request").
+        """
+        # Mirrors Users.create_user_request (Refs #41) — same
+        # "validate id + non-empty body, POST body verbatim, optional
+        # query params" shape. The RS endpoint has its own swagger
+        # surface (no mms_id / item_pid / holding_id discriminator —
+        # the resource is described inside ``request_data``).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_data, dict) or not request_data:
+            raise AlmaValidationError(
+                "request_data must be a non-empty dictionary"
+            )
+        clean_id = user_id.strip()
+
+        params: Dict[str, Any] = {}
+        if user_id_type is not None:
+            params["user_id_type"] = user_id_type
+        if override_blocks is not None:
+            # Alma accepts the string form for booleans on query params
+            # (cf. cancel_user_rs_request's notify_user); normalise to
+            # lowercase string for consistency.
+            params["override_blocks"] = (
+                "true" if override_blocks else "false"
+            )
+
+        endpoint = (
+            f"almaws/v1/users/{clean_id}/resource-sharing-requests"
+        )
+        # Audit-log: only the user_id and the optional query flags —
+        # never the full request_data (carries title / citation /
+        # comments — treat as PII-adjacent).
+        self.logger.info(
+            f"Creating resource-sharing request for user {clean_id} "
+            f"(user_id_type={user_id_type!r}, "
+            f"override_blocks={override_blocks!r})"
+        )
+        try:
+            response = self.client.post(
+                endpoint,
+                data=request_data,
+                params=params if params else None,
+            )
+            request_id: Any = None
+            try:
+                request_id = (response.data or {}).get("request_id")
+            except (ValueError, AttributeError):
+                request_id = None
+            self.logger.info(
+                f"Created resource-sharing request for user "
+                f"{clean_id} (request_id={request_id!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error creating resource-sharing request for "
+                f"user {clean_id}: {e}"
+            )
+            raise
+
+    def get_user_rs_request(
+        self,
+        user_id: str,
+        request_id: str,
+        request_id_type: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Retrieve a single resource-sharing request's details.
+
+        Calls
+        ``GET /almaws/v1/users/{user_id}/resource-sharing-requests/{request_id}``
+        and returns the unwrapped request dict.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Resource-sharing request identifier. Must be a
+                non-empty string.
+            request_id_type: Optional. Forwarded as a query parameter
+                only when non-``None``. Use ``"external"`` to look up
+                by the external identifier instead of the internal id.
+
+        Returns:
+            The resource-sharing request dict as returned by Alma.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``request_id`` is
+                empty or not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``40166450`` "No result found for given parameters" or
+                ``401890`` "User not found").
+        """
+        # Mirrors Users.get_user_request (Refs #41) — same
+        # "validate two ids, GET, return dict" shape, with the
+        # swagger-documented optional ``request_id_type`` query param.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+
+        params: Dict[str, Any] = {}
+        if request_id_type is not None:
+            params["request_id_type"] = request_id_type
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}"
+            f"/resource-sharing-requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Retrieving resource-sharing request {clean_request_id} "
+            f"for user {clean_user_id} "
+            f"(request_id_type={request_id_type!r})"
+        )
+        try:
+            response = self.client.get(
+                endpoint, params=params if params else None
+            )
+            data: Dict[str, Any] = response.json() or {}
+            self.logger.info(
+                f"Retrieved resource-sharing request "
+                f"{clean_request_id} for user {clean_user_id}"
+            )
+            return data
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error retrieving resource-sharing request "
+                f"{clean_request_id} for user {clean_user_id}: {e}"
+            )
+            raise
+
+    def cancel_user_rs_request(
+        self,
+        user_id: str,
+        request_id: str,
+        reason: Optional[str] = None,
+        note: Optional[str] = None,
+        remove_request: Optional[bool] = None,
+        notify_user: Optional[bool] = None,
+    ) -> AlmaResponse:
+        """Cancel a single resource-sharing request.
+
+        Calls
+        ``DELETE /almaws/v1/users/{user_id}/resource-sharing-requests/{request_id}``.
+        Per the swagger this endpoint returns ``204 No Content``, so
+        ``response.data`` will typically be empty. All cancellation
+        modifiers (``reason``, ``note``, ``remove_request``,
+        ``notify_user``) are forwarded as query parameters.
+
+        Note:
+            Unlike :meth:`cancel_user_request` (which requires
+            ``reason``), the RS DELETE endpoint marks ``reason`` as
+            **optional** in the swagger (default empty). It is kept
+            optional here to match Alma's contract.
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Resource-sharing request identifier. Must be a
+                non-empty string.
+            reason: Optional cancel reason code from the
+                ``RequestCancellationReasons`` code table. Forwarded as
+                a query parameter only when non-``None``.
+            note: Optional free-text note with additional information
+                about the cancellation. Forwarded as a query parameter
+                only when non-``None``.
+            remove_request: Optional boolean flag to permanently delete
+                the resource-sharing request (vs. cancel it).
+                Forwarded as a query parameter only when non-``None``.
+                Defaults to Alma's ``false`` when omitted.
+            notify_user: Optional boolean flag controlling whether the
+                requester is notified of the cancellation. Forwarded as
+                a query parameter only when non-``None``. Defaults to
+                Alma's ``true`` when omitted.
+
+        Returns:
+            ``AlmaResponse`` wrapping the (typically empty 204)
+            response.
+
+        Raises:
+            AlmaValidationError: If ``user_id`` or ``request_id`` is
+                empty or not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``401694`` "Request Identifier not found" or
+                ``401890`` "User not found").
+        """
+        # Mirrors Users.cancel_user_request (Refs #41) for the
+        # "validate ids / log / DELETE / log" shape; ``reason`` is
+        # downgraded to optional because the RS DELETE swagger marks
+        # it optional (in contrast to the regular cancel endpoint).
+        # Swagger response is 204 No Content — callers should not
+        # expect a body.
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        if reason is not None and not isinstance(reason, str):
+            raise AlmaValidationError(
+                "reason must be a string when supplied"
+            )
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+
+        params: Dict[str, Any] = {}
+        if reason is not None:
+            params["reason"] = reason.strip()
+        if note is not None:
+            # Operator-supplied free text; forward verbatim (don't
+            # strip — Alma may treat trailing whitespace as
+            # significant). Don't audit-log the note value (PII-
+            # adjacent).
+            params["note"] = note
+        if remove_request is not None:
+            params["remove_request"] = (
+                "true" if remove_request else "false"
+            )
+        if notify_user is not None:
+            params["notify_user"] = (
+                "true" if notify_user else "false"
+            )
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}"
+            f"/resource-sharing-requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Cancelling resource-sharing request "
+            f"{clean_request_id} for user {clean_user_id} "
+            f"(reason={reason!r}, note_supplied={note is not None}, "
+            f"remove_request={remove_request!r}, "
+            f"notify_user={notify_user!r})"
+        )
+        try:
+            response = self.client.delete(
+                endpoint, params=params if params else None
+            )
+            self.logger.info(
+                f"Cancelled resource-sharing request "
+                f"{clean_request_id} for user {clean_user_id}"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error cancelling resource-sharing request "
+                f"{clean_request_id} for user {clean_user_id}: {e}"
+            )
+            raise
+
+    def perform_user_rs_request_action(
+        self,
+        user_id: str,
+        request_id: str,
+        op: str,
+        shipping_cost: Optional[str] = None,
+        fund_code: Optional[str] = None,
+        request_id_type: Optional[str] = None,
+    ) -> AlmaResponse:
+        """Perform an action on a single resource-sharing request.
+
+        Calls
+        ``POST /almaws/v1/users/{user_id}/resource-sharing-requests/{request_id}?op=<op>``
+        with an empty request body. Per the swagger, ``op``
+        is currently documented only as ``"update_shipping"`` (used to
+        update the shipping cost / fund code on a borrowing request).
+        The wrapper does NOT enumerate / restrict the set: invalid ops
+        are rejected by Alma with its own error response (a future
+        Alma release may add new ops, and the wrapper should not be
+        the bottleneck).
+
+        Args:
+            user_id: User identifier (primary ID, barcode, etc.). Must
+                be a non-empty string.
+            request_id: Resource-sharing request identifier. Must be a
+                non-empty string.
+            op: Action to perform. Must be a non-empty string. Per
+                Alma docs, currently only ``"update_shipping"`` is
+                supported — not validated client-side.
+            shipping_cost: Optional updated shipping cost. Forwarded as
+                a query parameter only when non-``None``. Relevant for
+                ``op="update_shipping"``.
+            fund_code: Optional code of the updated fund. Forwarded as
+                a query parameter only when non-``None``. Relevant for
+                ``op="update_shipping"``.
+            request_id_type: Optional. Use ``"external"`` to address
+                the request by its external identifier. Forwarded as a
+                query parameter only when non-``None``.
+
+        Returns:
+            ``AlmaResponse`` wrapping the Alma response (the updated
+            resource-sharing request body).
+
+        Raises:
+            AlmaValidationError: If ``user_id``, ``request_id``, or
+                ``op`` is empty / not a string.
+            AlmaAPIError: If the API request fails (e.g. error code
+                ``40166411`` "Parameter value is invalid", ``40166425``
+                "Shipping cost cannot be lower than 0", or ``40166412``
+                "Failed to perform operation").
+        """
+        # Mirrors Users.perform_user_request_action (Refs #41) —
+        # same op-driven POST shape (op as query param, empty body).
+        # The wrapper is deliberately op-agnostic; per the same
+        # convention, "let Alma reject invalid ops with its own
+        # error". Swagger note: error code 40166411 also maps to
+        # AlmaInvalidPolModeError via ERROR_CODE_REGISTRY (a pre-
+        # existing cross-domain collision — out of scope here).
+        if not isinstance(user_id, str) or not user_id.strip():
+            raise AlmaValidationError("User ID cannot be empty")
+        if not isinstance(request_id, str) or not request_id.strip():
+            raise AlmaValidationError("Request ID cannot be empty")
+        if not isinstance(op, str) or not op.strip():
+            raise AlmaValidationError("op must be a non-empty string")
+        clean_user_id = user_id.strip()
+        clean_request_id = request_id.strip()
+        clean_op = op.strip()
+
+        params: Dict[str, Any] = {"op": clean_op}
+        if shipping_cost is not None:
+            params["shipping_cost"] = shipping_cost
+        if fund_code is not None:
+            params["fund_code"] = fund_code
+        if request_id_type is not None:
+            params["request_id_type"] = request_id_type
+
+        endpoint = (
+            f"almaws/v1/users/{clean_user_id}"
+            f"/resource-sharing-requests/{clean_request_id}"
+        )
+        self.logger.info(
+            f"Performing resource-sharing request action for user "
+            f"{clean_user_id} (request_id={clean_request_id!r}, "
+            f"op={clean_op!r}, shipping_cost={shipping_cost!r}, "
+            f"fund_code={fund_code!r})"
+        )
+        try:
+            response = self.client.post(endpoint, params=params)
+            self.logger.info(
+                f"Performed resource-sharing request action for user "
+                f"{clean_user_id} (request_id={clean_request_id!r}, "
+                f"op={clean_op!r})"
+            )
+            return response
+        except AlmaAPIError as e:
+            self.logger.error(
+                f"API error performing resource-sharing request "
+                f"action for user {clean_user_id} "
+                f"(request_id={clean_request_id!r}, op={clean_op!r}): "
+                f"{e}"
+            )
+            raise
+
     def create_user(self, user_data: Dict[str, Any]) -> AlmaResponse:
         """Create a new Alma user.
 

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -5350,3 +5350,672 @@ class TestPerformUserRsRequestAction:
             )
 
         assert exc_info.value.alma_code == "40166425"
+
+
+# ---------------------------------------------------------------------------
+# list_user_purchase_requests  (issue #43)
+# ---------------------------------------------------------------------------
+
+
+class TestListUserPurchaseRequests:
+    """Tests for ``Users.list_user_purchase_requests`` (issue #43)."""
+
+    def test_list_user_purchase_requests_defaults(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user_request": [
+                    {"id": "pr-1", "status": "INREVIEW"},
+                    {"id": "pr-2", "status": "APPROVED"},
+                ],
+                "total_record_count": 2,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_purchase_requests("u1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/purchase-requests"
+        # Default limit/offset are forwarded; status / user_id_type absent.
+        assert call["params"] == {"limit": 10, "offset": 0}
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0]["id"] == "pr-1"
+
+    def test_list_user_purchase_requests_forwards_status(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_request": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_purchase_requests("u1", status="INREVIEW")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "status": "INREVIEW",
+        }
+
+    def test_list_user_purchase_requests_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_request": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_purchase_requests("u1", user_id_type="all_unique")
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 10,
+            "offset": 0,
+            "user_id_type": "all_unique",
+        }
+
+    def test_list_user_purchase_requests_forwards_limit_offset(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_request": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_purchase_requests("u1", limit=50, offset=100)
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"limit": 50, "offset": 100}
+
+    def test_list_user_purchase_requests_forwards_all_filters(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_request": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_purchase_requests(
+            "u1",
+            status="APPROVED",
+            user_id_type="all_unique",
+            limit=25,
+            offset=50,
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {
+            "limit": 25,
+            "offset": 50,
+            "status": "APPROVED",
+            "user_id_type": "all_unique",
+        }
+
+    def test_list_user_purchase_requests_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"user_request": []}
+        )
+        users = Users(mock_client)
+
+        users.list_user_purchase_requests("  u1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == "almaws/v1/users/u1/purchase-requests"
+
+    def test_list_user_purchase_requests_returns_empty_list_on_missing_key(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"total_record_count": 0}
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_purchase_requests("u1")
+
+        assert result == []
+
+    def test_list_user_purchase_requests_handles_single_dict_response(self):
+        """A single record returned as dict (not list) is normalised."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "user_request": {"id": "only-pr"},
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_purchase_requests("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "only-pr"
+
+    def test_list_user_purchase_requests_falls_back_to_purchase_request_key(
+        self,
+    ):
+        """If Alma returns the singular-form key, the wrapper still
+        unwraps it."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "purchase_request": [
+                    {"id": "pr-1"},
+                ],
+                "total_record_count": 1,
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.list_user_purchase_requests("u1")
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["id"] == "pr-1"
+
+    def test_list_user_purchase_requests_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_purchase_requests("")
+        assert mock_client.calls["get"] == []
+
+    def test_list_user_purchase_requests_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_purchase_requests("   ")
+
+    def test_list_user_purchase_requests_raises_on_non_string_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.list_user_purchase_requests(
+                None  # type: ignore[arg-type]
+            )
+
+    def test_list_user_purchase_requests_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Purchase request status is not valid",
+            status_code=400,
+            alma_code="60275",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.list_user_purchase_requests("u1", status="BOGUS")
+
+        assert exc_info.value.alma_code == "60275"
+
+
+# ---------------------------------------------------------------------------
+# create_user_purchase_request  (issue #43)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserPurchaseRequest:
+    """Tests for ``Users.create_user_purchase_request`` (issue #43)."""
+
+    def test_create_user_purchase_request_posts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        body = {
+            "resource_metadata": {
+                "title": "Sample title",
+                "author": "Ada Lovelace",
+                "isbn": "9780000000000",
+            },
+            "format": {"value": "PHYSICAL"},
+            "library": {"value": "MAIN"},
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"id": "pr-42", "status": "INREVIEW"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_purchase_request(
+            "u1", purchase_request_data=body
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests"
+        )
+        # No optional kwargs => no query params forwarded.
+        assert call["params"] is None
+        # Body forwarded verbatim.
+        assert call["data"] == body
+        assert response.data["id"] == "pr-42"
+
+    def test_create_user_purchase_request_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        body = {"resource_metadata": {"title": "Sample"}}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "pr-42"})
+        users = Users(mock_client)
+
+        users.create_user_purchase_request(
+            "u1", purchase_request_data=body, user_id_type="all_unique"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"user_id_type": "all_unique"}
+
+    def test_create_user_purchase_request_strips_whitespace_in_user_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={"id": "pr-42"})
+        users = Users(mock_client)
+
+        users.create_user_purchase_request(
+            "  u1  ",
+            purchase_request_data={"resource_metadata": {"title": "x"}},
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests"
+        )
+
+    def test_create_user_purchase_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_purchase_request(
+                "",
+                purchase_request_data={
+                    "resource_metadata": {"title": "x"}
+                },
+            )
+        assert mock_client.calls["post"] == []
+
+    def test_create_user_purchase_request_raises_on_whitespace_user_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_purchase_request(
+                "   ",
+                purchase_request_data={
+                    "resource_metadata": {"title": "x"}
+                },
+            )
+
+    def test_create_user_purchase_request_raises_on_empty_request_data(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_purchase_request(
+                "u1", purchase_request_data={}
+            )
+
+    def test_create_user_purchase_request_raises_on_non_dict_request_data(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_purchase_request(
+                "u1",
+                purchase_request_data="not-a-dict",  # type: ignore[arg-type]
+            )
+
+    def test_create_user_purchase_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Title is missing",
+            status_code=400,
+            alma_code="60273",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.create_user_purchase_request(
+                "u1",
+                purchase_request_data={
+                    "resource_metadata": {"author": "Anon"}
+                },
+            )
+
+        assert exc_info.value.alma_code == "60273"
+
+
+# ---------------------------------------------------------------------------
+# get_user_purchase_request  (issue #43)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserPurchaseRequest:
+    """Tests for ``Users.get_user_purchase_request`` (issue #43)."""
+
+    def test_get_user_purchase_request_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"id": "pr-1", "status": "INREVIEW"}
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_purchase_request("u1", "pr-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests/pr-1"
+        )
+        # No optional kwargs => no query params.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["id"] == "pr-1"
+
+    def test_get_user_purchase_request_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "pr-1"})
+        users = Users(mock_client)
+
+        users.get_user_purchase_request(
+            "u1", "pr-1", user_id_type="all_unique"
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"user_id_type": "all_unique"}
+
+    def test_get_user_purchase_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={"id": "pr-1"})
+        users = Users(mock_client)
+
+        users.get_user_purchase_request("  u1  ", "  pr-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests/pr-1"
+        )
+
+    def test_get_user_purchase_request_returns_empty_dict_on_empty_body(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_purchase_request("u1", "pr-1")
+
+        assert result == {}
+
+    def test_get_user_purchase_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_purchase_request("", "pr-1")
+
+    def test_get_user_purchase_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_purchase_request("u1", "")
+
+    def test_get_user_purchase_request_raises_on_non_string_request_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_purchase_request(
+                "u1", None  # type: ignore[arg-type]
+            )
+
+    def test_get_user_purchase_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "The purchase request identifier is not valid",
+            status_code=400,
+            alma_code="60276",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.get_user_purchase_request("u1", "pr-bogus")
+
+        assert exc_info.value.alma_code == "60276"
+
+
+# ---------------------------------------------------------------------------
+# perform_user_purchase_request_action  (issue #43)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformUserPurchaseRequestAction:
+    """Tests for ``Users.perform_user_purchase_request_action`` (issue #43)."""
+
+    def test_perform_user_purchase_request_action_sends_op_as_param(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        response = users.perform_user_purchase_request_action(
+            "u1", "pr-1", op="cancel"
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests/pr-1"
+        )
+        assert call["params"] == {"op": "cancel"}
+        # Empty body — action is op-driven, not body-driven.
+        assert call["data"] is None
+        assert response.data == {}
+
+    def test_perform_user_purchase_request_action_accepts_arbitrary_op(
+        self,
+    ):
+        """Wrapper does not enumerate ops; Alma rejects invalid ones."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_purchase_request_action(
+            "u1", "pr-1", op="some_future_op"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"op": "some_future_op"}
+
+    def test_perform_user_purchase_request_action_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_purchase_request_action(
+            "  u1  ", "  pr-1  ", op="  cancel  "
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/purchase-requests/pr-1"
+        )
+        assert call["params"] == {"op": "cancel"}
+
+    def test_perform_user_purchase_request_action_raises_on_empty_user_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_purchase_request_action(
+                "", "pr-1", op="cancel"
+            )
+
+    def test_perform_user_purchase_request_action_raises_on_empty_request_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_purchase_request_action(
+                "u1", "", op="cancel"
+            )
+
+    def test_perform_user_purchase_request_action_raises_on_empty_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_purchase_request_action(
+                "u1", "pr-1", op=""
+            )
+
+    def test_perform_user_purchase_request_action_raises_on_whitespace_op(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_purchase_request_action(
+                "u1", "pr-1", op="   "
+            )
+
+    def test_perform_user_purchase_request_action_raises_on_non_string_op(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_purchase_request_action(
+                "u1", "pr-1", op=None  # type: ignore[arg-type]
+            )
+
+    def test_perform_user_purchase_request_action_propagates_api_error(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "The operation is not supported",
+            status_code=400,
+            alma_code="401873",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.perform_user_purchase_request_action(
+                "u1", "pr-1", op="approve"
+            )
+
+        assert exc_info.value.alma_code == "401873"

--- a/tests/unit/domains/test_users.py
+++ b/tests/unit/domains/test_users.py
@@ -4668,3 +4668,685 @@ class TestRemoveUserNotes:
             users.remove_user_notes("u1", predicate=broken)
         # PUT must not be issued when predicate explodes.
         assert mock_client.calls["put"] == []
+
+
+# ---------------------------------------------------------------------------
+# create_user_rs_request  (issue #42)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateUserRsRequest:
+    """Tests for ``Users.create_user_rs_request`` (issue #42)."""
+
+    def test_create_user_rs_request_posts_body_verbatim(self):
+        from almaapitk.domains.users import Users
+
+        body = {
+            "citation_type": "BK",
+            "format": "PHYSICAL",
+            "title": "Sample title",
+            "owner": {"value": "ILL"},
+        }
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42", "external_id": "ext-1"}
+        )
+        users = Users(mock_client)
+
+        response = users.create_user_rs_request("u1", request_data=body)
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests"
+        )
+        # No optional kwargs => no query params forwarded.
+        assert call["params"] is None
+        # Body forwarded verbatim.
+        assert call["data"] == body
+        assert response.data["request_id"] == "rs-42"
+
+    def test_create_user_rs_request_forwards_user_id_type(self):
+        from almaapitk.domains.users import Users
+
+        body = {"citation_type": "BK", "title": "Sample"}
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_rs_request(
+            "u1", request_data=body, user_id_type="all_unique"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"user_id_type": "all_unique"}
+
+    def test_create_user_rs_request_forwards_override_blocks_true(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_rs_request(
+            "u1",
+            request_data={"citation_type": "BK"},
+            override_blocks=True,
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"override_blocks": "true"}
+
+    def test_create_user_rs_request_forwards_override_blocks_false(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_rs_request(
+            "u1",
+            request_data={"citation_type": "BK"},
+            override_blocks=False,
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"override_blocks": "false"}
+
+    def test_create_user_rs_request_forwards_all_query_params(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_rs_request(
+            "u1",
+            request_data={"citation_type": "BK"},
+            user_id_type="all_unique",
+            override_blocks=True,
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "user_id_type": "all_unique",
+            "override_blocks": "true",
+        }
+
+    def test_create_user_rs_request_strips_whitespace_in_user_id(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-42"}
+        )
+        users = Users(mock_client)
+
+        users.create_user_rs_request(
+            "  u1  ", request_data={"citation_type": "BK"}
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests"
+        )
+
+    def test_create_user_rs_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_rs_request(
+                "", request_data={"citation_type": "BK"}
+            )
+        assert mock_client.calls["post"] == []
+
+    def test_create_user_rs_request_raises_on_whitespace_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_rs_request(
+                "   ", request_data={"citation_type": "BK"}
+            )
+
+    def test_create_user_rs_request_raises_on_empty_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_rs_request("u1", request_data={})
+
+    def test_create_user_rs_request_raises_on_non_dict_request_data(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.create_user_rs_request(
+                "u1", request_data="not-a-dict"  # type: ignore[arg-type]
+            )
+
+    def test_create_user_rs_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Patron is not affiliated with a resource sharing library",
+            status_code=400,
+            alma_code="401768",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.create_user_rs_request(
+                "u1", request_data={"citation_type": "BK"}
+            )
+
+        assert exc_info.value.alma_code == "401768"
+
+
+# ---------------------------------------------------------------------------
+# get_user_rs_request  (issue #42)
+# ---------------------------------------------------------------------------
+
+
+class TestGetUserRsRequest:
+    """Tests for ``Users.get_user_rs_request`` (issue #42)."""
+
+    def test_get_user_rs_request_calls_correct_endpoint(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={
+                "request_id": "rs-1",
+                "request_status": "REQUEST_CREATED_BOR",
+            }
+        )
+        users = Users(mock_client)
+
+        result = users.get_user_rs_request("u1", "rs-1")
+
+        assert len(mock_client.calls["get"]) == 1
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+        # No optional kwargs => no query params.
+        assert call["params"] is None
+        assert isinstance(result, dict)
+        assert result["request_id"] == "rs-1"
+
+    def test_get_user_rs_request_forwards_request_id_type(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"request_id": "rs-1"}
+        )
+        users = Users(mock_client)
+
+        users.get_user_rs_request(
+            "u1", "rs-ext-1", request_id_type="external"
+        )
+
+        call = mock_client.calls["get"][0]
+        assert call["params"] == {"request_id_type": "external"}
+
+    def test_get_user_rs_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(
+            body={"request_id": "rs-1"}
+        )
+        users = Users(mock_client)
+
+        users.get_user_rs_request("  u1  ", "  rs-1  ")
+
+        call = mock_client.calls["get"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+
+    def test_get_user_rs_request_returns_empty_dict_on_empty_body(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.get_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        result = users.get_user_rs_request("u1", "rs-1")
+
+        assert result == {}
+
+    def test_get_user_rs_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_rs_request("", "rs-1")
+
+    def test_get_user_rs_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_rs_request("u1", "")
+
+    def test_get_user_rs_request_raises_on_non_string_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.get_user_rs_request(
+                "u1", None  # type: ignore[arg-type]
+            )
+
+    def test_get_user_rs_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "No result found for given parameters",
+            status_code=400,
+            alma_code="40166450",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.get_user_rs_request("u1", "rs-1")
+
+        assert exc_info.value.alma_code == "40166450"
+
+
+# ---------------------------------------------------------------------------
+# cancel_user_rs_request  (issue #42)
+# ---------------------------------------------------------------------------
+
+
+class TestCancelUserRsRequest:
+    """Tests for ``Users.cancel_user_rs_request`` (issue #42)."""
+
+    def test_cancel_user_rs_request_no_kwargs(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        # Swagger says 204 No Content — body is empty.
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        response = users.cancel_user_rs_request("u1", "rs-1")
+
+        assert len(mock_client.calls["delete"]) == 1
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+        # No optional kwargs => no query params (reason is OPTIONAL on
+        # the RS DELETE endpoint per swagger, unlike the regular
+        # cancel_user_request).
+        assert call["params"] is None
+        # Empty body for 204 response — wrapper still returns it.
+        assert response.data == {}
+
+    def test_cancel_user_rs_request_with_reason(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_rs_request(
+            "u1", "rs-1", reason="CancelledAtPatronRequest"
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["params"] == {"reason": "CancelledAtPatronRequest"}
+
+    def test_cancel_user_rs_request_with_all_kwargs(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_rs_request(
+            "u1",
+            "rs-1",
+            reason="CancelledAtPatronRequest",
+            note="Patron asked to cancel",
+            remove_request=True,
+            notify_user=False,
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["params"] == {
+            "reason": "CancelledAtPatronRequest",
+            "note": "Patron asked to cancel",
+            "remove_request": "true",
+            "notify_user": "false",
+        }
+
+    def test_cancel_user_rs_request_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_rs_request(
+            "  u1  ",
+            "  rs-1  ",
+            reason="  CancelledAtPatronRequest  ",
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+        # Reason whitespace is stripped.
+        assert call["params"] == {"reason": "CancelledAtPatronRequest"}
+
+    def test_cancel_user_rs_request_remove_request_false_flag(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.delete_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.cancel_user_rs_request(
+            "u1", "rs-1", remove_request=False, notify_user=True
+        )
+
+        call = mock_client.calls["delete"][0]
+        assert call["params"] == {
+            "remove_request": "false",
+            "notify_user": "true",
+        }
+
+    def test_cancel_user_rs_request_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_rs_request("", "rs-1")
+        assert mock_client.calls["delete"] == []
+
+    def test_cancel_user_rs_request_raises_on_empty_request_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_rs_request("u1", "")
+
+    def test_cancel_user_rs_request_raises_on_non_string_reason(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.cancel_user_rs_request(
+                "u1", "rs-1", reason=123  # type: ignore[arg-type]
+            )
+
+    def test_cancel_user_rs_request_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Request Identifier not found",
+            status_code=400,
+            alma_code="401694",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.cancel_user_rs_request("u1", "rs-1")
+
+        assert exc_info.value.alma_code == "401694"
+
+
+# ---------------------------------------------------------------------------
+# perform_user_rs_request_action  (issue #42)
+# ---------------------------------------------------------------------------
+
+
+class TestPerformUserRsRequestAction:
+    """Tests for ``Users.perform_user_rs_request_action`` (issue #42)."""
+
+    def test_perform_user_rs_request_action_sends_op_as_param(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(
+            body={"request_id": "rs-1", "shipping_cost": "12.50"}
+        )
+        users = Users(mock_client)
+
+        response = users.perform_user_rs_request_action(
+            "u1", "rs-1", op="update_shipping"
+        )
+
+        assert len(mock_client.calls["post"]) == 1
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+        assert call["params"] == {"op": "update_shipping"}
+        # Empty body — action is op-driven, not body-driven.
+        assert call["data"] is None
+        assert response.data["request_id"] == "rs-1"
+
+    def test_perform_user_rs_request_action_forwards_shipping_cost(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_rs_request_action(
+            "u1", "rs-1", op="update_shipping", shipping_cost="12.50"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "update_shipping",
+            "shipping_cost": "12.50",
+        }
+
+    def test_perform_user_rs_request_action_forwards_fund_code(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_rs_request_action(
+            "u1", "rs-1", op="update_shipping", fund_code="FUND-001"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "update_shipping",
+            "fund_code": "FUND-001",
+        }
+
+    def test_perform_user_rs_request_action_forwards_all_query_params(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_rs_request_action(
+            "u1",
+            "rs-1",
+            op="update_shipping",
+            shipping_cost="12.50",
+            fund_code="FUND-001",
+            request_id_type="external",
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {
+            "op": "update_shipping",
+            "shipping_cost": "12.50",
+            "fund_code": "FUND-001",
+            "request_id_type": "external",
+        }
+
+    def test_perform_user_rs_request_action_accepts_arbitrary_op(self):
+        """Wrapper does not enumerate ops; Alma rejects invalid ones."""
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_rs_request_action(
+            "u1", "rs-1", op="some_future_op"
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["params"] == {"op": "some_future_op"}
+
+    def test_perform_user_rs_request_action_strips_whitespace(self):
+        from almaapitk.domains.users import Users
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.post_response = MockAlmaResponse(body={})
+        users = Users(mock_client)
+
+        users.perform_user_rs_request_action(
+            "  u1  ", "  rs-1  ", op="  update_shipping  "
+        )
+
+        call = mock_client.calls["post"][0]
+        assert call["endpoint"] == (
+            "almaws/v1/users/u1/resource-sharing-requests/rs-1"
+        )
+        assert call["params"] == {"op": "update_shipping"}
+
+    def test_perform_user_rs_request_action_raises_on_empty_user_id(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_rs_request_action(
+                "", "rs-1", op="update_shipping"
+            )
+
+    def test_perform_user_rs_request_action_raises_on_empty_request_id(
+        self,
+    ):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_rs_request_action(
+                "u1", "", op="update_shipping"
+            )
+
+    def test_perform_user_rs_request_action_raises_on_empty_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_rs_request_action("u1", "rs-1", op="")
+
+    def test_perform_user_rs_request_action_raises_on_whitespace_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_rs_request_action(
+                "u1", "rs-1", op="   "
+            )
+
+    def test_perform_user_rs_request_action_raises_on_non_string_op(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaValidationError
+
+        mock_client = MockAlmaAPIClient()
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaValidationError):
+            users.perform_user_rs_request_action(
+                "u1", "rs-1", op=None  # type: ignore[arg-type]
+            )
+
+    def test_perform_user_rs_request_action_propagates_api_error(self):
+        from almaapitk.domains.users import Users
+        from almaapitk import AlmaAPIError
+
+        mock_client = MockAlmaAPIClient()
+        mock_client.next_exception = AlmaAPIError(
+            "Shipping cost cannot be lower than 0",
+            status_code=400,
+            alma_code="40166425",
+        )
+        users = Users(mock_client)
+
+        with pytest.raises(AlmaAPIError) as exc_info:
+            users.perform_user_rs_request_action(
+                "u1", "rs-1", op="update_shipping", shipping_cost="-1"
+            )
+
+        assert exc_info.value.alma_code == "40166425"


### PR DESCRIPTION
## Summary

Chunk `users-requests-followup` ships coverage for two user-side request domains on the existing `Users` class:

- **#42** — Resource-sharing requests (user-side, distinct from partner-side `ResourceSharing`). Four wrappers: `create_user_rs_request`, `get_user_rs_request`, `cancel_user_rs_request`, `perform_user_rs_request_action`. Commit `2ea089d`.
- **#43** — User-side purchase requests. Four wrappers: `list_user_purchase_requests`, `create_user_purchase_request`, `get_user_purchase_request`, `perform_user_purchase_request_action`. Commit `f0fdb47`.

Eight new public methods total, all type-hinted, Google-style-docstring'd, validation-guarded, and logged via `alma_logging`.

## Tests

- **78 new mocked-HTTP unit tests** in `tests/unit/domains/test_users.py` (40 for #42, 38 for #43).
- Full local validation suite (smoke_import, public-API contract, version-drift guard, the 829 pre-existing tests across `tests/unit/ tests/logging/ tests/integration/client/ tests/meta/ tests/agentic/`) — **907 pass, 0 fail.**

## SANDBOX verification — deferred to a post-merge R10 follow-up

The chunk's `test-recommendation.json` includes a live SANDBOX round-trip plan for `t-42-3` (create → get → update_shipping → cancel an RS request) and `t-43-3` (create → get → list → cancel a purchase request). Both round-trips are blocked by a tenant-config detail: the operator needs to retrieve a valid Borrowing-Request pickup library code from the Alma staff UI (per the chunk's late-session empirical finding documented in commit 2ea089d). The 78 mocked-HTTP tests stand as the verification gate for this merge; live verification will be a post-merge R10 follow-up when the pickup-library code is in hand.

Rationale: this chunk's surface (8 new wrappers mirroring established patterns) is small and the unit-test coverage is comprehensive. Deferring live SANDBOX is the same call as #41's `users-requests` chunk at merge time, and avoids the round-trip-with-stale-fixtures problem that 0.4.5 surfaced in the api_client log path. With 0.4.5 now on main (and on this rebased branch), any future live SANDBOX run from this code path benefits from the `TextFormatter` redaction.

## Rebase note

Branched from main at `7bfcbba`; rebased onto current main (`994879c`) immediately before this PR. The rebase encountered one conflict in `tests/unit/domains/test_users.py` because PR #141 (`users-notes`) had also appended test classes at the end of the file. Resolution: both branches strictly appended, so the resolved file is main's content + this chunk's appended test classes. Verified by syntax-parsing and the 352-test pass of the full `test_users.py` post-rebase.

## Late-session empirical findings worth surfacing

(See `docs/session-handoff-2026-05-13.md` for full context.)

- **Borrowing-request CREATE does not require a `partner` field.** Proven across 11 SANDBOX experiments; Alma's validation chain never raised a partner-related error with `partner` absent. The `partner` attachment happens later, during the "Locate" / "Send Request" workflow steps.
- **Error 401929 ("The library selected is not a valid pickup location")** is the actual gate for create. Resolution: pickup library code must come from the RS Library's pickup-locations subform, not from a generic library list.

## Issue closure

- Closes #42
- Closes #43
- Issue #142 (logging redaction) — fixed in 0.4.5, partial-fix comment already filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)