### PR TITLE
feat(testing): workflow smoke-test harness v1 (core + analytics pilot)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,7 @@ scripts/error_codes/swagger_cache/
 
 # bandit JSON report produced by the CI security guard (scripts/ci/check_bandit.py)
 bandit.json
+
+# Smoke-test inputs hold synthetic-but-environment-specific values (R9).
+# Copy smoke-data.example.json -> smoke-data.json and fill in locally.
+smoke-data.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Workflow smoke tests (issue #156/#157). Friendly wrappers over pytest so
+# "validate this version" is one command.
+.PHONY: smoke smoke-live
+
+# Dry-run only (no credentials needed): validates each workflow's wiring.
+smoke:
+	poetry run python -m pytest tests/smoke/ -q
+
+# Live mode: real read-only calls. Live checks whose env credentials are
+# absent auto-skip (they never fail the run).
+smoke-live:
+	ALMA_SMOKE_LIVE=1 poetry run python -m pytest tests/smoke/ -q

--- a/poetry.lock
+++ b/poetry.lock
@@ -120,7 +120,7 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["dev"]
+groups = ["main", "dev"]
 markers = "sys_platform == \"win32\""
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
@@ -148,7 +148,7 @@ version = "2.3.0"
 description = "brain-dead simple config-ini parsing"
 optional = false
 python-versions = ">=3.10"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12"},
     {file = "iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730"},
@@ -160,7 +160,7 @@ version = "26.0"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
     {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
@@ -172,7 +172,7 @@ version = "1.6.0"
 description = "plugin and hook calling mechanisms for python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746"},
     {file = "pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3"},
@@ -188,7 +188,7 @@ version = "2.19.2"
 description = "Pygments is a syntax highlighting package written in Python."
 optional = false
 python-versions = ">=3.8"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b"},
     {file = "pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887"},
@@ -203,7 +203,7 @@ version = "8.4.2"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79"},
     {file = "pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01"},
@@ -259,7 +259,10 @@ h2 = ["h2 (>=4,<5)"]
 socks = ["pysocks (>=1.5.6,!=1.5.7,<2.0)"]
 zstd = ["zstandard (>=0.18.0)"]
 
+[extras]
+smoke = ["pytest"]
+
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12"
-content-hash = "08c31fc0116fc4cf802db5e2e3c02c83a6f062d7c43a65a2fbfe2720cce75716"
+content-hash = "2545a19ae966357e12786af4fc692c83062bb3d5595d6f77040d8b6e09805121"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
     "requests>=2.32.0,<3.0.0"
 ]
 
