### PR TITLE
chunk: electronic-bootstrap (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,6 +203,7 @@ The primary deliverable - a clean, importable Python package.
 | **Analytics** | `analytics.py` | Analytics reports (headers, rows with pagination) |
 | **BibliographicRecords** | `bibs.py` | Bib records, holdings, items, scan-in |
 | **Configuration** | `configuration.py` | Configuration API foundation skeleton (issue #22; concrete methods land in sibling tickets 24-35) |
+| **Electronic** | `electronic.py` | Electronic API foundation skeleton (issue #66; e-collection/e-service/portfolio methods land in sibling tickets 67-69) |
 | **ResourceSharing** | `resource_sharing.py` | Lending/borrowing via Partners API |
 | **Users** | `users.py` | User management, email updates |
 

--- a/src/almaapitk/__init__.py
+++ b/src/almaapitk/__init__.py
@@ -89,6 +89,7 @@ __all__ = [
     "ResourceSharing",
     "Analytics",
     "Configuration",
+    "Electronic",
     # Utilities
     "TSVGenerator",
     "CitationMetadataError",
@@ -117,6 +118,7 @@ _lazy_imports = {
     "ResourceSharing": ("almaapitk._internal", "ResourceSharing"),
     "Analytics": ("almaapitk._internal", "Analytics"),
     "Configuration": ("almaapitk._internal", "Configuration"),
+    "Electronic": ("almaapitk._internal", "Electronic"),
     # Utilities
     "TSVGenerator": ("almaapitk.utils.tsv_generator", "TSVGenerator"),
     "CitationMetadataError": ("almaapitk.utils.citation_metadata", "CitationMetadataError"),

--- a/src/almaapitk/_internal/__init__.py
+++ b/src/almaapitk/_internal/__init__.py
@@ -31,6 +31,7 @@ from .domains import (
     ResourceSharing,
     Analytics,
     Configuration,
+    Electronic,
 )
 
 __all__ = [
@@ -54,4 +55,5 @@ __all__ = [
     "ResourceSharing",
     "Analytics",
     "Configuration",
+    "Electronic",
 ]

--- a/src/almaapitk/_internal/domains.py
+++ b/src/almaapitk/_internal/domains.py
@@ -12,6 +12,7 @@ Domain classes provide high-level API wrappers for specific Alma functional area
 - ResourceSharing: Lending/borrowing requests via Partners API
 - Analytics: Analytics reports and data retrieval
 - Configuration: Configuration API surface (foundation skeleton, issue #22)
+- Electronic: Electronic API surface (foundation skeleton, issue #66)
 """
 from almaapitk.domains.admin import Admin
 from almaapitk.domains.users import Users
@@ -20,6 +21,7 @@ from almaapitk.domains.acquisition import Acquisitions
 from almaapitk.domains.resource_sharing import ResourceSharing
 from almaapitk.domains.analytics import Analytics
 from almaapitk.domains.configuration import Configuration
+from almaapitk.domains.electronic import Electronic
 
 __all__ = [
     "Admin",
@@ -29,4 +31,5 @@ __all__ = [
     "ResourceSharing",
     "Analytics",
     "Configuration",
+    "Electronic",
 ]

--- a/src/almaapitk/domains/electronic.py
+++ b/src/almaapitk/domains/electronic.py
@@ -1,0 +1,95 @@
+"""
+Electronic Domain Class for Alma API.
+
+Foundation skeleton for the Electronic API surface (issue #66). The
+Electronic domain wraps Alma's ``/almaws/v1/electronic/*`` endpoints —
+e-collections, e-services, and portfolios. This module deliberately
+ships only the class skeleton (environment introspection and a smoke
+connection check) so the sibling coverage tickets (#67 e-collections,
+#68 e-services, #69 portfolios) can each land one focused PR on top of
+this foundation.
+
+Concrete API methods do NOT live here — they belong to the sibling
+tickets.
+"""
+from almaapitk.client.AlmaAPIClient import AlmaAPIClient
+from almaapitk.alma_logging import get_logger
+
+
+class Electronic:
+    """
+    Domain class for handling Alma Electronic API operations.
+
+    Foundation skeleton (issue #66). Sibling tickets layer the concrete
+    endpoints on top of this class:
+
+    - issue #67: e-collections coverage
+    - issue #68: e-services coverage
+    - issue #69: portfolios coverage
+
+    This class uses the AlmaAPIClient as its foundation for all HTTP
+    operations.
+    """
+
+    def __init__(self, client: AlmaAPIClient):
+        """
+        Initialize the Electronic domain.
+
+        Args:
+            client: The AlmaAPIClient instance for making HTTP requests.
+        """
+        # Pattern source: Configuration.__init__ in configuration.py
+        # (which itself mirrors Admin.__init__ in admin.py). Store the
+        # client, snapshot the environment for log context, and create
+        # a domain-specific logger via the shared logging factory.
+        self.client = client
+        self.environment = client.get_environment()
+        self.logger = get_logger('electronic', environment=self.environment)
+
+    # =========================================================================
+    # Utility Methods
+    # =========================================================================
+
+    def get_environment(self) -> str:
+        """
+        Get the current environment from the underlying client.
+
+        Returns:
+            The environment string ('SANDBOX' or 'PRODUCTION').
+        """
+        # Pattern source: Configuration.get_environment in configuration.py.
+        self.logger.debug("Electronic.get_environment called")
+        environment = self.client.get_environment()
+        self.logger.debug(f"Electronic.get_environment returning: {environment}")
+        return environment
+
+    def test_connection(self) -> bool:
+        """
+        Test if the Alma API connection is working.
+
+        Delegates to ``AlmaAPIClient.test_connection``. Electronic
+        endpoints are exercised by sibling tickets — at the foundation
+        level we simply confirm the client itself can reach the API.
+
+        Returns:
+            True if the underlying client connection succeeds, False
+            otherwise.
+        """
+        # Pattern source: Configuration.test_connection in configuration.py
+        # — delegate to the client rather than hitting a domain-specific
+        # endpoint, since no Electronic endpoints are wired up yet.
+        self.logger.info(
+            f"Testing Electronic API connection ({self.environment})"
+        )
+        success = self.client.test_connection()
+
+        if success:
+            self.logger.info(
+                f"✓ Electronic API connection successful ({self.environment})"
+            )
+        else:
+            self.logger.error(
+                f"✗ Electronic API connection failed ({self.environment})"
+            )
+
+        return success

--- a/tests/test_public_api_contract.py
+++ b/tests/test_public_api_contract.py
@@ -189,6 +189,21 @@ class TestPublicAPIContract(unittest.TestCase):
             "Expected domain symbol 'Configuration' to be in __all__",
         )
 
+    def test_electronic_importable(self):
+        """Test that Electronic domain class is importable from almaapitk (issue #66)."""
+        from almaapitk import Electronic
+        self.assertIsNotNone(Electronic)
+        self.assertTrue(callable(Electronic))
+
+    def test_electronic_in_all(self):
+        """Test that Electronic is in __all__ (issue #66)."""
+        import almaapitk
+        self.assertIn(
+            'Electronic',
+            almaapitk.__all__,
+            "Expected domain symbol 'Electronic' to be in __all__",
+        )
+
     def test_stdlib_logging_not_shadowed(self):
         """Test that stdlib logging is not shadowed by internal modules."""
         import logging

--- a/tests/unit/domains/test_electronic.py
+++ b/tests/unit/domains/test_electronic.py
@@ -1,0 +1,164 @@
+"""
+Unit tests for the Electronic domain class (issue #66).
+
+Tests cover the foundation skeleton only:
+- Initialization (client, environment, logger setup)
+- get_environment() - returns the environment from the underlying client
+- test_connection() - delegates to client.test_connection()
+
+Concrete Electronic API methods (e-collections, e-services, portfolios)
+land in sibling tickets (#67, #68, #69) and are tested there.
+
+These tests use a mocked AlmaAPIClient to exercise the Electronic
+domain in isolation. Pattern source mirrors
+``tests/unit/domains/test_configuration.py`` (the most recent foundation
+skeleton, issue #22).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+class MockAlmaAPIClient:
+    """Mock AlmaAPIClient for testing the Electronic domain.
+
+    The foundation tests (issue #66) only need ``get_environment`` and
+    ``test_connection``. Pattern source mirrors the foundation-tier of
+    ``tests/unit/domains/test_configuration.py``'s
+    ``MockAlmaAPIClient``.
+    """
+
+    def __init__(
+        self,
+        environment: str = 'SANDBOX',
+        connection_result: bool = True,
+    ):
+        self.environment = environment
+        self.logger = MagicMock()
+        self._connection_result = connection_result
+        self.test_connection_call_count = 0
+
+    def get_environment(self) -> str:
+        return self.environment
+
+    def test_connection(self) -> bool:
+        self.test_connection_call_count += 1
+        return self._connection_result
+
+
+class TestElectronicInit:
+    """Tests for Electronic class initialization."""
+
+    def test_init_sets_client(self):
+        """Test that __init__ properly stores the client."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX')
+        electronic = Electronic(mock_client)
+
+        assert electronic.client is mock_client
+
+    def test_init_sets_environment_from_client(self):
+        """Test that __init__ stores the environment from the client."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX')
+        electronic = Electronic(mock_client)
+
+        assert electronic.environment == 'SANDBOX'
+
+    def test_init_with_production_environment(self):
+        """Test initialization with PRODUCTION environment."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('PRODUCTION')
+        electronic = Electronic(mock_client)
+
+        assert electronic.environment == 'PRODUCTION'
+
+    def test_init_creates_logger(self):
+        """Test that __init__ initializes a domain-specific logger."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX')
+        electronic = Electronic(mock_client)
+
+        # Logger must exist and have the standard logging methods we use.
+        assert electronic.logger is not None
+        assert hasattr(electronic.logger, 'info')
+        assert hasattr(electronic.logger, 'debug')
+        assert hasattr(electronic.logger, 'error')
+
+
+class TestElectronicGetEnvironment:
+    """Tests for Electronic.get_environment() method."""
+
+    def test_get_environment_returns_sandbox(self):
+        """Test that get_environment returns SANDBOX from sandbox client."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX')
+        electronic = Electronic(mock_client)
+
+        assert electronic.get_environment() == 'SANDBOX'
+
+    def test_get_environment_returns_production(self):
+        """Test that get_environment returns PRODUCTION from prod client."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('PRODUCTION')
+        electronic = Electronic(mock_client)
+
+        assert electronic.get_environment() == 'PRODUCTION'
+
+    def test_get_environment_delegates_to_client(self):
+        """Test that get_environment reads through to the client each call."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX')
+        # Spy on the client's get_environment.
+        mock_client.get_environment = MagicMock(return_value='SANDBOX')
+        electronic = Electronic(mock_client)
+        # Reset call count: __init__ also calls get_environment once.
+        mock_client.get_environment.reset_mock()
+
+        result = electronic.get_environment()
+
+        assert result == 'SANDBOX'
+        mock_client.get_environment.assert_called_once()
+
+
+class TestElectronicTestConnection:
+    """Tests for Electronic.test_connection() method."""
+
+    def test_test_connection_success(self):
+        """Test that test_connection returns True when client connects OK."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX', connection_result=True)
+        electronic = Electronic(mock_client)
+
+        assert electronic.test_connection() is True
+
+    def test_test_connection_failure(self):
+        """Test that test_connection returns False when client fails."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX', connection_result=False)
+        electronic = Electronic(mock_client)
+
+        assert electronic.test_connection() is False
+
+    def test_test_connection_delegates_to_client(self):
+        """Test that test_connection calls the client's test_connection."""
+        from almaapitk.domains.electronic import Electronic
+
+        mock_client = MockAlmaAPIClient('SANDBOX', connection_result=True)
+        electronic = Electronic(mock_client)
+
+        electronic.test_connection()
+
+        # The client's test_connection must have been called exactly once
+        # by our delegation.
+        assert mock_client.test_connection_call_count == 1


### PR DESCRIPTION
## Chunk: `electronic-bootstrap`

Closes #66

## Implementation summary

Chunk electronic-bootstrap shipped the foundation Electronic domain class on branch chunk/electronic-bootstrap: new src/almaapitk/domains/electronic.py with __init__, get_environment, and test_connection (no API endpoints wired); lazy-import wiring in src/almaapitk/__init__.py and _internal re-export; new unit tests in tests/unit/domains/test_electronic.py; assertion of the new Electronic symbol in tests/test_public_api_contract.py; and a CLAUDE.md Domain Classes table update. Foundation-only — unblocks sibling coverage tickets #67/#68/#69.

## SANDBOX test summary

Test execution finished at 2026-05-19T11:18:14Z with 1 passed / 0 failed / 0 skipped. T1-electronic-smoke (non-state-changing pytest under chunks/electronic-bootstrap/sandbox-tests/) ran against the live SANDBOX tenant and verified Electronic importability, instantiation with a SANDBOX AlmaAPIClient, get_environment()=='SANDBOX', and test_connection()==True. Outcome: tested:passing-needs-review — every test passed but the test-recommendation.json plan declared 4 ACs as unmappable (smoke_import.py, public-API contract pytest, CLAUDE.md doc update, negative 'no API methods' AC), all covered by the impl pipeline's offline gates rather than SANDBOX exercise.

## Verification done in the loop

- [x] py_compile on changed files
- [x] smoke_import.py
- [x] tests/test_public_api_contract.py
- [x] scope-check (files-to-touch) per R7
- [x] Per-issue unit tests
- [x] SANDBOX integration tests (see test-results.json in chunks/electronic-bootstrap/)

## Pending

- [ ] Human PR review
- [ ] Manual merge to `main` (R2 — never auto-merged)
- [ ] (Later) Manual `prod` promotion via test release + soak (R1 — out of pipeline scope)
