### PR TITLE
ci: PyPI Trusted Publishing workflow on tag push (Closes #128)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+# Tag-triggered release pipeline for almaapitk.
+#
+# Runs the full Phase F validation suite from docs/RELEASE_CHECKLIST.md, verifies
+# the built wheel filename matches pyproject.toml (the #131 + 0.4.2 yank guard),
+# then publishes to PyPI via Trusted Publishing (OIDC, no token in repo secrets).
+#
+# Design source: docs/superpowers/specs/2026-05-10-release-0.4.0-design.md
+# Implements: issue #128, supersedes #1.
+#
+# PyPI-side setup (one-time, manual): configure almaapitk as a Trusted Publisher
+# on pypi.org pointing at this repo + workflow filename `release.yml`.
+# See docs/RELEASE_CHECKLIST.md Phase J for the dashboard URL.
+
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    name: validate and publish
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write   # required for PyPI Trusted Publishing (OIDC)
+      contents: read
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Install project (locked)
+        run: poetry install --sync
+
+      - name: Smoke import
+        run: poetry run python scripts/smoke_import.py
+
+      - name: Public API contract
+        run: poetry run pytest tests/test_public_api_contract.py -v
+
+      - name: Version drift guard
+        run: poetry run pytest tests/test_version.py -v
+
+      - name: Full local validation suite
+        run: poetry run pytest tests/unit/ tests/logging/ tests/integration/client/ tests/meta/ tests/agentic/ -q
+
+      - name: Regression smoke (SANDBOX, skips cleanly when no key)
+        env:
+          ALMA_SB_API_KEY: ${{ secrets.ALMA_SB_API_KEY }}
+        run: poetry run scripts/agentic/chunks regression-smoke
+
+      - name: Build distributions
+        run: |
+          rm -rf dist/
+          poetry build
+
+      - name: Verify wheel filename matches pyproject.toml
+        run: |
+          expected="$(poetry version --short)"
+          wheel="$(ls dist/almaapitk-*-py3-none-any.whl)"
+          case "$wheel" in
+            "dist/almaapitk-${expected}-py3-none-any.whl") echo "wheel version OK: ${expected}";;
+            *) echo "wheel filename ${wheel} does not match pyproject version ${expected}"; exit 1;;
+          esac
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,6 @@ jobs:
   release:
     name: validate and publish
     runs-on: ubuntu-latest
-    environment: release
     permissions:
       id-token: write   # required for PyPI Trusted Publishing (OIDC)
       contents: read

--- a/docs/CHUNK_BACKLOG.md
+++ b/docs/CHUNK_BACKLOG.md
@@ -1,13 +1,13 @@
 # Chunk Backlog
 
-_Last rendered: 2026-05-18T13:47:42Z_
+_Last rendered: 2026-05-19T04:24:02Z_
 
 > **Generated artifact** — do not hand-edit. Source: `docs/chunks-backlog.yaml`.
 > Regenerate with `scripts/agentic/chunks render-backlog`.
 > CI runs `--check`; PRs that touch the YAML must include the regenerated markdown.
 
-**Total chunks:** 70
-**Total issues:** 96
+**Total chunks:** 67
+**Total issues:** 93
 
 **Status:** Suggested groupings — revise freely. The chunking is your call; this doc removes the "what do I chunk next" decision fatigue.
 **Inputs used:** `docs/issue-finalization-report-2026-05-01.md`, `docs/issue-audit-2026-05-01.md`, handbook §10.1 wave structure, CLAUDE.md priority/prereq notes, `docs/reviews/2026-05-12-release-0.4.x-review.md` (post-0.4.3 retrospective).
@@ -180,19 +180,11 @@ Three of four tickets in this phase are previously-flagged. Take care.
 | 57 | · planned | `rs-partners` | #74 | med | #120 | #74 partially aligned (no `q`/`type_filter`; documented filter is `status`) | Already rewritten. **Hard prereq: `partners-rename` (#120) must land first** — otherwise this chunk ships partner CRUD into a name that's about to be deprecated. |
 | 58 | · planned | `rs-directory-members` | #78 | high | #120 | #78 NOT ALIGNED (`localize` POST has no body params; `localization_data` was invented) | Already rewritten — bodyless POST. Solo. Same `#120` prereq as `rs-partners`. |
 
-## Phase 14 — Courses
-
-| # | Status | Chunk | Issues | Risk | Prereqs | Audit | Notes |
-|---|---|---|---|---|---|---|---|
-| 59 | · planned | `courses-bootstrap` | #75 | low | none | clean | Foundation. **Blocks #76, #77.** |
-| 60 | · planned | `courses-crud-enrollment` | #76 | high | #75 | #76 NOT ALIGNED (POST is op-driven via query params: `op` + `user_ids`/`list_ids`, NOT a JSON body) | Already rewritten. Method signature is now `enroll_users_in_course(user_ids)` and `associate_reading_lists(list_ids)`. |
-| 61 | · planned | `courses-reading-lists` | #77 | med | #75 | #77 partially aligned (citation file removal needs `op`; tags are objects not strings) | Already rewritten. |
-
 ## Phase 15 — Analytics
 
 | # | Status | Chunk | Issues | Risk | Prereqs | Audit | Notes |
 |---|---|---|---|---|---|---|---|