+[project.optional-dependencies]
+# Install with: pip install almaapitk[smoke]
+# Pulls the test runner used by the workflow smoke-test harness
+# (almaapitk.testing). Kept out of the core install so normal users
+# don't pay for pytest.
+smoke = ["pytest>=8.0.0,<9.0.0"]
+
 [project.urls]
 Homepage = "https://github.com/hagaybar/AlmaAPITK"
 Repository = "https://github.com/hagaybar/AlmaAPITK"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,11 @@ dependencies = [
 # don't pay for pytest.
 smoke = ["pytest>=8.0.0,<9.0.0"]
 
+# Auto-load the `alma` fixture when almaapitk[smoke] is installed —
+# consumers get the harness fixture without writing a conftest.
+[project.entry-points.pytest11]
+almaapitk_smoke = "almaapitk.testing.pytest_plugin"
+
 [project.urls]
 Homepage = "https://github.com/hagaybar/AlmaAPITK"
 Repository = "https://github.com/hagaybar/AlmaAPITK"

--- a/smoke-data.example.json
+++ b/smoke-data.example.json
@@ -1,0 +1,3 @@
+{
+  "analytics_report_path": "/shared/<your-institution>/Reports/<some-report>"
+}

--- a/src/almaapitk/testing/__init__.py
+++ b/src/almaapitk/testing/__init__.py
@@ -1,0 +1,11 @@
+"""Workflow smoke-test harness for almaapitk.
+
+Install with ``pip install almaapitk[smoke]``. See
+``docs/superpowers/specs/2026-05-25-workflow-smoke-harness-design.md``.
+
+The public surface is populated as the harness components land; the full
+set is exported once the ``@workflow`` marker and pytest plugin exist.
+"""
+from __future__ import annotations
+
+__all__: list[str] = []

--- a/src/almaapitk/testing/__init__.py
+++ b/src/almaapitk/testing/__init__.py
@@ -2,10 +2,25 @@
 
 Install with ``pip install almaapitk[smoke]``. See
 ``docs/superpowers/specs/2026-05-25-workflow-smoke-harness-design.md``.
-
-The public surface is populated as the harness components land; the full
-set is exported once the ``@workflow`` marker and pytest plugin exist.
 """
 from __future__ import annotations
 
-__all__: list[str] = []
+from .client import build_smoke_client
+from .flaky import TransientAPIError, run_with_flaky_tolerance
+from .guards import ReadOnlyViolation, install_readonly_guard
+from .inputs import MissingTestInput, smoke_input
+from .transport import RecordedCall, RecordingTransport
+from .workflow import workflow
+
+__all__ = [
+    "build_smoke_client",
+    "RecordingTransport",
+    "RecordedCall",
+    "install_readonly_guard",
+    "ReadOnlyViolation",
+    "smoke_input",
+    "MissingTestInput",
+    "run_with_flaky_tolerance",
+    "TransientAPIError",
+    "workflow",
+]

--- a/src/almaapitk/testing/client.py
+++ b/src/almaapitk/testing/client.py
@@ -1,0 +1,40 @@
+"""Assemble an ``AlmaAPIClient`` wired for smoke testing.
+
+See issue #156 / the harness spec. The read-only guard is installed LAST so
+it wraps the dry-run recorder too — a write in dry-run is still a violation.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from almaapitk import AlmaAPIClient
+
+from .guards import install_readonly_guard
+from .transport import CannedResponse, RecordingTransport
+
+
+def build_smoke_client(
+    environment: str,
+    *,
+    readonly: bool,
+    dry_run: bool,
+    api_key: Optional[str] = None,
+    canned_response_factory: Optional[CannedResponse] = None,
+) -> "tuple[AlmaAPIClient, Optional[RecordingTransport]]":
+    """Return ``(client, transport)`` wired for a workflow smoke.
+
+    In dry-run a :class:`RecordingTransport` is installed (no network) and
+    returned; otherwise ``None`` is returned for the transport. When
+    ``readonly`` is set the client's session refuses any non-GET request.
+    """
+    client = AlmaAPIClient(environment, api_key=api_key)
+
+    transport: Optional[RecordingTransport] = None
+    if dry_run:
+        transport = RecordingTransport(canned_response_factory=canned_response_factory)
+        transport.install(client._session)
+
+    if readonly:
+        install_readonly_guard(client._session)
+
+    return client, transport

--- a/src/almaapitk/testing/flaky.py
+++ b/src/almaapitk/testing/flaky.py
@@ -1,0 +1,47 @@
+"""Tolerate transient Alma hiccups in live smokes.
+
+Live analytics (and other PROD reads) intermittently return ``5xx``/``429``
+(observed: analytics 500 storms). Such a failure should not turn a smoke
+red — it means "couldn't check right now", not "the workflow is broken". So
+we retry a few times and, if still failing, raise :class:`TransientAPIError`
+which callers translate into ``skipped``. See issue #156.
+"""
+from __future__ import annotations
+
+import time
+from typing import Callable, Optional, TypeVar
+
+from almaapitk import AlmaRateLimitError, AlmaServerError
+
+T = TypeVar("T")
+
+_TRANSIENT = (AlmaServerError, AlmaRateLimitError)
+
+
+class TransientAPIError(RuntimeError):
+    """A live check could not complete due to a transient API failure.
+
+    Callers should treat this as ``skipped``, not ``failed``.
+    """
+
+
+def run_with_flaky_tolerance(
+    fn: Callable[[], T], *, retries: int = 2, delay: float = 1.0
+) -> T:
+    """Call ``fn``; retry on transient API errors, then skip.
+
+    Returns ``fn()``'s result on success. Re-raises any non-transient error
+    unchanged. Raises :class:`TransientAPIError` if every attempt hit a
+    transient failure.
+    """
+    last: Optional[Exception] = None
+    for attempt in range(retries + 1):
+        try:
+            return fn()
+        except _TRANSIENT as exc:
+            last = exc
+            if attempt < retries:
+                time.sleep(delay)
+    raise TransientAPIError(
+        f"transient API failure after {retries + 1} attempts: {last}"
+    )

--- a/src/almaapitk/testing/guards.py
+++ b/src/almaapitk/testing/guards.py
@@ -1,0 +1,29 @@
+"""Read-only rail: a guarded session refuses non-GET requests.
+
+A workflow targeting PRODUCTION is handed a client whose session is guarded
+so it can only ever read — a write attempt raises immediately, before any
+I/O. This makes the "PRODUCTION is read-only, always" invariant enforceable
+rather than aspirational. See issue #156 / the harness spec.
+"""
+from __future__ import annotations
+
+import requests
+
+
+class ReadOnlyViolation(RuntimeError):
+    """Raised when a read-only (e.g. PRODUCTION) smoke attempts a write."""
+
+
+def install_readonly_guard(session: requests.Session) -> None:
+    """Wrap ``session.request`` so any non-GET verb raises ReadOnlyViolation."""
+    inner = session.request
+
+    def _guarded(method, url, **kwargs):
+        if str(method).upper() != "GET":
+            raise ReadOnlyViolation(
+                f"Read-only smoke attempted a {method} to {url}. "
+                "PRODUCTION-targeted workflows may only read."
+            )
+        return inner(method, url, **kwargs)
+
+    session.request = _guarded  # type: ignore[assignment]

--- a/src/almaapitk/testing/inputs.py
+++ b/src/almaapitk/testing/inputs.py
@@ -1,0 +1,39 @@
+"""Load synthetic smoke inputs from a gitignored JSON file.
+
+Workflow smokes read environment-specific values (a test user id, an
+analytics report path, …) through :func:`smoke_input`. The values live in a
+gitignored ``smoke-data.json`` so real identifiers never reach the repo (R9).
+The file path is overridable via ``ALMA_SMOKE_DATA``. See issue #156.
+"""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+class MissingTestInput(KeyError):
+    """Raised when a requested smoke input (or its file) is absent."""
+
+
+def _path() -> Path:
+    return Path(os.getenv("ALMA_SMOKE_DATA", "smoke-data.json"))
+
+
+def smoke_input(key: str) -> Any:
+    """Return the synthetic value for ``key`` from the smoke-data file.
+
+    Raises :class:`MissingTestInput` with actionable guidance when the file
+    or the key is missing.
+    """
+    path = _path()
+    if not path.exists():
+        raise MissingTestInput(
+            f"smoke data file not found at {path}. Copy smoke-data.example.json "
+            "to smoke-data.json (gitignored) and fill in synthetic values."
+        )
+    data = json.loads(path.read_text())
+    if key not in data:
+        raise MissingTestInput(f"missing smoke input {key!r} in {path}")
+    return data[key]

--- a/src/almaapitk/testing/pytest_plugin.py
+++ b/src/almaapitk/testing/pytest_plugin.py
@@ -1,0 +1,52 @@
+"""pytest plugin exposing the ``alma`` fixture for workflow smokes.
+
+Registered as a ``pytest11`` entry point so it loads automatically once
+``almaapitk[smoke]`` is installed — no conftest needed. See issue #156.
+
+Live vs dry-run is selected by the ``ALMA_SMOKE_LIVE`` env var (set by
+``make smoke-live``). A live check whose environment credentials are absent
+is skipped, not failed (R-H3).
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from .client import build_smoke_client
+
+_ENV_KEYS = {"SANDBOX": "ALMA_SB_API_KEY", "PRODUCTION": "ALMA_PROD_API_KEY"}
+
+
+def _live_mode() -> bool:
+    return os.getenv("ALMA_SMOKE_LIVE", "").strip().lower() in ("1", "true", "yes")
+
+
+@pytest.fixture
+def alma(request):
+    """Yield a smoke client configured from the test's ``@workflow`` marker."""
+    meta = getattr(request.function, "__alma_workflow__", None)
+    if meta is None:
+        pytest.fail(
+            "a test using the `alma` fixture must be decorated with "
+            "@workflow(name=..., environment=..., readonly=...)"
+        )
+
+    env = meta["environment"]
+    readonly = meta["readonly"]
+    live = _live_mode()
+
+    if live and not os.getenv(_ENV_KEYS[env]):
+        pytest.skip(f"live smoke needs {_ENV_KEYS[env]}; not set")
+
+    client, transport = build_smoke_client(
+        environment=env, readonly=readonly, dry_run=not live
+    )
+    # Stash run context so the workflow body can branch dry-run vs live and
+    # inspect recorded requests.
+    request.node.alma_transport = transport
+    request.node.alma_live = live
+    try:
+        yield client
+    finally:
+        client.close()

--- a/src/almaapitk/testing/pytest_plugin.py
+++ b/src/almaapitk/testing/pytest_plugin.py
@@ -39,8 +39,15 @@ def alma(request):
     if live and not os.getenv(_ENV_KEYS[env]):
         pytest.skip(f"live smoke needs {_ENV_KEYS[env]}; not set")
 
+    # Dry-run sends nothing, so it must never require real credentials
+    # (R-H3: runnable anywhere, including credential-free CI). Hand the
+    # client a placeholder key in dry-run; in live mode pass None so the
+    # client resolves the real key from the environment.
     client, transport = build_smoke_client(
-        environment=env, readonly=readonly, dry_run=not live
+        environment=env,
+        readonly=readonly,
+        dry_run=not live,
+        api_key=None if live else "dry-run-no-network",
     )
     # Stash run context so the workflow body can branch dry-run vs live and
     # inspect recorded requests.

--- a/src/almaapitk/testing/transport.py
+++ b/src/almaapitk/testing/transport.py
@@ -1,0 +1,63 @@
+"""Dry-run transport: record requests, send nothing.
+
+Used by the workflow smoke harness so a workflow's wiring can be validated
+with no network and no credentials. See issue #156 / the harness spec.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+import requests
+
+
+@dataclass
+class RecordedCall:
+    """One request a workflow attempted while running under dry-run."""
+
+    method: str
+    url: str
+    params: Optional[dict] = None
+    headers: Optional[dict] = None
+    body: Any = None
+
+
+# Returns (status_code, content_bytes, content_type) for the canned response.
+CannedResponse = Callable[[Optional[requests.PreparedRequest]], "tuple[int, bytes, str]"]
+
+
+class RecordingTransport:
+    """Replaces ``Session.request`` with a recorder that performs no I/O.
+
+    Every call is appended to :attr:`calls`; a canned :class:`requests.Response`
+    is returned so the workflow's own code keeps running. By default the canned
+    response is an empty HTTP 200 JSON body; pass ``canned_response_factory`` to
+    supply a shape a particular workflow needs (e.g. minimal analytics XML).
+    """
+
+    def __init__(self, canned_response_factory: Optional[CannedResponse] = None):
+        self.calls: list[RecordedCall] = []
+        self._factory: CannedResponse = canned_response_factory or (
+            lambda req: (200, b"{}", "application/json")
+        )
+
+    def install(self, session: requests.Session) -> None:
+        def _record(method, url, **kwargs):
+            self.calls.append(
+                RecordedCall(
+                    method=method,
+                    url=url,
+                    params=kwargs.get("params"),
+                    headers=kwargs.get("headers"),
+                    body=kwargs.get("json", kwargs.get("data")),
+                )
+            )
+            status, content, content_type = self._factory(None)
+            resp = requests.Response()
+            resp.status_code = status
+            resp._content = content
+            resp.headers["Content-Type"] = content_type
+            resp.url = url
+            return resp
+
+        session.request = _record  # type: ignore[assignment]

--- a/src/almaapitk/testing/workflow.py
+++ b/src/almaapitk/testing/workflow.py
@@ -1,0 +1,35 @@
+"""The ``@workflow`` marker for smoke tests.
+
+A workflow smoke is an ordinary pytest test decorated with ``@workflow(...)``;
+the decorator records the workflow's metadata on the function so the ``alma``
+fixture can build the right client (environment, read-only). See issue #156.
+"""
+from __future__ import annotations
+
+from typing import Callable
+
+
+def workflow(*, name: str, environment: str, readonly: bool) -> Callable:
+    """Mark a test function as a workflow smoke.
+
+    Args:
+        name: Human-readable workflow name (for reports).
+        environment: ``"SANDBOX"`` or ``"PRODUCTION"``.
+        readonly: When True, the client handed to the test refuses writes
+            (mandatory for ``PRODUCTION``).
+    """
+    if environment == "PRODUCTION" and not readonly:
+        raise ValueError(
+            "PRODUCTION workflows must be readonly=True (the harness enforces "
+            "PRODUCTION = read-only)."
+        )
+
+    def deco(fn: Callable) -> Callable:
+        fn.__alma_workflow__ = {
+            "name": name,
+            "environment": environment,
+            "readonly": readonly,
+        }
+        return fn
+
+    return deco

--- a/tests/smoke/test_analytics_report_fetch.py
+++ b/tests/smoke/test_analytics_report_fetch.py
@@ -1,0 +1,49 @@
+"""Pilot workflow smoke: fetch an analytics report (PRODUCTION, read-only).
+
+Dry-run validates the request wiring with no credentials (runs anywhere,
+including CI). Live mode (``make smoke-live`` with a prod key present)
+additionally checks the response, under flaky-API tolerance.
+
+R9: in live mode the report path is a synthetic placeholder from the
+gitignored ``smoke-data.json``; report rows are never printed.
+"""
+from __future__ import annotations
+
+from almaapitk import Analytics
+from almaapitk.testing import run_with_flaky_tolerance, smoke_input, workflow
+
+# Dry-run never reaches a real API, so any path works for the request-check.
+_DRY_RUN_PLACEHOLDER_PATH = "/shared/PLACEHOLDER/Reports/dry-run"
+
+
+@workflow(name="analytics-report-fetch", environment="PRODUCTION", readonly=True)
+def test_analytics_report_fetch(alma, request):
+    live = request.node.alma_live
+    report_path = (
+        smoke_input("analytics_report_path") if live else _DRY_RUN_PLACEHOLDER_PATH
+    )
+    analytics = Analytics(alma)
+
+    def _fetch():
+        headers = analytics.get_report_headers(report_path)
+        rows = list(analytics.fetch_report_rows(report_path, max_rows=5))
+        return headers, rows
+
+    if not live:
+        # DRY-RUN: run the workflow against the recorder, then request-check.
+        # Parsing the canned response is not under test here.
+        try:
+            _fetch()
+        except Exception:
+            pass
+        calls = request.node.alma_transport.calls
+        assert calls, "workflow issued no requests"
+        assert any("analytics/reports" in (c.url or "") for c in calls), (
+            "workflow did not hit the analytics reports endpoint"
+        )
+        return
+
+    # LIVE (PROD, read-only): response-checks, under flaky tolerance.
+    headers, rows = run_with_flaky_tolerance(_fetch, retries=2, delay=2.0)
+    assert headers, "analytics report returned no column headers"
+    assert rows, "analytics report returned no rows"

--- a/tests/unit/testing/test_build_smoke_client.py
+++ b/tests/unit/testing/test_build_smoke_client.py
@@ -1,0 +1,40 @@
+import pytest
+
+from almaapitk.testing.client import build_smoke_client
+from almaapitk.testing.guards import ReadOnlyViolation
+
+
+def test_dry_run_records_and_blocks_network():
+    client, transport = build_smoke_client(
+        environment="PRODUCTION", readonly=True, dry_run=True, api_key="fake-key"
+    )
+    try:
+        client.get("almaws/v1/analytics/reports", params={"path": "/x"})
+        assert transport is not None
+        assert len(transport.calls) == 1
+        assert transport.calls[0].method == "GET"
+    finally:
+        client.close()
+
+
+def test_dry_run_readonly_still_blocks_writes():
+    client, _ = build_smoke_client(
+        environment="PRODUCTION", readonly=True, dry_run=True, api_key="fake-key"
+    )
+    try:
+        with pytest.raises(ReadOnlyViolation):
+            client.post("almaws/v1/anything", data={"k": "v"})
+    finally:
+        client.close()
+
+
+def test_live_readonly_blocks_writes_without_network():
+    # The read-only guard wraps the real session; a POST must raise before any I/O.
+    client, _ = build_smoke_client(
+        environment="PRODUCTION", readonly=True, dry_run=False, api_key="fake-key"
+    )
+    try:
+        with pytest.raises(ReadOnlyViolation):
+            client.post("almaws/v1/anything", data={"k": "v"})
+    finally:
+        client.close()

--- a/tests/unit/testing/test_flaky.py
+++ b/tests/unit/testing/test_flaky.py
@@ -1,0 +1,28 @@
+import pytest
+
+from almaapitk import AlmaServerError
+from almaapitk.testing.flaky import TransientAPIError, run_with_flaky_tolerance
+
+
+def test_passes_through_success():
+    assert run_with_flaky_tolerance(lambda: 42, retries=2, delay=0) == 42
+
+
+def test_retries_then_skips_on_transient():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        raise AlmaServerError("boom", status_code=503)
+
+    with pytest.raises(TransientAPIError):
+        run_with_flaky_tolerance(flaky, retries=2, delay=0)
+    assert calls["n"] == 3  # initial attempt + 2 retries
+
+
+def test_real_error_propagates():
+    def boom():
+        raise ValueError("real bug")
+
+    with pytest.raises(ValueError):
+        run_with_flaky_tolerance(boom, retries=2, delay=0)

--- a/tests/unit/testing/test_inputs.py
+++ b/tests/unit/testing/test_inputs.py
@@ -1,0 +1,28 @@
+import json
+
+import pytest
+
+from almaapitk.testing.inputs import MissingTestInput, smoke_input
+
+
+def test_reads_value(tmp_path, monkeypatch):
+    f = tmp_path / "smoke-data.json"
+    f.write_text(json.dumps({"analytics_report_path": "/shared/Placeholder/Reports/Demo"}))
+    monkeypatch.setenv("ALMA_SMOKE_DATA", str(f))
+    assert smoke_input("analytics_report_path") == "/shared/Placeholder/Reports/Demo"
+
+
+def test_missing_key_raises_clear_error(tmp_path, monkeypatch):
+    f = tmp_path / "smoke-data.json"
+    f.write_text("{}")
+    monkeypatch.setenv("ALMA_SMOKE_DATA", str(f))
+    with pytest.raises(MissingTestInput) as exc_info:
+        smoke_input("nope")
+    assert "nope" in str(exc_info.value)
+
+
+def test_missing_file_raises_clear_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("ALMA_SMOKE_DATA", str(tmp_path / "does-not-exist.json"))
+    with pytest.raises(MissingTestInput) as exc_info:
+        smoke_input("anything")
+    assert "not found" in str(exc_info.value)

--- a/tests/unit/testing/test_package_imports.py
+++ b/tests/unit/testing/test_package_imports.py
@@ -1,0 +1,4 @@
+def test_testing_package_importable():
+    import almaapitk.testing as t
+
+    assert hasattr(t, "__all__")

--- a/tests/unit/testing/test_readonly_guard.py
+++ b/tests/unit/testing/test_readonly_guard.py
@@ -1,0 +1,25 @@
+import pytest
+import requests
+
+from almaapitk.testing.guards import ReadOnlyViolation, install_readonly_guard
+
+
+def _session_that_never_calls_network():
+    s = requests.Session()
+    # Stand-in so a GET that passes the guard does not actually dial out.
+    s.request = lambda method, url, **kw: "ok"
+    return s
+
+
+def test_get_is_allowed():
+    s = _session_that_never_calls_network()
+    install_readonly_guard(s)
+    assert s.request("GET", "https://example.test/x") == "ok"
+
+
+@pytest.mark.parametrize("verb", ["POST", "PUT", "DELETE", "PATCH"])
+def test_writes_are_blocked(verb):
+    s = _session_that_never_calls_network()
+    install_readonly_guard(s)
+    with pytest.raises(ReadOnlyViolation):
+        s.request(verb, "https://example.test/x")

--- a/tests/unit/testing/test_transport.py
+++ b/tests/unit/testing/test_transport.py
@@ -1,0 +1,33 @@
+import requests
+
+from almaapitk.testing.transport import RecordingTransport
+
+
+def test_records_request_and_sends_nothing():
+    transport = RecordingTransport()
+    session = requests.Session()
+    transport.install(session)
+
+    resp = session.request(
+        "GET", "https://example.test/almaws/v1/foo", params={"q": "x"}
+    )
+
+    assert resp.status_code == 200
+    assert len(transport.calls) == 1
+    call = transport.calls[0]
+    assert call.method == "GET"
+    assert call.url.endswith("/almaws/v1/foo")
+    assert call.params == {"q": "x"}
+
+
+def test_canned_response_factory_used():
+    transport = RecordingTransport(
+        canned_response_factory=lambda req: (200, b"<rows/>", "application/xml")
+    )
+    session = requests.Session()
+    transport.install(session)
+
+    resp = session.request("GET", "https://example.test/x")
+
+    assert resp.content == b"<rows/>"
+    assert resp.headers["Content-Type"] == "application/xml"

--- a/tests/unit/testing/test_workflow_marker.py
+++ b/tests/unit/testing/test_workflow_marker.py
@@ -1,0 +1,13 @@
+from almaapitk.testing import workflow
+
+
+def test_marker_attaches_metadata():
+    @workflow(name="demo", environment="SANDBOX", readonly=True)
+    def some_workflow(alma):
+        ...
+
+    assert some_workflow.__alma_workflow__ == {
+        "name": "demo",
+        "environment": "SANDBOX",
+        "readonly": True,
+    }


### PR DESCRIPTION
Implements the v1 of the workflow smoke-test harness. Closes #156 (core) and #157 (pilot); part of the meta-issue #158.

Design: `docs/superpowers/specs/2026-05-25-workflow-smoke-harness-design.md`
Plan: `docs/superpowers/plans/2026-05-25-workflow-smoke-harness.md`

## Summary
A reusable, pytest-based harness in `almaapitk[smoke]` that turns "validate a version" into a command. Built TDD, one commit per component.

- **`almaapitk.testing`** package (behind a `[smoke]` extra; core lib stays lean):
  - `RecordingTransport` — dry-run recorder; replaces `session.request`, records calls, no network.
  - read-only guard (`ReadOnlyViolation`) — a PRODUCTION client refuses any non-GET, enforced at the single request chokepoint.
  - `build_smoke_client(env, readonly, dry_run, api_key)` — assembles the client (using the `api_key=` injection from #143) + hooks.
  - `smoke_input` — synthetic inputs from a gitignored `smoke-data.json` (+ committed example); R9-safe.
  - `run_with_flaky_tolerance` — retries transient 5xx/429, then skips (so flaky analytics never cries wolf).
  - `@workflow(name, environment, readonly)` marker + the `alma` pytest fixture (auto-loaded via a `pytest11` entry point); rejects PRODUCTION+writable at declaration time.
  - `make smoke` / `make smoke-live` wrappers.
- **Pilot** `tests/smoke/test_analytics_report_fetch.py` — analytics report fetch (PRODUCTION, read-only): dry-run request-check (no creds) + live read-only response-checks (auto-skips without a prod key).

## Notes
- **Two run modes:** dry-run checks request *wiring* (no creds, CI-safe); live checks the *response*.
- **Safety rail proven by a test:** a write against a read-only client raises (R-H5/R10).
- The pilot surfaced one gap and the fixture was fixed so **dry-run is fully credential-free** — verified by running the pilot with both API keys unset.

## Test Plan
- [x] `make smoke` passes the pilot dry-run with **no credentials** (`env -u ALMA_PROD_API_KEY -u ALMA_SB_API_KEY`).
- [x] Harness unit tests green (transport, read-only rail, build_smoke_client, input loader, flaky tolerance, marker).
- [x] No regressions: `scripts/smoke_import.py` + `tests/unit` + `tests/logging` green (881 passed; the lone failure is the pre-existing `Electronic` meta-categorisation issue, unrelated to this PR).
- [x] CI guards pass locally on this branch: wheel/sdist contents clean, bandit HIGH=0.
- [ ] (operator, later) `make smoke-live` with a prod key + a real `smoke-data.json` report path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)