### PR TITLE
ci: wheel/sdist contents + High-severity bandit guards (#150, #151)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+# Push-time packaging + security guards (issues #150, #151). These run on
+# every push to main and every PR targeting main, days/weeks before any
+# release tag, so regressions are caught on the PR that introduces them.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  artifact-contents:
+    name: Verify wheel + sdist contents
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Poetry
+        run: pipx install poetry
+
+      - name: Build sdist + wheel
+        run: poetry build
+
+      # Stdlib-only checker: no project deps needed.
+      - name: Check artifact contents
+        run: python scripts/ci/check_artifact_contents.py
+
+  bandit:
+    name: Block new High-severity bandit findings
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install bandit
+        run: pip install bandit
+
+      # Scan to JSON (all severities). bandit exits non-zero whenever it
+      # finds anything at all, including the Medium/Low findings we do NOT
+      # want to block on, so swallow its exit code and let the script be
+      # the gate -- it fails only on HIGH severity.
+      - name: Run bandit
+        run: bandit -r src/almaapitk/ -f json -o bandit.json || true
+
+      - name: Fail on High-severity findings
+        run: python scripts/ci/check_bandit.py bandit.json

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,6 @@ chunks/*/_swagger_errors_*.json
 # (fetched Alma swagger specs + extracted error-code reports). Regenerated
 # on every fetch-swagger-codes step in the chunk pipeline.
 scripts/error_codes/swagger_cache/
+
+# bandit JSON report produced by the CI security guard (scripts/ci/check_bandit.py)
+bandit.json

--- a/scripts/ci/check_artifact_contents.py
+++ b/scripts/ci/check_artifact_contents.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Verify the built wheel and sdist contain only what they should (issue #150).
+
+Guards against packaging regressions like the pre-0.3.1 "empty wheel"
+footgun and stray ``tests/``/``scripts/``/``docs/`` leaking into a release.
+Run after ``poetry build``; exits non-zero (listing every offending entry)
+when either artifact contains an unexpected file.
+
+Stdlib only -- runs on a bare CI Python with no project deps installed.
+"""
+from __future__ import annotations
+
+import glob
+import os
+import re
+import sys
+import tarfile
+import zipfile
+
+
+def _version_from(filename: str, suffix: str) -> str:
+    """Pull ``<version>`` out of ``almaapitk-<version><suffix...>``."""
+    stem = os.path.basename(filename)
+    # almaapitk-0.4.5-py3-none-any.whl  /  almaapitk-0.4.5.tar.gz
+    return stem.split("-")[1] if suffix == ".whl" else stem[: -len(".tar.gz")].split("-", 1)[1]
+
+
+def check_wheel(path: str) -> list[str]:
+    """A wheel may contain only package code + its ``.dist-info`` metadata."""
+    version = _version_from(path, ".whl")
+    allowed = ("almaapitk/", f"almaapitk-{version}.dist-info/")
+    with zipfile.ZipFile(path) as zf:
+        return [n for n in zf.namelist()
+                if not n.endswith("/") and not n.startswith(allowed)]
+
+
+def check_sdist(path: str) -> list[str]:
+    """An sdist may contain only the documented metadata files + source."""
+    version = _version_from(path, ".tar.gz")
+    root = f"almaapitk-{version}/"
+    allowed_exact = {"PKG-INFO", "pyproject.toml", "README.md",
+                     "CHANGELOG.md", "LICENSE"}
+    offenders: list[str] = []
+    with tarfile.open(path) as tf:
+        for member in tf.getmembers():
+            if member.isdir():
+                continue
+            name = member.name
+            if not name.startswith(root):
+                offenders.append(name)
+                continue
+            rel = name[len(root):]
+            if rel in allowed_exact:
+                continue
+            if rel.startswith("src/almaapitk/"):
+                continue
+            if re.fullmatch(r"docs/releases/.*\.md", rel):
+                continue
+            offenders.append(name)
+    return offenders
+
+
+def _exactly_one(pattern: str, label: str, problems: list[str]) -> str | None:
+    matches = sorted(glob.glob(pattern))
+    if len(matches) != 1:
+        problems.append(f"expected exactly one {label} matching {pattern}, "
+                        f"found {len(matches)}: {matches}")
+        return None
+    return matches[0]
+
+
+def main() -> int:
+    problems: list[str] = []
+    wheel = _exactly_one("dist/*.whl", "wheel", problems)
+    sdist = _exactly_one("dist/*.tar.gz", "sdist", problems)
+    if problems:
+        for p in problems:
+            print(f"ERROR: {p}")
+        return 1
+
+    failures = 0
+    for label, offenders in (("wheel", check_wheel(wheel)),
+                             ("sdist", check_sdist(sdist))):
+        if offenders:
+            failures += len(offenders)
+            print(f"ERROR: unexpected {label} entries:")
+            for name in offenders:
+                print(f"  {name}")
+    if failures:
+        print(f"\n{failures} unexpected artifact entr(ies). "
+              "Tighten pyproject.toml include/exclude.")
+        return 1
+    print(f"OK: {os.path.basename(wheel)} and {os.path.basename(sdist)} "
+          "contain only expected files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/check_bandit.py
+++ b/scripts/ci/check_bandit.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Fail the build on any HIGH-severity bandit finding (issue #151).
+
+Reads a bandit JSON report (default ``bandit.json``) and exits non-zero if
+it contains one or more findings whose ``issue_severity`` is ``HIGH``.
+Medium/Low findings are reported for visibility but never block — the
+baseline at adoption is zero HIGH findings, so enforcement starts clean.
+
+Stdlib only.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def main() -> int:
+    report = Path(sys.argv[1] if len(sys.argv) > 1 else "bandit.json")
+    if not report.exists():
+        print(f"ERROR: bandit report not found: {report}")
+        return 1
+
+    results = json.loads(report.read_text()).get("results", [])
+    by_severity = Counter(r.get("issue_severity", "UNDEFINED") for r in results)
+    print(f"bandit: {len(results)} finding(s) "
+          f"(HIGH={by_severity['HIGH']}, MEDIUM={by_severity['MEDIUM']}, "
+          f"LOW={by_severity['LOW']})")
+
+    high = [r for r in results if r.get("issue_severity") == "HIGH"]
+    for r in high:
+        print(f"  HIGH {r.get('test_id')} "
+              f"{r.get('filename')}:{r.get('line_number')} "
+              f"-- {r.get('issue_text')}")
+    if high:
+        print(f"\n{len(high)} HIGH-severity finding(s). Fix them, or "
+              "suppress a confirmed false positive with `# nosec <test_id>`.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a push-time CI workflow (`.github/workflows/ci.yml`) with two independent guards, running on every push to `main` and every PR targeting `main`. Closes #150 and #151.

## Jobs

**`artifact-contents`** (#150) — `poetry build`, then `scripts/ci/check_artifact_contents.py` asserts:
- **Wheel** contains only `almaapitk/**` + `almaapitk-<version>.dist-info/*` — no `tests/`, `scripts/`, `docs/`, `.a5c/`, `logs/`, `config/`, `CLAUDE.md`, `AGENTS.md`.
- **Sdist** contains only `PKG-INFO`, `pyproject.toml`, `README.md`, `CHANGELOG.md`, `LICENSE`, `docs/releases/*.md`, and `src/almaapitk/**`.

Catches packaging regressions (the pre-0.3.1 "empty wheel" footgun, or stray files leaking in) weeks before a release tag — today this is only verified by eye during Phase G of the release checklist.

**`bandit`** (#151) — scans `src/almaapitk/`; `scripts/ci/check_bandit.py` fails the job on any **HIGH**-severity finding. Medium/Low are reported for visibility but never block. **Baseline at adoption: HIGH=0** (8 Medium, 5 Low), so enforcement starts clean — no immediate breakage.

## Notes
- Both checker scripts are **stdlib-only** (run on a bare CI Python, no project deps).
- `bandit` is intentionally **unpinned** (`pip install bandit`); suppress a confirmed false positive with `# nosec <test_id>` rather than version-pinning.
- Per #151, hold off on marking these as required status checks until they've run green for a release cycle.

## Verified locally
- Real built artifacts pass the contents check (exit 0).
- An injected `tests/` file in the wheel is caught (exit 1).
- Current bandit scan is HIGH-free (`check_bandit` exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)