-| 62 | · planned | `analytics-paths` | #79 | low | none | #79 partially aligned (root `/paths` endpoint — `{path}` is optional) | Already rewritten with single `get_analytics_paths(path=None)`. **Memory note: analytics is PRODUCTION-only** (per project memory `feedback_analytics_prod_only.md`). The SANDBOX test for this MUST use the PROD client + `ALMA_PROD_API_KEY`, BUT R8 forbids the prod key in the orchestration env. **This chunk requires manual SANDBOX-step substitution OR explicit user approval to relax R8 just for this test.** Likely: mark all paths-related ACs `unmappable` and verify by hand. |
+| 59 | · planned | `analytics-paths` | #79 | low | none | #79 partially aligned (root `/paths` endpoint — `{path}` is optional) | Already rewritten with single `get_analytics_paths(path=None)`. **Memory note: analytics is PRODUCTION-only** (per project memory `feedback_analytics_prod_only.md`). The SANDBOX test for this MUST use the PROD client + `ALMA_PROD_API_KEY`, BUT R8 forbids the prod key in the orchestration env. **This chunk requires manual SANDBOX-step substitution OR explicit user approval to relax R8 just for this test.** Likely: mark all paths-related ACs `unmappable` and verify by hand. |
 
 ## Phase 16 — Pipeline & dev-experience improvements
 
@@ -200,8 +192,8 @@ Improvements to the chunk pipeline itself, surfaced from running it at scale acr
 
 | # | Status | Chunk | Issues | Risk | Prereqs | Audit | Notes |
 |---|---|---|---|---|---|---|---|
-| 63 | · planned | `pipeline-swagger-enrich` | #123 | med | none | clean | Enrich `_swagger_*.json` sidecars with per-endpoint description/requestBody/responses so the implement agent has structured context instead of just error codes. Pipeline internals only. |
-| 64 | · planned | `re-verify-create-user-request` | #129 | low | none | clean | Calendar-tied: re-verify `Users.create_user_request` live SANDBOX behavior around 2026-05-25. Not really a chunk — surface here so it isn't forgotten; execute as a one-shot when the date arrives. |
+| 60 | · planned | `pipeline-swagger-enrich` | #123 | med | none | clean | Enrich `_swagger_*.json` sidecars with per-endpoint description/requestBody/responses so the implement agent has structured context instead of just error codes. Pipeline internals only. |
+| 61 | · planned | `re-verify-create-user-request` | #129 | low | none | clean | Calendar-tied: re-verify `Users.create_user_request` live SANDBOX behavior around 2026-05-25. Not really a chunk — surface here so it isn't forgotten; execute as a one-shot when the date arrives. |
 
 ## Phase 17 — Advanced architecture (deferred until coverage stabilizes)
 
@@ -209,12 +201,12 @@ The handbook recommends doing these in wave 7, after most of the high-priority c
 
 | # | Status | Chunk | Issues | Risk | Prereqs | Audit | Notes |
 |---|---|---|---|---|---|---|---|
-| 65 | · planned | `rate-limiting` | #8 | high | #3, #4, #5 | clean | Rolling-window throttler. Hard to validate in SANDBOX. |
-| 66 | · planned | `async-bulk` | #18 | high | #3, #4 | clean | Sibling async client + `bulk_call`. Big surface; mostly mock-tested. |
-| 67 | · planned | `marc-layer` | #19 | high | #46 | clean | Optional `pymarc` integration; needs careful design review. |
-| 68 | · planned | `openapi-validation` | #20 | high | none | clean | Optional opt-in validator vendoring Ex Libris specs. Defer until specs are stable. |
-| 69 | · planned | `batch-runner` | #21 | high | #18 | clean | DataFrame batch orchestrator built on #18 async. |
-| 70 | · planned | `pydantic-models` | #12 | high | none | clean | Schema-derived models. Defer to last; benefits most from real fixtures. |
+| 62 | · planned | `rate-limiting` | #8 | high | #3, #4, #5 | clean | Rolling-window throttler. Hard to validate in SANDBOX. |
+| 63 | · planned | `async-bulk` | #18 | high | #3, #4 | clean | Sibling async client + `bulk_call`. Big surface; mostly mock-tested. |
+| 64 | · planned | `marc-layer` | #19 | high | #46 | clean | Optional `pymarc` integration; needs careful design review. |
+| 65 | · planned | `openapi-validation` | #20 | high | none | clean | Optional opt-in validator vendoring Ex Libris specs. Defer until specs are stable. |
+| 66 | · planned | `batch-runner` | #21 | high | #18 | clean | DataFrame batch orchestrator built on #18 async. |
+| 67 | · planned | `pydantic-models` | #12 | high | none | clean | Schema-derived models. Defer to last; benefits most from real fixtures. |
 
 ## Blocked — resolve before chunking
 

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -113,17 +113,31 @@ Run from `release/<version>` after Phase C–E commits. Any failure stops the re
 
 ---
 
-## Phase J — Real PyPI publish (irreversible)
+## Phase J — Real PyPI publish (automated by tag push)
 
-- [ ] **Rebuild on main** to confirm artifacts match the merged code. `rm -rf dist/ && poetry build`. Filename version should match `pyproject.toml`.
+As of `0.4.x` post-cycle (issue #128), pushing a `v<version>` tag triggers `.github/workflows/release.yml`, which re-runs the full Phase F validation, rebuilds the wheel, verifies the wheel filename matches `pyproject.toml`, and publishes to PyPI via Trusted Publishing (OIDC, no token in repo secrets).
+
+- [ ] **Tag the merged commit.** `git tag -a v<version> -m "Release <version>" && git push origin v<version>`. This triggers the workflow.
+- [ ] **Watch the workflow run.** `gh run watch` (or the **Actions** tab). If the `release` GitHub Environment has required reviewers, the publish step waits for approval — click **Review deployments → Approve and deploy**.
+- [ ] **Verify on `https://pypi.org/project/almaapitk/<version>/`** — version listed, README renders. The workflow's publish step is the gate; this is the human confirmation.
+
+**Manual fallback** (Trusted Publishing breaks, or you want to publish out-of-band):
+
+- [ ] **Rebuild on main.** `rm -rf dist/ && poetry build`. Filename version should match `pyproject.toml`.
 - [ ] **`twine upload dist/almaapitk-<version>*`** — to real PyPI. **Once this returns success, the version cannot be re-uploaded under any circumstances.** Yanking is possible but only discourages new installs; pinned consumers still get the artifact.
 - [ ] **Verify on `https://pypi.org/project/almaapitk/<version>/`** — version is listed, README renders.
 
+**One-time PyPI-side setup for Trusted Publishing** (already done as of #128 — re-do only if the PyPI project, repo, or workflow filename changes):
+
+1. Log in at https://pypi.org and open `https://pypi.org/manage/project/almaapitk/settings/publishing/`.
+2. Add a GitHub Trusted Publisher: Owner `hagaybar`, Repository `AlmaAPITK`, Workflow filename `release.yml`, Environment name `release` (if the GitHub `release` environment is configured for approval gates; otherwise leave blank).
+
 ---
 
-## Phase K — Tag + GitHub Release
+## Phase K — GitHub Release
 
-- [ ] **Tag the merged commit.** `git tag -a v<version> -m "Release <version>" && git push origin v<version>`.
+The Phase J tag push already triggers the publish workflow. This phase just publishes the human-readable release notes.
+
 - [ ] **Extract the CHANGELOG excerpt** to a file: `awk '/^## \[<version>\]/,/^## \[<prev>\]/' CHANGELOG.md | head -n -1 > /tmp/release-<version>-notes.md`. Verify it's non-empty and starts with the version heading.
 - [ ] **Create the GitHub Release.** `gh release create v<version> --title "v<version>" --notes-file /tmp/release-<version>-notes.md`.
 

--- a/docs/chunks-backlog.yaml
+++ b/docs/chunks-backlog.yaml
@@ -1,6 +1,6 @@
 schema_version: 1
-total_chunks: 70
-total_issues: 96
+total_chunks: 67
+total_issues: 93
 
 intro: |
   **Status:** Suggested groupings — revise freely. The chunking is your call; this doc removes the "what do I chunk next" decision fatigue.
@@ -514,32 +514,6 @@ phases:
         audit: "#78 NOT ALIGNED (`localize` POST has no body params; `localization_data` was invented)"
         notes: |
           Already rewritten — bodyless POST. Solo. Same `#120` prereq as `rs-partners`.
-
-  - id: 14
-    title: Courses
-    description: ""
-    chunks:
-      - name: courses-bootstrap
-        issues: [75]
-        risk: low
-        prereqs: []
-        audit: clean
-        notes: |
-          Foundation. **Blocks #76, #77.**
-      - name: courses-crud-enrollment
-        issues: [76]
-        risk: high
-        prereqs: [75]
-        audit: "#76 NOT ALIGNED (POST is op-driven via query params: `op` + `user_ids`/`list_ids`, NOT a JSON body)"
-        notes: |
-          Already rewritten. Method signature is now `enroll_users_in_course(user_ids)` and `associate_reading_lists(list_ids)`.
-      - name: courses-reading-lists
-        issues: [77]
-        risk: med
-        prereqs: [75]
-        audit: "#77 partially aligned (citation file removal needs `op`; tags are objects not strings)"
-        notes: |
-          Already rewritten.
 
   - id: 15
     title: Analytics

--- a/docs/superpowers/specs/2026-05-10-release-0.4.0-design.md
+++ b/docs/superpowers/specs/2026-05-10-release-0.4.0-design.md
@@ -91,7 +91,10 @@ Linear, one gate per phase. Nothing is irreversible until step 7.
 **Explicitly out of scope:**
 
 - GitHub Actions publish workflow — filed as a follow-up issue after
-  `0.4.0` ships.
+  `0.4.0` ships. (Landed post-0.4.3 via issue #128:
+  `.github/workflows/release.yml` is now the canonical publish path on
+  tag push; manual `poetry publish` / `twine upload` becomes the
+  fallback documented in `docs/RELEASE_CHECKLIST.md` Phase J.)
 - Remaining open architecture issues (`#3–#21`) — ship in `0.5.0` or
   later. Don't expand scope mid-release.
 
@@ -194,8 +197,8 @@ release.
 
 ## Follow-ups (deferred)
 
-- File a GitHub Actions publish workflow (PyPI Trusted Publishing
+- ~~File a GitHub Actions publish workflow (PyPI Trusted Publishing
   via OIDC, triggered on `v*` tag push). Pays back from `0.5.0`
-  onward.
+  onward.~~ — **Done** in issue #128 (`.github/workflows/release.yml`).
 - Once the architecture backlog (`#3–#21`) settles, decide whether
   `1.0.0` is the next semantic version (declares API stability).


### PR DESCRIPTION
## Summary

- New `.github/workflows/release.yml`: triggers on `push` of `v*` tags, runs the full Phase F validation suite, verifies the wheel filename matches `pyproject.toml`, then publishes to PyPI via Trusted Publishing (OIDC — no token in repo secrets).
- `docs/RELEASE_CHECKLIST.md` Phase J rewritten: tag push is now the canonical publish path; manual `twine upload` documented as the fallback.
- `docs/superpowers/specs/2026-05-10-release-0.4.0-design.md` updated: the deferred follow-up is marked done with a pointer to the workflow.
- Side commit: `chore(backlog)` defers the Courses phase indefinitely. #75 / #76 / #77 were closed as not-planned in this same session — no current consumer demand.
- Follow-up commit: dropped the optional GitHub `environment: release` binding from the workflow. PyPI Trusted Publisher was configured with `Environment name: (Any)`, so the OIDC token from any run of this workflow is accepted; binding the job to a nonexistent GitHub environment would have caused the run to refuse to start.

Workflow stays under 80 lines (76 after the environment removal).

## PyPI-side setup — DONE

Trusted Publisher is configured on PyPI:
- Repository: `hagaybar/AlmaAPITK`
- Workflow: `release.yml`
- Environment name: `(Any)`

No GitHub Environment is required at the repo level.

## Acceptance criteria check

- [x] `.github/workflows/release.yml` exists, valid YAML, uses `actions/checkout@v4` and `pypa/gh-action-pypi-publish@release/v1`.
- [x] Triggers on `push: tags: [v*]` only.
- [x] Full Phase F validation runs before the build step; any failure stops the run before publish.
- [x] Wheel-filename-matches-pyproject check is wired in between build and publish.
- [x] `permissions: id-token: write` set at the job level (required for OIDC).
- [x] No TestPyPI step (operator runs it manually per the Phase H out-of-scope note).
- [x] `docs/RELEASE_CHECKLIST.md` Phase J updated; manual fallback documented.
- [x] YAML parses (validated via `yaml.safe_load`).

## Follow-ups

- Close #1 (the original "Approach 3: Trusted Publisher" issue) as duplicate of #128 once this merges.
- Latent renderer bug noticed mid-PR: `scripts/agentic/render_backlog.py` treats `closed-as-not-planned` issues as ✅ merged when no PR matches. Workaround applied here (dropped the Courses chunks from the YAML). File a separate issue if the renderer's correctness around `stateReason: NOT_PLANNED` needs a proper fix.

## Test plan

- [ ] After merge, walk the full `docs/RELEASE_CHECKLIST.md` for the next release. Push the `v*` tag and watch the `release` workflow run end-to-end. With no environment gate, the workflow runs through validation → build → publish without manual intervention.
- [ ] Confirm the release artifact appears at `https://pypi.org/project/almaapitk/<version>/`.
- [ ] If anything fails, fall back to manual `twine upload` per the updated Phase J.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
